### PR TITLE
Add tutorials to navbar

### DIFF
--- a/_includes/primary-nav.html
+++ b/_includes/primary-nav.html
@@ -3,5 +3,6 @@
     <li><a {% if page.id == 'about' %}class="active"{% endif %} href="/about/">About</a></li>
     <li><a {% if page.id == 'blog' %}class="active"{% endif %} href="/blog/">Blog</a></li>
     <li><a {% if page.id == 'support' %}class="active"{% endif %} href="/support/">Support</a></li>
+    <li><a {% if page.id == 'tutorials' %}class="active"{% endif %} href="http://pytorch.org/tutorials/">Tutorials</a></li>
     <li><a {% if page.id == 'apps' %}class="active"{% endif %} href="https://discuss.pytorch.org">Discuss</a></li>
 </ul>


### PR DESCRIPTION
Tutorials are below the fold on the website, so many people (including both new and current users) miss them. Would be good to add them to the navbar.