### PR TITLE
Allow static serving of activation images.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ safe: true
 future: true
 include:
     - _static
+    - _images
     - _modules
     - _sources
     - _tensor_str.html


### PR DESCRIPTION
They're located in _images/, but _config.yml didn't allow serving those
as a static folder. This pr enables that.

cc @soumith @SsnL 

### Test Plan
Tested with `jekyll serve` locally.