### PR TITLE
Fix Google Analytics ID dash characters

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -4,7 +4,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA‌-90545585-1', 'auto');
+  ga('create', 'UA-90545585-1', 'auto');
   ga('send', 'pageview');
 
 </script>


### PR DESCRIPTION
The dash characters aren't correct or are not encoded properly, keeping GA from recording data.