### PR TITLE
Small HTML fix to make copy and paste on home page better

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ layout: default
         </div>
         <div class="command">
             <div class="label">Run this command:</div>
-            <div class="text"></div>
+            <div><!-- prevents highlighting text from div above--><div class="text"></div></div>
         </div>
         <div class="title" align="right">
           <h4><a href="/previous-versions/">Click here for previous versions of PyTorch</a></h4>


### PR DESCRIPTION
This change prevents text in the div containing  'Run this command' from getting selected.

New users double clicking on the getting started command may select the wrong text.