### PR TITLE
Center contents of 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,18 +8,20 @@ layout: general
 <!DOCTYPE html>
 <html>
 <body>
-  <img src="{{ site.baseurl }}/assets/images/404_sign.png" />
+  <div style="text-align: center;">
+    <img src="{{ site.baseurl }}/assets/images/404_sign.png" />
 
-  <h1>Oops!</h1>
+    <h1>Oops!</h1>
 
-  <h4>You've reached a dead end.</h4>
+    <h4>You've reached a dead end.</h4>
 
-  <h4>
-    If you feel like something should be here, you can <a href="https://github.com/pytorch/pytorch.github.io/issues">open an issue</a> on GitHub.
-  </h4>
+    <h4>
+      If you feel like something should be here, you can <a href="https://github.com/pytorch/pytorch.github.io/issues">open an issue</a> on GitHub.
+    </h4>
 
-  <h4>
-    Click <a href="/">here</a> to go back to the main page.
-  </h4>
+    <h4>
+      Click <a href="/">here</a> to go back to the main page.
+    </h4>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Reopening this to be on the /site branch as requested. Here is the old version
![404pg_broken](https://user-images.githubusercontent.com/14957047/47745167-6c2eb300-dc59-11e8-9cdb-b13e5ff8f01e.PNG)

Here is the new version
![404pg_fixed](https://user-images.githubusercontent.com/14957047/47745171-70f36700-dc59-11e8-9a2e-3888c1ba6042.PNG)

It needed a container to center it
