### PR TITLE
Links & instructions for previous versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,9 @@ layout: default
             <div class="label">Run this command:</div>
             <div class="text"></div>
         </div>
+        <div class="title" align="right">
+          <h4><a href="/previous-versions/">Click here for previous versions of PyTorch</a></h4>
+        </div>
     </div>
 </section>
 

--- a/previous-versions.md
+++ b/previous-versions.md
@@ -1,0 +1,203 @@
+---
+title: PyTorch | Previous Versions
+id: previous-versions
+permalink: /previous-versions/
+layout: about
+---
+
+# Installing previous versions of PyTorch
+
+We'd prefer you install the [latest version](http://pytorch.org/),
+but old binaries and installation instructions are provided below for
+your convenience.
+
+### Via conda
+
+To install a previous version of PyTorch via Anaconda or Miniconda,
+replace "0.1.12" in the following commands with the desired version
+(i.e., "0.2.0").
+
+Installing with CUDA 8
+
+`conda install pytorch=0.1.12 cuda80 -c soumith`
+
+Installing with CUDA 7.5
+
+`conda install pytorch=0.1.12 cuda75 -c soumith`
+
+Installing without CUDA
+
+`conda install pytorch=0.1.12 -c soumith`
+
+### From source
+
+It is possible to checkout an older version of [PyTorch](https://github.com/pytorch/pytorch)
+and build it.
+You can list tags in PyTorch git repository with `git tag` and checkout a
+particular one (replace '0.1.9' with the desired version) with
+
+`git checkout v0.1.9`
+
+Follow the install from source instructions in the README.md of the PyTorch
+checkout.
+
+### Via pip
+
+Download the `whl` file with the desired version from the list below, and run
+
+`pip install /path/to/whl/file`
+
+You can also directly pass a URL to pip:
+
+`pip install http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl`
+
+CUDA support is optional; for example, you can install the
+cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl package on a system
+that does not have CUDA.
+
+There are three major lists below: Linux binaries compiled with CUDA 8 support,
+Linux binaries with CUDA 7.5 support, and Mac OSX & miscellaneous other binaries.
+
+### PyTorch Linux binaries compiled with CUDA 8
+- [cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post3-cp27-cp27m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post3-cp27-cp27m-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post2-cp36-cp36m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post2-cp36-cp36m-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post2-cp27-cp27mu-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post2-cp27-cp27mu-manylinux1_x86_64.whl)
+- [cu80/torch-0.2.0.post2-cp27-cp27m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.2.0.post2-cp27-cp27m-manylinux1_x86_64.whl)
+- [cu80/torch-0.1.12.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.12.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.12.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post2-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.12.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.12.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.12.post1-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post5-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post5-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post5-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post4-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post4-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post4-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post4-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.11.post4-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.11.post4-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post2-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.10.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.10.post1-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post2-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.9.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.9.post1-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.8.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.8.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.8.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.8.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.8.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.8.post1-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.7.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.7.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu80/torch-0.1.7.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.7.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.7.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.7.post2-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.6.post22-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.6.post22-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.6.post22-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.6.post22-cp27-none-linux_x86_64.whl)
+- [cu80/torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl)
+- [cu80/torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/cu80/torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl)
+
+### PyTorch Linux binaries compiled with CUDA 7.5
+- [cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp36-cp36m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp35-cp35m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp27-cp27mu-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post3-cp27-cp27m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post3-cp27-cp27m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post2-cp36-cp36m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp36-cp36m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp35-cp35m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post2-cp27-cp27mu-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp27-cp27mu-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post2-cp27-cp27m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post2-cp27-cp27m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post1-cp36-cp36m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post1-cp36-cp36m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post1-cp35-cp35m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post1-cp35-cp35m-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post1-cp27-cp27mu-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post1-cp27-cp27mu-manylinux1_x86_64.whl)
+- [cu75/torch-0.2.0.post1-cp27-cp27m-manylinux1_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.2.0.post1-cp27-cp27m-manylinux1_x86_64.whl)
+- [cu75/torch-0.1.12.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.12.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.12.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post2-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.12.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.12.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.12.post1-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post5-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post5-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post5-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post5-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post5-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post4-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post4-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post4-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post4-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.11.post4-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.11.post4-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post2-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.10.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.10.post1-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post2-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.9.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.9.post1-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.8.post1-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.8.post1-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.8.post1-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.8.post1-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.8.post1-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.8.post1-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.7.post2-cp36-cp36m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.7.post2-cp36-cp36m-linux_x86_64.whl)
+- [cu75/torch-0.1.7.post2-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.7.post2-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.7.post2-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.7.post2-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.6.post22-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.6.post22-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.6.post22-cp27-none-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.6.post22-cp27-none-linux_x86_64.whl)
+- [cu75/torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl)
+- [cu75/torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/cu75/torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl)
+
+### Mac and misc. binaries
+- [torchvision-0.1.6-py3-none-any.whl](http://download.pytorch.org/whl/torchvision-0.1.6-py3-none-any.whl)
+- [torchvision-0.1.6-py2-none-any.whl](http://download.pytorch.org/whl/torchvision-0.1.6-py2-none-any.whl)
+- [torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post3-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post3-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post3-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post3-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post2-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post2-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post2-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post2-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post2-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post2-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post1-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post1-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post1-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post1-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.2.0.post1-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.2.0.post1-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post2-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post2-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post2-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post2-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post2-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post2-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post1-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post1-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post1-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post1-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.1.12.post1-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.12.post1-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post5-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post5-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post5-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post5-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post5-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post5-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post4-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post4-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post4-cp35-cp35m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post4-cp35-cp35m-macosx_10_7_x86_64.whl)
+- [torch-0.1.11.post4-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.11.post4-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.10.post1-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.10.post1-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.10.post1-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.10.post1-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.10.post1-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.10.post1-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.9.post2-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post2-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.9.post2-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post2-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.9.post2-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post2-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.9.post1-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post1-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.9.post1-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post1-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.9.post1-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.9.post1-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.8.post1-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.8.post1-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.8.post1-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.8.post1-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.8.post1-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.8.post1-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.7.post2-cp36-cp36m-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.7.post2-cp36-cp36m-macosx_10_7_x86_64.whl)
+- [torch-0.1.7.post2-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.7.post2-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.7.post2-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.7.post2-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.6.post22-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post22-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1.6.post22-cp27-none-macosx_10_7_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post22-cp27-none-macosx_10_7_x86_64.whl)
+- [torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post20-cp35-cp35m-linux_x86_64.whl)
+- [torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl)
+- [torch-0.1.6.post17-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post17-cp35-cp35m-linux_x86_64.whl)
+- [torch-0.1.6.post17-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/torch-0.1.6.post17-cp27-cp27mu-linux_x86_64.whl)
+- [torch-0.1-cp35-cp35m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1-cp35-cp35m-macosx_10_6_x86_64.whl)
+- [torch-0.1-cp27-cp27m-macosx_10_6_x86_64.whl](http://download.pytorch.org/whl/torch-0.1-cp27-cp27m-macosx_10_6_x86_64.whl)
+- [torch_cuda80-0.1.6.post20-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/torch_cuda80-0.1.6.post20-cp35-cp35m-linux_x86_64.whl)
+- [torch_cuda80-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/torch_cuda80-0.1.6.post20-cp27-cp27mu-linux_x86_64.whl)
+- [torch_cuda80-0.1.6.post17-cp35-cp35m-linux_x86_64.whl](http://download.pytorch.org/whl/torch_cuda80-0.1.6.post17-cp35-cp35m-linux_x86_64.whl)
+- [torch_cuda80-0.1.6.post17-cp27-cp27mu-linux_x86_64.whl](http://download.pytorch.org/whl/torch_cuda80-0.1.6.post17-cp27-cp27mu-linux_x86_64.whl)


### PR DESCRIPTION
Adds a new path, /previous-versions/, that has links to binaries of previous versions and installation instructions. Also added a link to this from the home page.

Partially addresses https://github.com/pytorch/pytorch/issues/2689

### Test Plan
Build the website.

How the link to the page looks:
![image](https://user-images.githubusercontent.com/5652049/32519466-df539dd4-c3da-11e7-83aa-34b4e997ae1f.png)

How the new page looks:
![image](https://user-images.githubusercontent.com/5652049/32519490-f328dd1a-c3da-11e7-92c5-2fcb9bc5043d.png)
