### PR TITLE
Correct sample-code function indentation

### DIFF
--- a/_features/hybrid-front-end.md
+++ b/_features/hybrid-front-end.md
@@ -3,8 +3,8 @@ title: Hybrid Front-End
 order: 1
 snippet: >
   ```python
-    @torch.jit.script
-    def RNN(h, x, 
+  @torch.jit.script
+  def RNN(h, x, 
        W_h, U_h, W_y, 
        b_h, b_y):
     y = []


### PR DESCRIPTION
Tiny update. The indentation of the sample code was invalid - the function body wasn't indented