### PR TITLE
Change pip to pip3 for Python 3 installations

### DIFF
--- a/_data/wizard.yml
+++ b/_data/wizard.yml
@@ -67,22 +67,22 @@
   cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp27-none-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cuda7.5,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cuda8.0,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cudanone,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cuda7.5,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cuda8.0,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 - 
   matcher: 'pip,osx,cudanone,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
+  cmd: 'pip3 install http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl <br/> pip3 install torchvision <br /> # OSX Binaries dont support CUDA, install from source if CUDA is needed'
 ######### Linux ######################
 - 
   matcher: 'pip,linux,cuda7.5,python2.7'
@@ -96,19 +96,19 @@
  work, then you have python 2.7 UCS2, use this command <br/> pip install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp27-cp27m-manylinux1_x86_64.whl'
 - 
   matcher: 'pip,linux,cuda7.5,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip3 install torchvision'
 - 
   matcher: 'pip,linux,cudanone,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip3 install torchvision'
 - 
   matcher: 'pip,linux,cuda8.0,python3.5'
-  cmd: 'pip install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl <br/> pip3 install torchvision'
 - 
   matcher: 'pip,linux,cuda7.5,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip3 install torchvision'
 - 
   matcher: 'pip,linux,cudanone,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip3 install torchvision'
 - 
   matcher: 'pip,linux,cuda8.0,python3.6'
-  cmd: 'pip install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip install torchvision'
+  cmd: 'pip3 install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl <br/> pip3 install torchvision'


### PR DESCRIPTION
Using `pip3` ensures that it will be installed for Python 3 and not Python 2 if both are present.