### PR TITLE
Fix wrong linking to Ritchie Ng's course

### DIFF
--- a/_posts/2018-01-19-a-year-in.md
+++ b/_posts/2018-01-19-a-year-in.md
@@ -105,7 +105,7 @@ Each new tutorial helped users find their way faster, with different approaches 
 We've seen quite a few university machine learning courses being taught with PyTorch as the primary tool, such as Harvard's [CS287](https://harvard-ml-courses.github.io/cs287-web/). Taking it one step further and democratizing learning, we had three online courses pop up that teach using PyTorch.
 
 - **Fast.ai's** “Deep Learning for Coders” is a popular online course. In September, Jeremy and Rachel [announced that the next fast.ai courses will be nearly entirely based on PyTorch](http://www.fast.ai/2017/09/08/introducing-pytorch-for-fastai/). 
-- Ritchie Ng, a researcher with ties to NUS Singapore and Tsinghua released [a Udemy course](https://www.udemy.com/practical-deep-learning-with-pytorch/ (https://www.udemy.com/practical-deep-learning-with-pytorch/?siteID=je6NUbpObpQ-bacNjq.w8HOdY9kUSkGASg&LSNPUBID=je6NUbpObpQ)) titled Practical Deep Learning with PyTorch.
+- Ritchie Ng, a researcher with ties to NUS Singapore and Tsinghua released [a Udemy course](https://www.udemy.com/practical-deep-learning-with-pytorch/) titled Practical Deep Learning with PyTorch.
 - Sung Kim from HKUST released an [online course on Youtube](https://www.youtube.com/playlist?list=PLlMkM4tgfjnJ3I-dbhO9JTw7gNty6o_2m) that was aimed towards a general audience, titled: “PyTorch Zero to All”.
 
 


### PR DESCRIPTION
There were 2 links present  :-
- https://www.udemy.com/practical-deep-learning-with-pytorch/
- https://www.udemy.com/practical-deep-learning-with-pytorch/?siteID=je6NUbpObpQ-bacNjq.w8HOdY9kUSkGASg&LSNPUBID=je6NUbpObpQ

I kept first based on assumption that initially by mistake a link with ?siteID would have been written and while correcting it, forgot to delete earlier.