### PR TITLE
Make jekyll baseurl empty to fix image paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ url: http://pytorch.org
 name: PyTorch
 description: 'Scientific Computing...'
 latest_version: 1.0
-baseurl: /
+baseurl:
 relative_permalinks: false
 timezone: America/Los_Angeles
 sass:


### PR DESCRIPTION
Currently all of the images embedded in markdown docs on the website are broken (in particular, on the about page) because the image paths are erroneously prefixed with two slashes, e.g. "//static/img/tensor_illustration.png". This is happening because the jekyll baseurl is '/' but it should be empty.