### PR TITLE
move quick-start to right below 'Key Features'

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,7 @@ body-class: homepage
     </div>
   </div>
 
-  <div class="homepage-feature-module">
-    {% include quick_start_module.html %}
-  </div>
+  {% include quick_start_module.html %}
 
   <div class="homepage-feature-module community-module container-fluid">
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@ body-class: homepage
   </div>
 </div>
 
+
 <div class="main-content-wrapper">
   <div class="container homepage-feature-module key-features-module">
     <div class="row">
@@ -38,6 +39,10 @@ body-class: homepage
         </div>
       {% endfor %}
     </div>
+  </div>
+
+  <div class="homepage-feature-module">
+    {% include quick_start_module.html %}
   </div>
 
   <div class="homepage-feature-module community-module container-fluid">
@@ -160,7 +165,6 @@ body-class: homepage
   </div>
 </div>
 
-{% include quick_start_module.html %}
 
 <!-- Start Load Tweets -->
 


### PR DESCRIPTION
instead of the bottom of the page