### PR TITLE
Hide old docs from robot indexing.

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /docs/0.1.12/
+Disallow: /docs/0.2.0/
+Disallow: /docs/0.3.0/


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/3428
Added a robots.txt file.

Don't know if there's a good way to test this... I confirmed that robots.txt appears at the root level (ie, `localhost:4000/robots.txt` on `jekyll serve`).

cc @SsnL @soumith 