### PR TITLE
PyTorch 0.4.0 Migration Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+Gemfile.lock

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -46,9 +46,9 @@ Let's first see a quick example on our recommended changes for a common code pat
     total_loss = 0
     for input, target in train_loader:
         input, target = input.to(device), target.to(device)
-        hidden = input.new_zeros(*h_shape)  # init wth same device & dtype as input
+        hidden = input.new_zeros(*h_shape)  # has the same device & dtype as `input`
         ...  # get loss and optimize
-        total_loss += loss.item()           # get Python number in a 1-element Tensor
+        total_loss += loss.item()           # get Python number from 1-element Tensor
 
     # evaluate
     with torch.no_grad():                   # operations inside don't track history
@@ -276,19 +276,19 @@ we need some special formatting to make the above table and note look nicer
 ```python
 >>> cpu = torch.device("cpu")
 >>> cuda = torch.device("cuda")
->>> x = torch.randn(3, dtype=torch.double)             # a double tensor on CPU
+>>> x = torch.randn(3, dtype=torch.double)            # a double tensor on CPU
 >>> x
 tensor([-0.1061,  0.5796, -1.0124], dtype=torch.float64)
->>> y = torch.zeros(2, dtype=torch.half, device=cuda)  # a half tensor on GPU
+>>> y = torch.zeros(2, dtype=torch.half, device=cuda) # a half tensor on GPU
 >>> y
 tensor([ 0.,  0.], dtype=torch.float16, device='cuda:0')
->>> x.to(cuda)                                         # move to a different device
+>>> x.to(cuda)                                        # move to a different device
 tensor([-0.1061,  0.5796, -1.0124], dtype=torch.float64, device='cuda:0')
->>> y.to(torch.double)                                 # cast to a different type
+>>> y.to(torch.double)                                # cast to a different type
 tensor([ 0.,  0.], dtype=torch.float64, device='cuda:0')
->>> x.to(cuda, torch.half)                             # move and cast at the same time
+>>> x.to(cuda, torch.half)                            # move and cast at the same time
 tensor([-0.1061,  0.5796, -1.0127], dtype=torch.float16, device='cuda:0')
->>> y.to(x)                                            # move and cast to the same device and dtype as a tensor
+>>> y.to(x)                                           # move and cast to the same device and dtype as a given tensor
 tensor([ 0.,  0.], dtype=torch.float64)
 ```
 

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -23,8 +23,8 @@ Note also that the ``type()`` of a Tensor no longer reflects the data type. Use 
 
 ```python
 >>> x = torch.DoubleTensor([1, 1, 1])
->>> print(type(x)) # was torch.DoubleTensor
-<class 'torch.Tensor'>
+>>> print(type(x))  # was torch.DoubleTensor
+"<class 'torch.Tensor'>"
 >>> print(x.type())  # OK: 'torch.DoubleTensor'
 'torch.DoubleTensor'
 >>> print(isinstance(x, torch.DoubleTensor))  # OK: True
@@ -156,7 +156,7 @@ In previous versions of PyTorch, we used to specify data type (e.g. float vs dou
 
 In this release, we introduce [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties via NumPy-style creation functions.
 
-#### [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)
+### [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)
 
 Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)s (data types) and their corresponding tensor types.
 

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -200,7 +200,7 @@ True
 ```
 
 #### [``torch.tensor(data, ...)``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)
