### PR TITLE
Features indentation fix

### DIFF
--- a/_features/cloud-partners.md
+++ b/_features/cloud-partners.md
@@ -3,14 +3,14 @@ title: Cloud Partners
 order: 7
 snippet: >
   ```sh
-    export IMAGE_FAMILY="pytorch-latest-cpu"
-    export ZONE="us-west1-b"
-    export INSTANCE_NAME="my-instance"
+  export IMAGE_FAMILY="pytorch-latest-cpu"
+  export ZONE="us-west1-b"
+  export INSTANCE_NAME="my-instance"
     
-    gcloud compute instances create $INSTANCE_NAME \
-      --zone=$ZONE \
-      --image-family=$IMAGE_FAMILY \
-      --image-project=deeplearning-platform-release
+  gcloud compute instances create $INSTANCE_NAME \
+    --zone=$ZONE \
+    --image-family=$IMAGE_FAMILY \
+    --image-project=deeplearning-platform-release
   ```
 
 summary-home: PyTorch is well supported on major cloud platforms, providing frictionless development and easy scaling.

--- a/_features/cplusplus-front-end.md
+++ b/_features/cplusplus-front-end.md
@@ -3,20 +3,20 @@ title: C++ Front-End
 order: 6
 snippet: >
   ```cpp
-    #include <torch/torch.h>
+  #include <torch/torch.h>
 
-    torch::nn::Linear model(num_features, 1);
-    torch::optim::SGD optimizer(model->parameters());
-    auto data_loader = torch::data::data_loader(dataset);
+  torch::nn::Linear model(num_features, 1);
+  torch::optim::SGD optimizer(model->parameters());
+  auto data_loader = torch::data::data_loader(dataset);
 
-    for (size_t epoch = 0; epoch < 10; ++epoch) {
-      for (auto batch : data_loader) {
-        auto prediction = model->forward(batch.data);
-        auto loss = loss_function(prediction, batch.target);
-        loss.backward();
-        optimizer.step();
-      }
+  for (size_t epoch = 0; epoch < 10; ++epoch) {
+    for (auto batch : data_loader) {
+      auto prediction = model->forward(batch.data);
+      auto loss = loss_function(prediction, batch.target);
+      loss.backward();
+      optimizer.step();
     }
+  }
   ```
 ---
 

--- a/_features/distributed-training.md
+++ b/_features/distributed-training.md
@@ -3,11 +3,11 @@ title: Distributed Training
 order: 2
 snippet: >
   ```python
-    import torch.distributed as dist
-    from torch.nn.parallel import DistributedDataParallel
+  import torch.distributed as dist
+  from torch.nn.parallel import DistributedDataParallel
     
-    dist.init_process_group(backend='gloo')
-    model = DistributedDataParallel(model)
+  dist.init_process_group(backend='gloo')
+  model = DistributedDataParallel(model)
   ```
 
 summary-home: Scalable distributed training and performance optimization in research and production is enabled by the torch.distributed backend.

--- a/_features/hybrid-front-end.md
+++ b/_features/hybrid-front-end.md
@@ -3,15 +3,15 @@ title: Hybrid Front-End
 order: 1
 snippet: >
   ```python
-    @torch.jit.script
-    def RNN(h, x, W_h, U_h, W_y, b_h, b_y):
-      y = []
-      for t in range(x.size(0)):
-        h = torch.tanh(x[t] @ W_h + h @ U_h + b_h)
-        y += [torch.tanh(h @ W_y + b_y)]
-        if t % 10 == 0:
-          print("stats: ", h.mean(), h.var())
-      return torch.stack(y), h
+  @torch.jit.script
+  def RNN(h, x, W_h, U_h, W_y, b_h, b_y):
+    y = []
+    for t in range(x.size(0)):
+      h = torch.tanh(x[t] @ W_h + h @ U_h + b_h)
+      y += [torch.tanh(h @ W_y + b_y)]
+      if t % 10 == 0:
+        print("stats: ", h.mean(), h.var())
+    return torch.stack(y), h
   ```
 
 summary-home: A new hybrid front-end seamlessly transitions between eager mode and graph mode to provide both flexibility and speed.

--- a/_features/native-onnx-support.md
+++ b/_features/native-onnx-support.md
@@ -3,12 +3,12 @@ title: Native ONNX Support
 order: 5
 snippet: >
   ```python
-    import torch.onnx
-    import torchvision
+  import torch.onnx
+  import torchvision
 
-    dummy_input = torch.randn(1, 3, 224, 224)
-    model = torchvision.models.alexnet(pretrained=True)
-    torch.onnx.export(model, dummy_input, "alexnet.onnx")
+  dummy_input = torch.randn(1, 3, 224, 224)
+  model = torchvision.models.alexnet(pretrained=True)
+  torch.onnx.export(model, dummy_input, "alexnet.onnx")
   ```
 ---
 

--- a/_features/python-first.md
+++ b/_features/python-first.md
@@ -3,13 +3,13 @@ title: Python-First
 order: 3
 snippet: >
   ```python
-    import torch
-    import numpy as np
-    a = np.ones(5)
-    b = torch.from_numpy(a)
-    np.add(a, 1, out=a)
-    print(a)
-    print(b)
+  import torch
+  import numpy as np
+  a = np.ones(5)
+  b = torch.from_numpy(a)
+  np.add(a, 1, out=a)
+  print(a)
+  print(b)
   ```
 
 summary-home: Deep integration into Python allows popular libraries and packages to be used for easily writing neural network layers in Python.

--- a/_features/tools-libraries.md
+++ b/_features/tools-libraries.md
@@ -3,13 +3,13 @@ title: Tools & Libraries
 order: 4
 snippet: >
   ```python
-    import torchvision.models as models
-    resnet18 = models.resnet18(pretrained=True)
-    alexnet = models.alexnet(pretrained=True)
-    squeezenet = models.squeezenet1_0(pretrained=True)
-    vgg16 = models.vgg16(pretrained=True)
-    densenet = models.densenet161(pretrained=True)
-    inception = models.inception_v3(pretrained=True)
+  import torchvision.models as models
+  resnet18 = models.resnet18(pretrained=True)
+  alexnet = models.alexnet(pretrained=True)
+  squeezenet = models.squeezenet1_0(pretrained=True)
+  vgg16 = models.vgg16(pretrained=True)
+  densenet = models.densenet161(pretrained=True)
+  inception = models.inception_v3(pretrained=True)
   ```
 
 summary-home: A rich ecosystem of tools and libraries extends PyTorch and supports development in computer vision, NLP and more.


### PR DESCRIPTION
On the 'features' pages, the code snippets have an indent of two spaces. This makes it impractical to copy-and-paste these snippets from the site into your command line because that would result in an 'indentation error'. This commit remedies that by removing the superfluous indentations.