### PR TITLE
[PYT-282] Update alternating background colors of homepage modules

### DIFF
--- a/_sass/homepage.scss
+++ b/_sass/homepage.scss
@@ -31,6 +31,12 @@
     height: 490px;
     }
   }
+
+  .ecosystem-row {
+    .card {
+      background-color: $light_grey;
+    }
+  }
 }
 
 .homepage-feature-module {
@@ -114,7 +120,7 @@
 }
 
 .community-module {
-  background-color: $light_grey;
+  background-color: $white;
 
   .ecosystem-card {
     height: auto;
@@ -144,7 +150,7 @@
   }
 
   .module-button {
-    color: $slate;
+    background-color: $light_grey;
   }
 
   p {
@@ -169,6 +175,11 @@
       top: 10px;
     }
   }
+}
+
+.pytorch-users-module,
+.homepage-bottom-wrapper {
+  background-color: $light_grey;
 }
 
 .community-avatar {

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ body-class: homepage
         <div class="col-md-12">
           <h2>Ecosystem </h2>
 
-          <a href="{{ site.baseurl }}/ecosystem" class="btn btn-white btn-lg with-right-arrow module-button">
+          <a href="{{ site.baseurl }}/ecosystem" class="btn btn-lg with-right-arrow module-button">
             See all Projects
           </a>
 
@@ -59,7 +59,7 @@ body-class: homepage
         </div>
       </div>
 
-      <div class="row">
+      <div class="row ecosystem-row">
         {% assign ecosystems = site.ecosystem | where: "featured-home", true | sort: 'order' %}
         {% for item in ecosystems %}
         <div class="col-md-4">
@@ -131,7 +131,8 @@ body-class: homepage
   </div>
 </div>
 
-  <div class="homepage-feature-module pytorch-users-module container">
+  <div class="homepage-bottom-wrapper">
+    <div class="homepage-feature-module pytorch-users-module container">
     <div class="row">
       <div class="col-md-12 university-testimonials">
         <h2>Companies &amp; Universities<br />Using PyTorch</h2>
@@ -159,6 +160,7 @@ body-class: homepage
         <h2>Follow Us on Twitter</h2>
         <div data-target="twitter-timeline">Loading Twitter timeline...</div>
       </div>
+    </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR reestablishes the alternating background-color pattern of the homepage layout. The Showcased Projects/Our Community sections now feature a white background while the Companies and Universities/Twitter sections feature a gray background. Also, the ecosystem cards and the "See All Projects" button within the Ecosystem section are now gray.