### PR TITLE
Use normal font instead of light

### DIFF
--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -1,6 +1,6 @@
 * {
   font-family: FreightSans, Helvetica Neue, Helvetica, Arial, sans-serif;
-  font-weight: 300;
+  font-weight: 400; /* normal - https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping */
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
A great tip from @zpao and from [HN](https://news.ycombinator.com/item?id=18126089) noticed that the font weight was light. Let's just make it normal.