### PR TITLE
Add Atom/RSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,6 @@ exclude:
     - package.json
     
 # google_site_verification: eOAFtDphTbbm4OPKva2d3Z0Z_2bBxWMGdkD0IRQ6VeA
+
+plugins:
+  - jekyll-feed


### PR DESCRIPTION
From https://help.github.com/articles/atom-rss-feeds-for-github-pages/

> To enable automatic feed generation, you must add the following line to your site's *\_config.yml* file:  
>
> ```
> plugins:
>  - jekyll-feed
> ```

See also: https://github.com/jekyll/jekyll-feed#optional-configuration-options