### PR TITLE
Add missing "torchvision Reference"

### DIFF
--- a/docs/0.3.1/index.html
+++ b/docs/0.3.1/index.html
@@ -619,6 +619,16 @@
 </ul>
 </div>
 <div class="toctree-wrapper compound">
+<p class="caption"><span class="caption-text">torchvision Reference</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="torchvision/index.html">torchvision</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="torchvision/datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l2"><a class="reference internal" href="torchvision/models.html">torchvision.models</a></li>
+<li class="toctree-l2"><a class="reference internal" href="torchvision/transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l2"><a class="reference internal" href="torchvision/utils.html">torchvision.utils</a></li>
+</ul>
+</li>
+</ul>
 </div>
 </div>
 <div class="section" id="indices-and-tables">


### PR DESCRIPTION
In "https://pytorch.org/docs/[version-number]/",
"torchvision Reference" is missing in version 0.3.1 but present in version 0.4.0 , Although it's container "toctree-wrapper compound" was present but it was blank.