-[``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and copies the contained values into a new ``Tensor``. Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way. Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
+[``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and **copies** the contained values into a new ``Tensor``. Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way. Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
 
 ```python
 >>> cuda = torch.device("cuda")

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -5,7 +5,7 @@ author: <a href="https://ssnl.github.io/">Tongzhou Wang</a>
 date: 2018-04-22 12:00:00 -0500
 ---
 
-Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced many exciting new features and critical bug fixes, with the goal of providing users a better and cleaner interface. In this guide, we will cover the three most important changes in migrating existing code from previous versions.
+Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced [many exciting new features and critical bug fixes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0), with the goal of providing users a better and cleaner interface. In this guide, we will cover the three most important changes in migrating existing code from previous versions.
 
 Let's first see a quick example on our recommended changes for a common code pattern:
 

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -33,7 +33,7 @@ True
 
 ### When does [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) start tracking history now?
 
-``requires_grad``, the central flag for [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html), is now an attribute on ``Tensor``s.  The same rules previously used for ``Variables`` applies to ``Tensors``; [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) starts tracking history when any input ``Tensor`` of an operation has ``requires_grad=True``. For example,
+``requires_grad``, the central flag for [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html), is now an attribute on ``Tensors``.  The same rules previously used for ``Variables`` applies to ``Tensors``; [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) starts tracking history when any input ``Tensor`` of an operation has ``requires_grad=True``. For example,
 
 ```python
 >>> x = torch.ones(1)  # create a tensor with requires_grad=False (default)
@@ -88,7 +88,7 @@ However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` wouldn
 
 ## Support for 0-dimensional (scalar) Tensors
 
-Previously, indexing into a ``Tensor`` vector (1-dimensional tensor) gave a Python number but indexing into a ``Variable`` vector gave (incosistently!) a vector of size ``(1,)``!  Similar behavior existed with reduction functions, i.e. `tensor.sum()` would return a Python number, but `variable.sum()` would retun a vector of size `(1,)`.
+Previously, indexing into a ``Tensor`` vector (1-dimensional tensor) gave a Python number but indexing into a ``Variable`` vector gave (incosistently!) a vector of size ``(1,)``!  Similar behavior existed with reduction functions, e.g. `tensor.sum()` would return a Python number, but `variable.sum()` would retun a vector of size `(1,)`.
 
 Fortunately, this release introduces proper scalar (0-dimensional tensor) support in PyTorch!  Scalars can be created using the new `torch.tensor` function (which will be explained in more detail later; for now just think of it as the PyTorch equivalent of `numpy.array`).  Now you can do things like:
 
@@ -109,10 +109,10 @@ torch.Size([4])
 tensor(5.)
 >>> vector[3].item()             # .item() gives the value as a Python number
 5.0
->>> sum = torch.tensor([2, 3]).sum()
->>> sum
+>>> mysum = torch.tensor([2, 3]).sum()
+>>> mysum
 tensor(5)
->>> sum.size()
+>>> mysum.size()
 torch.Size([])
 ```
 
@@ -125,7 +125,7 @@ Note that if you don't convert to a Python number when accumulating losses, you 
 
 ## Deprecation of ``volatile`` flag
 
-The ``volatile`` flag is now deprecated and has no effect. Previously, any computation that involves a ``Variable`` with ``volatile=True`` won't be tracked by ``autograd``. This has now been replaced by [a set of more flexible context managers](http://pytorch.org/docs/v0.4.0/torch.html#locally-disabling-gradient-computation) including ``torch.no_grad()``, ``torch.set_grad_enabled(grad_mode)``, and others.
+The ``volatile`` flag is now deprecated and has no effect. Previously, any computation that involves a ``Variable`` with ``volatile=True`` wouldn't be tracked by ``autograd``. This has now been replaced by [a set of more flexible context managers](http://pytorch.org/docs/v0.4.0/torch.html#locally-disabling-gradient-computation) including ``torch.no_grad()``, ``torch.set_grad_enabled(grad_mode)``, and others.
 
 ```python
 >>> x = torch.zeros(1, requires_grad=True)
@@ -152,7 +152,7 @@ False
 
 ## [``dtypes``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``devices``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and NumPy-style creation functions
 
-In previous versions of PyTorch, we used to specify data type (e.g. float vs double), device type (cpu vs cuda) and layout (dense vs sparse) together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` was the ``Tensor`` type respresenting``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).
+In previous versions of PyTorch, we used to specify data type (e.g. float vs double), device type (cpu vs cuda) and layout (dense vs sparse) together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` was the ``Tensor`` type respresenting the ``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).
 
 In this release, we introduce [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties via NumPy-style creation functions.
 
@@ -187,11 +187,11 @@ The device of a tensor can be accessed via its ``device`` attribute.
 
 ### [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
 
-[``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) represents the data layout of a [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html). Currently``torch.strided`` (dense tensors) and ``torch.sparse_coo`` (sparse tensors with COO format) are supported.
+[``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) represents the data layout of a [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html). Currently``torch.strided`` (dense tensors, the default) and ``torch.sparse_coo`` (sparse tensors with COO format) are supported.
 
 The layout of a tensor can be access via its ``layout`` attribute.
 
-### Creating ``Tensor``s
+### Creating ``Tensors``
 
 [Methods that create a ``Tensor``](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops) now also take in ``dtype``, ``device``, ``layout``, and ``requires_grad`` options to specify the desired attributes on the returned ``Tensor``. For example,
 

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -32,13 +32,13 @@ Let's first see a quick example on our recommended changes for a common code pat
         if use_cuda:
             ...
         ...
-    ```  
+    ```
 
 + 0.4.0 (new):
 
     ```python
     # torch.device object used throughout this script
-    device = torch.device("cuda" if use_cuda else "cpu")  
+    device = torch.device("cuda" if use_cuda else "cpu")
 
     model = MyRNN().to(device)
 
@@ -67,7 +67,7 @@ I'm sure you noticed many interesting changes! In sections below, we will now co
 
 ``torch.autograd.Variable`` and [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) are now the same class! This means that you don't need the ``Variable`` wrapper everywhere in your code anymore.
 
-``requires_grad``, the central flag for ``autograd``, is now an attribute on ``Tensor``s. Let's see how this change manifests in code!
+``requires_grad``, the central flag for [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html), is now an attribute on ``Tensor``s. Let's see how this change manifests in code!
 
 ### When does [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) start tracking history now?
 
@@ -78,7 +78,7 @@ I'm sure you noticed many interesting changes! In sections below, we will now co
 >>> x.requires_grad
 False
 >>> y = torch.ones(1)  # another tensor with requires_grad=False
->>> z = x + y          
+>>> z = x + y
 >>> # both inputs have requires_grad=False. so does the output
 >>> z.requires_grad
 False
@@ -106,7 +106,7 @@ True
 
 #### Manipulating ``requires_grad`` flag
 
-Other than directly setting the attribute, you can change this flag **in-place** using [``my_tensor.requires_grad_(flag=True)``](http://pytorch.org/docs/master/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is ``False``), e.g.,
+Other than directly setting the attribute, you can change this flag **in-place** using [``my_tensor.requires_grad_(requires_grad=True)``](http://pytorch.org/docs/master/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is ``False``), e.g.,
 
 ```python
 >>> existing_tensor.requires_grad_()
@@ -147,7 +147,7 @@ False
 
 ``.data`` was the primary way to get the underlying ``Tensor`` from a ``Variable``. After this merge, calling ``y = x.data`` still has the same semantics. So ``y`` will be a ``Tensor`` that shares the same data with ``x``, is unrelated with the computation history of ``x``, and has ``requires_grad=False``.
 
-However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` won't be tracked by ``autograd``, and the computed gradients will be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/master/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
+However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` won't be tracked by ``autograd``, and the computed gradients will be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/v0.4.0/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
 
 ## Introducing ``torch.dtype``, ``torch.device`` and ``torch.layout``
 
@@ -170,6 +170,7 @@ Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/
 | 32-bit integer (signed)   | ``torch.int32``   or ``torch.int``     | ``torch.*.IntTensor``     |
 | 64-bit integer (signed)   | ``torch.int64``   or ``torch.long``    | ``torch.*.LongTensor``    |
 
+Use [``torch.set_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.set_default_dtype) and [``torch.get_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.get_default_dtype) to manipulate default ``dtype`` for floating point tensors.
 
 ### ``torch.device``
 
@@ -236,6 +237,8 @@ We've also added more tensor creation methods. Some of them have ``torch.*_like`
     >>> x.new_ones(4, dtype=torch.int)
     tensor([ 1,  1,  1,  1], dtype=torch.int32)
     ```
+
+To specify the desired shape, you can either use a tuple (e.g., ``torch.zeros((2, 3))``) or variable arguments (e.g., ``torch.zeros(2, 3)``) in most cases.
 
 | Name                                                       | Returned ``Tensor``                                       | ``torch.*_like`` variant | ``tensor.new_*`` variant |
 |:-----------------------------------------------------------|-----------------------------------------------------------|--------------------------|--------------------------|

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -149,10 +149,6 @@ False
 
 However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` won't be tracked by ``autograd``, and the computed gradients will be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/master/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
 
-:::warning
-This also means that assigning to ``x.data`` doesn't change the ``x`` content now, although such assignment has always been not recommended.
-:::
-
 ## Introducing ``torch.dtype``, ``torch.device`` and ``torch.layout``
 
 In PyTorch, we used to specify data type, device (sort of) and layout together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` is for ``Tensor``s with ``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -1,13 +1,303 @@
 ---
 layout: post
 title: "PyTorch 0.4.0 Migration Guide"
-author: <a href="https://ssnl.github.io/">Tongzhou Wang</a>
+author: PyTorch Team
 date: 2018-04-22 12:00:00 -0500
 ---
 
-Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced [many exciting new features and critical bug fixes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0), with the goal of providing users a better and cleaner interface. In this guide, we will cover the three most important changes in migrating existing code from previous versions.
+Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced [many exciting new features and critical bug fixes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0), with the goal of providing users a better and cleaner interface. In this guide, we will cover the most important changes in migrating existing code from previous versions:
+* ``Tensor``s and ``Variable``s have merged
+* Support for 0-dimensional (scalar) ``Tensors``
+* Deprecation of the ``volatile`` flag
+* ``dtype``s, ``device``s, and Numpy-style ``Tensor`` creation functions
+* Writing device-agnostic code
 
-Let's first see a quick example on our recommended changes for a common code pattern:
+
+## Merging ``Variable`` and [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) classes
+
+``torch.autograd.Variable`` and [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) are now the same class.  More precisely, [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) is capable of tracking history and behaves like the old ``Variable``; ``Variable`` wrapping continues to work as before but returns an object of type [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html).  This means that you don't need the ``Variable`` wrapper everywhere in your code anymore.
+
+### The `type()` of a [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) has changed
+
+Note also that the ``type()`` of a Tensor no longer reflects the data type. Use ``isinstance()`` or ``x.type()`` instead:
+
+```python
+>>> x = torch.DoubleTensor([1, 1, 1])
+>>> print(type(x)) # was torch.DoubleTensor
+<class 'torch.autograd.variable.Variable'>
+>>> print(x.type())  # OK: 'torch.DoubleTensor'
+'torch.DoubleTensor'
+>>> print(isinstance(x, torch.DoubleTensor))  # OK: True
+True
+```
+
+### When does [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) start tracking history now?
+
+``requires_grad``, the central flag for [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html), is now an attribute on ``Tensor``s. Let's see how this change manifests in code.
+
+[``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) uses the same rules previously used for ``Variable``s. It starts tracking history when any input ``Tensor`` of an operation has ``requires_grad=True``. For example,
+
+```python
+>>> x = torch.ones(1)  # create a tensor with requires_grad=False (default)
+>>> x.requires_grad
+False
+>>> y = torch.ones(1)  # another tensor with requires_grad=False
+>>> z = x + y
+>>> # both inputs have requires_grad=False. so does the output
+>>> z.requires_grad
+False
+>>> # then autograd won't track this computation. let's verify!
+>>> z.backward()
+RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
+>>>
+>>> # now create a tensor with requires_grad=True
+>>> w = torch.ones(1, requires_grad=True)
+>>> w.requires_grad
+True
+>>> # add to the previous result that has require_grad=False
+>>> total = w + z
+>>> # the total sum now requires grad!
+>>> total.requires_grad
+True
+>>> # autograd can compute the gradients as well
+>>> total.backward()
+>>> w.grad
+tensor([ 1.])
+>>> # and no computation is wasted to compute gradients for x, y and z, which don't require grad
+>>> z.grad == x.grad == y.grad == None
+True
+```
+
+#### Manipulating ``requires_grad`` flag
+
+Other than directly setting the attribute, you can change this flag **in-place** using [``my_tensor.requires_grad_(requires_grad=True)``](http://pytorch.org/docs/v0.4.0/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is ``False``), e.g.,
+
+```python
+>>> existing_tensor.requires_grad_()
+>>> existing_tensor.requires_grad
+True
+>>> my_tensor = torch.zeros(3, 4, requires_grad=True)
+>>> my_tensor.requires_grad
+True
+```
+
+### What about ``.data``?
+
+``.data`` was the primary way to get the underlying ``Tensor`` from a ``Variable``. After this merge, calling ``y = x.data`` still has similar semantics. So ``y`` will be a ``Tensor`` that shares the same data with ``x``, is unrelated with the computation history of ``x``, and has ``requires_grad=False``.
+
+However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` wouldn't be tracked by ``autograd``, and the computed gradients would be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/master/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
+
+
+## Support for 0-dimensional (scalar) Tensors
+
+Previously, indexing into a ``Tensor`` vector (1-dimensional tensor) gave a Python number but indexing into a ``Variable`` vector gave (incosistently!) a vector of size ``(1,)``!  Similar behavior existed with reduction functions, i.e. `tensor.sum()` would return a Python number, but `variable.sum()` would retun a vector of size `(1,)`.
+
+Fortunately, this release introduces proper scalar (0-dimensional tensor) support in PyTorch!  Scalars can be created using the new `torch.tensor` function (which will be explained in more detail later; for now just think of it as the PyTorch equivalent of `numpy.array`).  Now you can do things like:
+
+```python
+>>> torch.tensor(3.1416)         # create a scalar directly
+tensor(3.1416)
+>>> torch.tensor(3.1416).size()  # scalar is 0-dimensional
+torch.Size([])
+>>> torch.tensor([3]).size()     # compare to a vector of size 1
+torch.Size([1])
+>>>
+>>> vector = torch.arange(2, 6)  # this is a vector
+>>> vector
+tensor([ 2.,  3.,  4.,  5.])
+>>> vector.size()
+torch.Size([4])
+>>> vector[3]                    # indexing into a vector gives a scalar
+tensor(5.)
+>>> vector[3].item()             # .item() gives the value as a Python number
+5.0
+>>> sum = torch.tensor([2, 3]).sum()
+>>> sum
+tensor(5)
+>>> sum.size()
+torch.Size([])
+```
+
+### Accumulating losses
+
+Consider the widely used pattern ``total_loss += loss.data[0]`` before 0.4.0. ``loss`` was a ``Variable`` wrapping a tensor of size ``(1,)``, but in 0.4.0 ``loss`` is now a scalar and has ``0`` dimensions. Indexing into a scalar doesn't make sense (it gives a warning now, but will be a hard error in 0.5.0): use ``loss.item()`` to get the Python number from a scalar.
+
+Note that if you don't convert to a Python number when accumulating losses, you may find increased memory usage in your program. This is because the right-hand-side of the above expression used to be a Python float, while it is now a zero-dim Tensor.  The total loss is thus accumulating Tensors and their gradient history, which may keep around large autograd graphs for much longer than necessary.
+
+
+## Deprecation of ``volatile`` flag
+
+The ``volatile`` flag is now deprecated and has no effect. Previously, any computation that involves a ``Variable`` with ``volatile=True`` won't be tracked by ``autograd``. This has now been replaced by [a set of more flexible context managers](http://pytorch.org/docs/v0.4.0/torch.html#locally-disabling-gradient-computation) including ``torch.no_grad()``, ``torch.set_grad_enabled(grad_mode)``, and others.
+
+```python
+>>> x = torch.zeros(1, requires_grad=True)
+>>> with torch.no_grad():
+...     y = x * 2
+>>> y.requires_grad
+False
+>>>
+>>> is_train = False
+>>> with torch.set_grad_enabled(is_train):
+...     y = x * 2
+>>> y.requires_grad
+False
+>>> torch.set_grad_enabled(True)  # this can also be used as a function
+>>> y = x * 2
+>>> y.requires_grad
+True
+>>> torch.set_grad_enabled(False)
+>>> y = x * 2
+>>> y.requires_grad
+False
+```
+
+
+## [``dtypes``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``devices``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and NumPy-style creation functions
+
+In previous versions of PyTorch, we used to specify data type (e.g. float vs double), device type (cpu vs cuda) and layout (dense vs sparse) together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` was the ``Tensor`` type respresenting``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).
+
+In this release, we introduce [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties via NumPy-style creation functions.
+
+#### [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)
+
+Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)s (data types) and their corresponding tensor types.
+
+| Data type                 | ``torch.dtype``                        | Tensor types              |
+|:------------------------- |:-------------------------------------- | :------------------------ |
+| 32-bit floating point     | ``torch.float32`` or ``torch.float``   | ``torch.*.FloatTensor``   |
+| 64-bit floating point     | ``torch.float64`` or ``torch.double``  | ``torch.*.DoubleTensor``  |
+| 16-bit floating point     | ``torch.float16`` or ``torch.half``    | ``torch.*.HalfTensor``    |
+| 8-bit integer (unsigned)  | ``torch.uint8``                        | ``torch.*.ByteTensor``    |
+| 8-bit integer (signed)    | ``torch.int8``                         | ``torch.*.CharTensor``    |
+| 16-bit integer (signed)   | ``torch.int16``   or ``torch.short``   | ``torch.*.ShortTensor``   |
+| 32-bit integer (signed)   | ``torch.int32``   or ``torch.int``     | ``torch.*.IntTensor``     |
+| 64-bit integer (signed)   | ``torch.int64``   or ``torch.long``    | ``torch.*.LongTensor``    |
+
+<!---
+Use [``torch.set_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.set_default_dtype) and [``torch.get_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.get_default_dtype) to manipulate default ``dtype`` for floating point tensors.
+--->
+
+### [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device)
+
+A [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) contains a device type (``'cpu'`` or ``'cuda'``) and optional device ordinal (id) for the device type. It can be initilized with ``torch.device('{device_type}')`` or ``torch.device('{device_type}:{device_ordinal}')``.
+
+If the device ordinal is not present, this represents the current device for the device type; e.g., ``torch.device('cuda')`` is equivalent to ``torch.device('cuda:X')`` where ``X`` is the result of ``torch.cuda.current_device()``.
+
+### [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
+
+[``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) represents the data layout of a [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html). Currently``torch.strided`` (dense tensors) and ``torch.sparse_coo`` (sparse tensors with COO format) are supported.
+
+### Creating ``Tensor``s
+
+[Methods that create a ``Tensor``](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops) now also take in ``dtype``, ``device``, ``layout``, and ``requires_grad`` options to specify the desired attributes on the returned ``Tensor``. For example,
+
+```python
+>>> device = torch.device("cuda:1")
+>>> x = torch.randn(3, 3, dtype=torch.float64, device=device)
+tensor([[-0.6344,  0.8562, -1.2758],
+        [ 0.8414,  1.7962,  1.0589],
+        [-0.1369, -1.0462, -0.4373]], dtype=torch.float64, device='cuda:1')
+>>> x.requires_grad  # default is False
+False
+>>> x = torch.zeros(3, requires_grad=True)
+>>> x.requires_grad
+True
+```
+
+#### [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)
+[``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and copies the contained values into a new ``Tensor``. As mentioned earlier, [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is the PyTorch equivalent of NumPy's ``numpy.array`` constructor.  Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way (a single python number is treated as a Size in the``torch.*Tensor``  methods). Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
+
+```python
+>>> cuda = torch.device("cuda")
+>>> torch.tensor([[1], [2], [3]], dtype=torch.half, device=cuda)
+tensor([[ 1],
+        [ 2],
+        [ 3]], device='cuda:0')
+>>> torch.tensor(1)               # scalar
+tensor(1)
+>>> torch.tensor([1, 2.3]).dtype  # type inferece
+torch.float32
+>>> torch.tensor([1, 2]).dtype    # type inferece
+torch.int64
+```
+
+We've also added more tensor creation methods. Some of them have ``torch.*_like`` and/or ``tensor.new_*`` variants.
+
+1. ``torch.*_like`` takes in an input ``Tensor`` instead of a shape. It returns a ``Tensor`` with same attributes as the input ``Tensor`` by default unless otherwise specified:
+
+    ```python
+    >>> x = torch.randn(3, dtype=torch.float64)
+    >>> torch.zeros_like(x)
+    tensor([ 0.,  0.,  0.], dtype=torch.float64)
+    >>> torch.zeros_like(x, dtype=torch.int)
+    tensor([ 0,  0,  0], dtype=torch.int32)
+    ```
+
+2. ``tensor.new_*`` can also create ``Tensor``s with same attributes as ``tensor``, but it always takes in a shape argument:
+
+    ```python
+    >>> x = torch.randn(3, dtype=torch.float64)
+    >>> x.new_ones(2)
+    tensor([ 1.,  1.], dtype=torch.float64)
+    >>> x.new_ones(4, dtype=torch.int)
+    tensor([ 1,  1,  1,  1], dtype=torch.int32)
+    ```
+To specify the desired shape, you can either use a tuple (e.g., ``torch.zeros((2, 3))``) or variable arguments (e.g., ``torch.zeros(2, 3)``) in most cases.
+
+| Name                                                       | Returned ``Tensor``                                       | ``torch.*_like`` variant | ``tensor.new_*`` variant |
+|:-----------------------------------------------------------|-----------------------------------------------------------|--------------------------|--------------------------|
+| [``torch.empty``](http://pytorch.org/docs/v0.4.0/torch.html#torch.empty)                                            | unintialized memory                                       | ✔                        | ✔                        |
+| [``torch.zeros``](http://pytorch.org/docs/v0.4.0/torch.html#torch.zeros)                                            | all zeros                                                 | ✔                        | ✔                        |
+| [``torch.ones``](http://pytorch.org/docs/v0.4.0/torch.html#torch.ones)                                             | all ones                                                  | ✔                        | ✔                        |
+| [``torch.full``](http://pytorch.org/docs/v0.4.0/torch.html#torch.full)                                             | filled with a given value                                 | ✔                        | ✔                        |
+| [``torch.rand``](http://pytorch.org/docs/v0.4.0/torch.html#torch.rand)                                             | i.i.d. continuous ``Uniform[0, 1)``                       | ✔                        |                          |
+| [``torch.randn``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randn)                                            | i.i.d. ``Normal(0, 1)``                                   | ✔                        |                          |
+| [``torch.randint``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randint)                                          | i.i.d. discrete Uniform in given range                    | ✔                        |                          |
+| [``torch.randperm``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randperm)                                         | random permutation of ``{0, 1, ..., n - 1}``              |                          |                          |
+| [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)                                           | copied from existing data (`list`, NumPy `ndarray`, etc.) |                          | ✔                        |
+| [``torch.from_numpy``](http://pytorch.org/docs/v0.4.0/torch.html#torch.from_numpy)*                                      | from NumPy ``ndarray`` (sharing storage without copying)  |                          |                          |
+| [``torch.arange``](http://pytorch.org/docs/v0.4.0/torch.html#torch.arange), <br>[``torch.range``](http://pytorch.org/docs/v0.4.0/torch.html#torch.range), and <br>[``torch.linspace``](http://pytorch.org/docs/v0.4.0/torch.html#torch.linspace)  | uniformly spaced values in a given range                  |                          |                          |
+| [``torch.logspace``](http://pytorch.org/docs/v0.4.0/torch.html#torch.logspace)                                         | logarithmically spaced values in a given range            |                          |                          |
+| [``torch.eye``](http://pytorch.org/docs/v0.4.0/torch.html#torch.eye)                                              | identity matrix                                           |                          |                          |
+
+<span class='note'>*: [``torch.from_numpy``](http://pytorch.org/docs/v0.4.0/torch.html#torch.from_numpy) only takes in a NumPy ``ndarray`` as its input argument.</span>
+
+<!---
+we need some special formatting to make the above table and note look nicer
+-->
+<style>
+  .content table code { font-size: inherit; }
+  .content table td { white-space: nowrap; }
+  .content .note { font-size: 85%; }
+  .content .note code { font-size: 13px; }
+</style>
+
+## Writing device-agnostic code
+
+Previous versions of PyTorch made it difficult to write code that was device agnostic (i.e. that could run on both CUDA-enabled and CPU-only machines without modification).
+
+PyTorch 0.4.0 makes this easier in two ways:
+* The `device` attribute of a Tensor gives the [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) for all Tensors (`get_device` only works for CUDA tensors)
+* The `to` method of ``Tensors`` and ``Modules`` can be used to easily move objects to different devices (instead of having to call `cpu()` or `cuda()` based on the context)
+
+
+We recommend the following pattern:
+```python
+# at beginning of the script
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+...
+
+# then whenever you get a new Tensor or Module
+# this won't copy if they are already on the desired device
+input = data.to(device)
+model = MyModule(...).to(device)
+```
+
+## Code Samples (Putting it all together)
+
+To get a flavor of the overall recommended changes in 0.4.0, let's look at a quick example for a common code pattern in both 0.3.1 and 0.4.0:
+
 
 + 0.3.1 (old):
 
@@ -54,287 +344,7 @@ Let's first see a quick example on our recommended changes for a common code pat
     with torch.no_grad():                   # operations inside don't track history
         for input, target in test_loader:
             ...
-
     ```
-
-I'm sure you noticed many interesting changes! In sections below, we will now cover them (and more) in this order:
-
-1. No more ``Variable`` wrappers! What is ``torch.no_grad()``?
-2. ``torch.device``, new tensor creation methods (e.g., `new_zeros`), and the magical `.to()`.
-3. `.data[0]` becomes `.item()`?
-
-## Merging ``Variable`` and [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) classes
-
-``torch.autograd.Variable`` and [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) are now the same class! This means that you don't need the ``Variable`` wrapper everywhere in your code anymore.
-
-``requires_grad``, the central flag for [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html), is now an attribute on ``Tensor``s. Let's see how this change manifests in code!
-
-### When does [``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) start tracking history now?
-
-[``autograd``](http://pytorch.org/docs/v0.4.0/autograd.html) uses the same rules previously used for ``Variable``s. It starts tracking history when any input ``Tensor`` of an operation has ``requires_grad=True``. For example,
-
-```python
->>> x = torch.ones(1)  # create a tensor with requires_grad=False (default)
->>> x.requires_grad
-False
->>> y = torch.ones(1)  # another tensor with requires_grad=False
->>> z = x + y
->>> # both inputs have requires_grad=False. so does the output
->>> z.requires_grad
-False
->>> # then autograd won't track this computation. let's verify!
->>> z.backward()
-RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
->>>
->>> # now create a tensor with requires_grad=True
->>> w = torch.ones(1, requires_grad=True)
->>> w.requires_grad
-True
->>> # add to the previous result that has require_grad=False
->>> total = w + z
->>> # the total sum now requires grad!
->>> total.requires_grad
-True
->>> # autograd can compute the gradients as well
->>> total.backward()
->>> w.grad
-tensor([ 1.0000])
->>> # and no computation is wasted to compute gradients for x, y and z, which don't require grad
->>> z.grad == x.grad == y.grad == None
-True
-```
-
-#### Manipulating ``requires_grad`` flag
-
-Other than directly setting the attribute, you can change this flag **in-place** using [``my_tensor.requires_grad_(requires_grad=True)``](http://pytorch.org/docs/master/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is ``False``), e.g.,
-
-```python
->>> existing_tensor.requires_grad_()
->>> existing_tensor.requires_grad
-True
->>> my_tensor = torch.zeros(3, 4, requires_grad=True)
->>> my_tensor.requires_grad
-True
-```
-
-#### Deprecation of ``volatile`` flag
-
-The ``volatile`` flag is now deprecated and has no effect. Previously, any computation that involves a ``Variable`` with ``volatile=True`` won't be tracked by ``autograd``. This has now been replaced by [a set of more flexible context managers](http://pytorch.org/docs/v0.4.0/torch.html#locally-disabling-gradient-computation) including ``torch.no_grad()``, ``torch.set_grad_enabled(grad_mode)``, and others.
-
-```python
->>> x = torch.zeros(1, requires_grad=True)
->>> with torch.no_grad():
-...     y = x * 2
->>> y.requires_grad
-False
->>>
->>> is_train = False
->>> with torch.set_grad_enabled(is_train):
-...     y = x * 2
->>> y.requires_grad
-False
->>> torch.set_grad_enabled(True)  # this can also be used as a function
->>> y = x * 2
->>> y.requires_grad
-True
->>> torch.set_grad_enabled(False)
->>> y = x * 2
->>> y.requires_grad
-False
-```
-
-### What about ``.data``?
-
-``.data`` was the primary way to get the underlying ``Tensor`` from a ``Variable``. After this merge, calling ``y = x.data`` still has the same semantics. So ``y`` will be a ``Tensor`` that shares the same data with ``x``, is unrelated with the computation history of ``x``, and has ``requires_grad=False``.
-
-However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` won't be tracked by ``autograd``, and the computed gradients will be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/v0.4.0/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
-
-## Introducing [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
-
-In PyTorch, we used to specify data type, device (sort of) and layout together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` is for ``Tensor``s with ``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).
-
-In this release, we introduce [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties.
-
-### [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)
-
-Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)s and their corresponding tensor types.
-
-| Data type                 | ``torch.dtype``                        | Tensor types              |
-|:------------------------- |:-------------------------------------- | :------------------------ |
-| 32-bit floating point     | ``torch.float32`` or ``torch.float``   | ``torch.*.FloatTensor``   |
-| 64-bit floating point     | ``torch.float64`` or ``torch.double``  | ``torch.*.DoubleTensor``  |
-| 16-bit floating point     | ``torch.float16`` or ``torch.half``    | ``torch.*.HalfTensor``    |
-| 8-bit integer (unsigned)  | ``torch.uint8``                        | ``torch.*.ByteTensor``    |
-| 8-bit integer (signed)    | ``torch.int8``                         | ``torch.*.CharTensor``    |
-| 16-bit integer (signed)   | ``torch.int16``   or ``torch.short``   | ``torch.*.ShortTensor``   |
-| 32-bit integer (signed)   | ``torch.int32``   or ``torch.int``     | ``torch.*.IntTensor``     |
-| 64-bit integer (signed)   | ``torch.int64``   or ``torch.long``    | ``torch.*.LongTensor``    |
-
-Use [``torch.set_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.set_default_dtype) and [``torch.get_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.get_default_dtype) to manipulate default ``dtype`` for floating point tensors.
-
-### [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device)
-
-A [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) contains a device type (``'cpu'`` or ``'cuda'``) and optional device ordinal (id) for the device type. It can be initilized with ``torch.device('{device_type}')`` or ``torch.device('{device_type}:{device_ordinal}')``.
-
-If the device ordinal is not present, this represents the current device for the device type; e.g., ``torch.device('cuda')`` is equivalent to ``torch.device('cuda:X')`` where ``X`` is the result of ``torch.cuda.current_device()``.
-
-### [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
-
-[``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) is created to support more ``Tensor`` formats in future. Currently only ``torch.strided`` (dense tensors) and ``torch.sparse_coo`` (sparse tensors with COO format) are available.
-
-### Creating ``Tensor``s
-
-[Methods that create a ``Tensor``](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops) now also take in ``dtype``, ``device``, ``layout``, and ``requires_grad`` options to specify the desired attributes on the returned ``Tensor``. For example,
-
-```python
->>> device = torch.device("cuda:1")
->>> x = torch.randn(3, 3, dtype=torch.float64, device=device)
-tensor([[-0.6344,  0.8562, -1.2758],
-        [ 0.8414,  1.7962,  1.0589],
-        [-0.1369, -1.0462, -0.4373]], dtype=torch.float64, device='cuda:1')
->>> x.requires_grad  # default is False
-False
->>> x = torch.zeros(3, requires_grad=True)
->>> x.requires_grad
-True
-```
-
-#### [``torch.tensor(data, ...)``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)
-[``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and **copies** the contained values into a new ``Tensor``. Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way. Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
-
-```python
->>> cuda = torch.device("cuda")
->>> torch.tensor([[1], [2], [3]], dtype=torch.half, device=cuda)
-tensor([[ 1],
-        [ 2],
-        [ 3]], device='cuda:0')
->>> torch.tensor(1)               # scalar
-tensor(1)
->>> torch.tensor([1, 2.3]).dtype  # type inferece
-torch.float32
->>> torch.tensor([1, 2]).dtype    # type inferece
-torch.int64
-```
-
-We've also added more tensor creation methods. Some of them have ``torch.*_like`` and/or ``tensor.new_*`` variants.
-
-1. ``torch.*_like`` takes in an input ``Tensor`` instead of a shape. It returns a ``Tensor`` with same shape and attributes as the input ``Tensor`` unless otherwise specified:
-
-    ```python
-    >>> x = torch.randn(3, dtype=torch.float64)
-    >>> torch.zeros_like(x)
-    tensor([ 0.,  0.,  0.], dtype=torch.float64)
-    >>> torch.zeros_like(x, dtype=torch.int)  # override dtype
-    tensor([ 0,  0,  0], dtype=torch.int32)
-    ```
-
-2. ``existing_tensor.new_*`` can also create ``Tensor``s with same attributes as ``existing_tensor``, but it always takes in a shape argument:
-
-    ```python
-    >>> x = torch.randn(3, dtype=torch.float64)
-    >>> x.new_ones(2)
-    tensor([ 1.,  1.], dtype=torch.float64)
-    >>> x.new_ones(4, dtype=torch.int)
-    tensor([ 1,  1,  1,  1], dtype=torch.int32)
-    ```
-
-To specify the desired shape, you can either use a tuple (e.g., ``torch.zeros((2, 3))``) or variable arguments (e.g., ``torch.zeros(2, 3)``) in most cases.
-
-| Name                                                       | Returned ``Tensor``                                       | ``torch.*_like`` variant | ``tensor.new_*`` variant |
-|:-----------------------------------------------------------|-----------------------------------------------------------|--------------------------|--------------------------|
-| [``torch.empty``](http://pytorch.org/docs/v0.4.0/torch.html#torch.empty)                                            | unintialized memory                                       | ✔                        | ✔                        |
-| [``torch.zeros``](http://pytorch.org/docs/v0.4.0/torch.html#torch.zeros)                                            | all zeros                                                 | ✔                        | ✔                        |
-| [``torch.ones``](http://pytorch.org/docs/v0.4.0/torch.html#torch.ones)                                             | all ones                                                  | ✔                        | ✔                        |
-| [``torch.full``](http://pytorch.org/docs/v0.4.0/torch.html#torch.full)                                             | filled with a given value                                 | ✔                        | ✔                        |
-| [``torch.rand``](http://pytorch.org/docs/v0.4.0/torch.html#torch.rand)                                             | i.i.d. continuous ``Uniform[0, 1)``                       | ✔                        |                          |
-| [``torch.randn``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randn)                                            | i.i.d. ``Normal(0, 1)``                                   | ✔                        |                          |
-| [``torch.randint``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randint)                                          | i.i.d. discrete Uniform in given range                    | ✔                        |                          |
-| [``torch.randperm``](http://pytorch.org/docs/v0.4.0/torch.html#torch.randperm)                                         | random permutation of ``{0, 1, ..., n - 1}``              |                          |                          |
-| [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)                                           | copied from existing data (`list`, NumPy `ndarray`, etc.) |                          | ✔                        |
-| [``torch.from_numpy``](http://pytorch.org/docs/v0.4.0/torch.html#torch.from_numpy)*                                      | from NumPy ``ndarray`` (sharing storage without copying)  |                          |                          |
-| [``torch.arange``](http://pytorch.org/docs/v0.4.0/torch.html#torch.arange), <br>[``torch.range``](http://pytorch.org/docs/v0.4.0/torch.html#torch.range), and <br>[``torch.linspace``](http://pytorch.org/docs/v0.4.0/torch.html#torch.linspace)  | uniformly spaced values in a given range                  |                          |                          |
-| [``torch.logspace``](http://pytorch.org/docs/v0.4.0/torch.html#torch.logspace)                                         | logarithmically spaced values in a given range            |                          |                          |
-| [``torch.eye``](http://pytorch.org/docs/v0.4.0/torch.html#torch.eye)                                              | identity matrix                                           |                          |                          |
-
-<span class='note'>*: [``torch.from_numpy``](http://pytorch.org/docs/v0.4.0/torch.html#torch.from_numpy) only takes in a NumPy ``ndarray`` as its input argument.</span>
-
-<!---
-we need some special formatting to make the above table and note look nicer
--->
-<style>
-  .content table code { font-size: inherit; }
-  .content table td { white-space: nowrap; }
-  .content .note { font-size: 85%; }
-  .content .note code { font-size: 13px; }
-</style>
-
-### Moving and casting ``Tensor``s and ``Module``s
-
-``.to(..)`` method is added on both ``Tensor`` and ``Module`` objects to support easily moving them to different devices and casting them to different types. For example, with [``tensor.to(..)``](http://pytorch.org/docs/v0.4.0/tensors.html#torch.Tensor.to),
-
-```python
->>> cpu = torch.device("cpu")
->>> cuda = torch.device("cuda")
->>> x = torch.randn(3, dtype=torch.double)            # a double tensor on CPU
->>> x
-tensor([-0.1061,  0.5796, -1.0124], dtype=torch.float64)
->>> y = torch.zeros(2, dtype=torch.half, device=cuda) # a half tensor on GPU
->>> y
-tensor([ 0.,  0.], dtype=torch.float16, device='cuda:0')
->>> x.to(cuda)                                        # move to a different device
-tensor([-0.1061,  0.5796, -1.0124], dtype=torch.float64, device='cuda:0')
->>> y.to(torch.double)                                # cast to a different type
-tensor([ 0.,  0.], dtype=torch.float64, device='cuda:0')
->>> x.to(cuda, torch.half)                            # move and cast at the same time
-tensor([-0.1061,  0.5796, -1.0127], dtype=torch.float16, device='cuda:0')
->>> y.to(x)                                           # move and cast to the same device and dtype as a given tensor
-tensor([ 0.,  0.], dtype=torch.float64)
-```
-
-[``module.to(...)``](http://pytorch.org/docs/v0.4.0/nn.html#torch.nn.Module.to) works similarly but is in-place and does not support taking in a ``Tensor``.
-
-### Writing device-agnostic code
-
-With the addition of [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device), it's much easier to write device-agnostic code. We suggest the following pattern:
-
-```python
-# at beginning of the script
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-...
-
-# then whenever you get a new Tensor or Module
-# this won't copy if they are already on the desired device
-input = data.to(device)
-model = MyModule(...).to(device)
-```
-
-## Zero-dimensional ``Tensor``s (aka scalars)
-
-Previously, indexing into a ``Tensor`` vector (1-dimensional tensor) gave a Python number but indexing into a ``Variable`` vector gave (unexpectedly!) a vector of size ``(1,)``! This behavior was inconsistent: it was necessary because ``autograd`` can't track history on Python numbers but indexing into a 1-dimensional tensor should give a 0-dimensional tensor (i.e., a scalar).
-
-Fortunately, this release introduces proper scalar support in PyTorch! Now you can do things like:
-
-```python
->>> torch.tensor(3.1416)         # create a scalar directly
-tensor(3.1416)
->>> torch.tensor(3.1416).size()  # scalar is 0-dimensional
-torch.Size([])
->>> torch.tensor([3]).size()     # compare to a vector of size 1
-torch.Size([1])
->>>
->>> vector = torch.arange(2, 6)  # this is a vector
->>> vector
-tensor([ 2.,  3.,  4.,  5.])
->>> vector.size()
-torch.Size([4])
->>> vector[3]                    # indexing into a vector gives a scalar
-tensor(5.)
->>> vector[3].item()             # .item() gives the Python number in a scalar
-5.0
-```
-
-Consider the widely used pattern ``loss.data[0]`` before 0.4.0. ``loss`` was a ``Variable`` wrapping a tensor of size ``(1,)``, but in 0.4.0 ``loss`` is now a scalar and has ``0`` dimensions. Indexing into a scalar doesn't make sense (and will be a hard error in 0.5.0): use ``loss.item()`` to get the Python number from a scalar.
 
 
 Thank you for reading! Please refer to our [documentation](http://pytorch.org/docs/0.4.0/index.html) and [release notes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0) for more details.

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -202,7 +202,7 @@ False
 True
 ```
 
-#### ``torch.tensor``
+#### ``torch.tensor(data, ...)``
 [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and copies the contained values into a new ``Tensor``. Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way. Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
 
 ```python

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -6,10 +6,10 @@ date: 2018-04-22 12:00:00 -0500
 ---
 
 Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced [many exciting new features and critical bug fixes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0), with the goal of providing users a better and cleaner interface. In this guide, we will cover the most important changes in migrating existing code from previous versions:
-* ``Tensor``s and ``Variable``s have merged
+* ``Tensors`` and ``Variables`` have merged
 * Support for 0-dimensional (scalar) ``Tensors``
 * Deprecation of the ``volatile`` flag
-* ``dtype``s, ``device``s, and Numpy-style ``Tensor`` creation functions
+* ``dtypes``, ``devices``, and Numpy-style ``Tensor`` creation functions
 * Writing device-agnostic code
 
 
@@ -242,6 +242,7 @@ We've also added more tensor creation methods. Some of them have ``torch.*_like`
     >>> x.new_ones(4, dtype=torch.int)
     tensor([ 1,  1,  1,  1], dtype=torch.int32)
     ```
+
 To specify the desired shape, you can either use a tuple (e.g., ``torch.zeros((2, 3))``) or variable arguments (e.g., ``torch.zeros(2, 3)``) in most cases.
 
 | Name                                                       | Returned ``Tensor``                                       | ``torch.*_like`` variant | ``tensor.new_*`` variant |

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -271,7 +271,7 @@ we need some special formatting to make the above table and note look nicer
 
 ### Moving and casting ``Tensor``s and ``Module``s
 
-``.to(..)`` method is added on both ``Tensor``s and ``Module``s to support easily moving them to different devices and casting them to different types. For example,
+``.to(..)`` method is added on both ``Tensor`` and ``Module`` objects to support easily moving them to different devices and casting them to different types. For example, with [``tensor.to(..)``](http://pytorch.org/docs/v0.4.0/tensors.html#torch.Tensor.to),
 
 ```python
 >>> cpu = torch.device("cpu")
@@ -292,7 +292,7 @@ tensor([-0.1061,  0.5796, -1.0127], dtype=torch.float16, device='cuda:0')
 tensor([ 0.,  0.], dtype=torch.float64)
 ```
 
-``module.to()`` works similarly but is in-place and does not support taking in a ``Tensor``.
+[``module.to(...)``](http://pytorch.org/docs/v0.4.0/nn.html#torch.nn.Module.to) works similarly but is in-place and does not support taking in a ``Tensor``.
 
 ### Writing device-agnostic code
 

--- a/_posts/2018-04-22-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-0_4_0-migration-guide.md
@@ -63,7 +63,7 @@ I'm sure you noticed many interesting changes! In sections below, we will now co
 2. ``torch.device``, new tensor creation methods (e.g., `new_zeros`), and the magical `.to()`.
 3. `.data[0]` becomes `.item()`?
 
-## Merging ``Variable`` and ``Tensor`` classes
+## Merging ``Variable`` and [``Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) classes
 
 ``torch.autograd.Variable`` and [``torch.Tensor``](http://pytorch.org/docs/v0.4.0/tensors.html) are now the same class! This means that you don't need the ``Variable`` wrapper everywhere in your code anymore.
 
@@ -149,13 +149,13 @@ False
 
 However, ``.data`` can be unsafe in some cases. Any changes on ``x.data`` won't be tracked by ``autograd``, and the computed gradients will be incorrect if ``x`` is needed in a backward pass. A safer alternative is to use [``x.detach()``](http://pytorch.org/docs/v0.4.0/autograd.html#torch.Tensor.detach), which also returns a ``Tensor`` that shares data with ``requires_grad=False``, but will have its in-place changes reported by ``autograd`` if ``x`` is needed in backward.
 
-## Introducing ``torch.dtype``, ``torch.device`` and ``torch.layout``
+## Introducing [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
 
 In PyTorch, we used to specify data type, device (sort of) and layout together as a "tensor type". For example, ``torch.cuda.sparse.DoubleTensor`` is for ``Tensor``s with ``double`` data type, living on CUDA devices, and with [COO sparse tensor layout](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)).
 
 In this release, we introduce [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype), [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) and [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties.
 
-### ``torch.dtype``
+### [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)
 
 Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.dtype)s and their corresponding tensor types.
 
@@ -172,13 +172,13 @@ Below is a complete list of available [``torch.dtype``](http://pytorch.org/docs/
 
 Use [``torch.set_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.set_default_dtype) and [``torch.get_default_dtype``](http://pytorch.org/docs/v0.4.0/torch.html#torch.get_default_dtype) to manipulate default ``dtype`` for floating point tensors.
 
-### ``torch.device``
+### [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device)
 
 A [``torch.device``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.device) contains a device type (``'cpu'`` or ``'cuda'``) and optional device ordinal (id) for the device type. It can be initilized with ``torch.device('{device_type}')`` or ``torch.device('{device_type}:{device_ordinal}')``.
 
 If the device ordinal is not present, this represents the current device for the device type; e.g., ``torch.device('cuda')`` is equivalent to ``torch.device('cuda:X')`` where ``X`` is the result of ``torch.cuda.current_device()``.
 
-### ``torch.layout``
+### [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout)
 
 [``torch.layout``](http://pytorch.org/docs/v0.4.0/tensor_attributes.html#torch.torch.layout) is created to support more ``Tensor`` formats in future. Currently only ``torch.strided`` (dense tensors) and ``torch.sparse_coo`` (sparse tensors with COO format) are available.
 
@@ -199,7 +199,7 @@ False
 True
 ```
 
-#### ``torch.tensor(data, ...)``
+#### [``torch.tensor(data, ...)``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor)
 [``torch.tensor``](http://pytorch.org/docs/v0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/v0.4.0/torch.html#creation-ops). It takes in array like data of all kinds and copies the contained values into a new ``Tensor``. Unlike the ``torch.*Tensor`` methods, you can also create zero-dimensional ``Tensor``s (aka scalars) this way. Moreover, if a ``dtype`` argument isn't given, it will infer the suitable ``dtype`` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
 
 ```python

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -76,8 +76,8 @@ a:hover {
 
     code {
         font-family: monospace !important;
-        font-size: 15px;
         font-weight: 400;
+        font-size: 95%;  // make code in headers look much better
         border-radius: 3px;
         color: #000;
         word-break: break-all;
@@ -86,6 +86,14 @@ a:hover {
         -ms-hyphens: auto;
         hyphens: auto;
         text-shadow: 0px 1px 0px #fff;
+    }
+
+    p code {
+      font-size: 15px;
+    }
+
+    a code {
+      color: inherit;  // allow code in <a> to show as blue
     }
 
     ul, ol {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -89,8 +89,8 @@ a:hover {
     }
 
     h1, h2, h3, h4 {
-      code {
-        font-size: 85%;  // make code in headers look much better
+      code {  // make code in headers look much better
+        font-size: 85%;
         font-weight: 600;
       }
     }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -90,7 +90,7 @@ a:hover {
     }
 
     .highlight code {
-        white-space: normal;
+        white-space: inherit;
     }
 
     h1, h2, h3, h4 {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -90,7 +90,8 @@ a:hover {
 
     h1, h2, h3, h4 {
       code {
-        font-size: 95%;  // make code in headers look much better
+        font-size: 85%;  // make code in headers look much better
+        font-weight: 600;
       }
     }
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -76,8 +76,8 @@ a:hover {
 
     code {
         font-family: monospace !important;
-        font-weight: 400;
         font-size: 15px;
+        font-weight: 400;
         border-radius: 3px;
         color: #000;
         word-break: break-all;

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -77,7 +77,7 @@ a:hover {
     code {
         font-family: monospace !important;
         font-weight: 400;
-        font-size: 95%;  // make code in headers look much better
+        font-size: 15px;
         border-radius: 3px;
         color: #000;
         word-break: break-all;
@@ -88,8 +88,10 @@ a:hover {
         text-shadow: 0px 1px 0px #fff;
     }
 
-    p code {
-      font-size: 15px;
+    h1, h2, h3, h4 {
+      code {
+        font-size: 95%;  // make code in headers look much better
+      }
     }
 
     a code {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -86,6 +86,11 @@ a:hover {
         -ms-hyphens: auto;
         hyphens: auto;
         text-shadow: 0px 1px 0px #fff;
+        white-space: nowrap;
+    }
+
+    .highlight code {
+        white-space: normal;
     }
 
     h1, h2, h3, h4 {


### PR DESCRIPTION
Notice that all links point to `http://pytorch.org/docs/v0.4.0/*`, which doesn't exist currently.

Reviewers, please ping me and I will give you a link to the rendered webpage hosted on my personal box.