### PR TITLE
Use https in references to pytorch.org instead of http

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -11,7 +11,7 @@ redirect_from: /previous-versions.html
 
 ## Installing previous versions of PyTorch
 
-We'd prefer you install the [latest version](http://pytorch.org/get-started/locally),
+We'd prefer you install the [latest version](https://pytorch.org/get-started/locally),
 but old binaries and installation instructions are provided below for
 your convenience.
 

--- a/_posts/2018-01-19-a-year-in.md
+++ b/_posts/2018-01-19-a-year-in.md
@@ -95,7 +95,7 @@ PyTorch is a research-focused framework. So one of the metrics of interest is to
 
 When we released PyTorch, we had good API documentation, but our tutorials were limited to a few ipython notebooks — helpful, but not good enough.
 
-[Sasank Chilamkurthy](https://github.com/chsasank) took it upon himself to revamp the tutorials into the [beautiful website](http://pytorch.org/tutorials/) that it is today.
+[Sasank Chilamkurthy](https://github.com/chsasank) took it upon himself to revamp the tutorials into the [beautiful website](https://pytorch.org/tutorials/) that it is today.
 
 <div class="text-center">
   <img src="{{ site.url }}/assets/images/blog_combined_tutorials.png" width="40%">

--- a/_posts/2018-04-22-pytorch-0_4_0-migration-guide.md
+++ b/_posts/2018-04-22-pytorch-0_4_0-migration-guide.md
@@ -13,11 +13,11 @@ Welcome to the migration guide for PyTorch 0.4.0. In this release we introduced 
 - Writing device-agnostic code
 - New edge-case constraints on names of submodules, parameters, and buffers in `nn.Module`
 
-## Merging [`Tensor`](http://pytorch.org/docs/0.4.0/tensors.html) and `Variable` and classes
+## Merging [`Tensor`](https://pytorch.org/docs/0.4.0/tensors.html) and `Variable` and classes
 
-[`torch.Tensor`](http://pytorch.org/docs/0.4.0/tensors.html) and `torch.autograd.Variable` are now the same class. More precisely, [`torch.Tensor`](http://pytorch.org/docs/0.4.0/tensors.html) is capable of tracking history and behaves like the old `Variable`; `Variable` wrapping continues to work as before but returns an object of type [`torch.Tensor`](http://pytorch.org/docs/0.4.0/tensors.html). This means that you don't need the `Variable` wrapper everywhere in your code anymore.
+[`torch.Tensor`](https://pytorch.org/docs/0.4.0/tensors.html) and `torch.autograd.Variable` are now the same class. More precisely, [`torch.Tensor`](https://pytorch.org/docs/0.4.0/tensors.html) is capable of tracking history and behaves like the old `Variable`; `Variable` wrapping continues to work as before but returns an object of type [`torch.Tensor`](https://pytorch.org/docs/0.4.0/tensors.html). This means that you don't need the `Variable` wrapper everywhere in your code anymore.
 
-### The `type()` of a [`Tensor`](http://pytorch.org/docs/0.4.0/tensors.html) has changed
+### The `type()` of a [`Tensor`](https://pytorch.org/docs/0.4.0/tensors.html) has changed
 
 Note also that the `type()` of a Tensor no longer reflects the data type. Use `isinstance()` or `x.type()`instead:
 
@@ -31,9 +31,9 @@ Note also that the `type()` of a Tensor no longer reflects the data type. Use `i
 True
 ```
 
-### When does [`autograd`](http://pytorch.org/docs/0.4.0/autograd.html) start tracking history now?
+### When does [`autograd`](https://pytorch.org/docs/0.4.0/autograd.html) start tracking history now?
 
-`requires_grad`, the central flag for [`autograd`](http://pytorch.org/docs/0.4.0/autograd.html), is now an attribute on `Tensors`. The same rules previously used for `Variables` applies to `Tensors`; [`autograd`](http://pytorch.org/docs/0.4.0/autograd.html) starts tracking history when any input `Tensor` of an operation has `requires_grad=True`. For example,
+`requires_grad`, the central flag for [`autograd`](https://pytorch.org/docs/0.4.0/autograd.html), is now an attribute on `Tensors`. The same rules previously used for `Variables` applies to `Tensors`; [`autograd`](https://pytorch.org/docs/0.4.0/autograd.html) starts tracking history when any input `Tensor` of an operation has `requires_grad=True`. For example,
 
 ```python
 >>> x = torch.ones(1)  # create a tensor with requires_grad=False (default)
@@ -68,7 +68,7 @@ True
 
 #### Manipulating `requires_grad` flag
 
-Other than directly setting the attribute, you can change this flag `in-place` using [`my_tensor.requires_grad_()`](http://pytorch.org/docs/0.4.0/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is `False`), e.g.,
+Other than directly setting the attribute, you can change this flag `in-place` using [`my_tensor.requires_grad_()`](https://pytorch.org/docs/0.4.0/tensors.html#torch.Tensor.requires_grad_), or, as in the above example, at creation time by passing it in as an argument (default is `False`), e.g.,
 
 ```python
 >>> existing_tensor.requires_grad_()
@@ -83,7 +83,7 @@ True
 
 `.data` was the primary way to get the underlying `Tensor` from a `Variable`. After this merge, calling `y = x.data` still has similar semantics. So `y` will be a `Tensor` that shares the same data with `x`, is unrelated with the computation history of `x`, and has `requires_grad=False`.
 
-However, `.data` can be unsafe in some cases. Any changes on `x.data` wouldn't be tracked by `autograd`, and the computed gradients would be incorrect if `x` is needed in a backward pass. A safer alternative is to use [`x.detach()`](http://pytorch.org/docs/master/autograd.html#torch.Tensor.detach), which also returns a `Tensor` that shares data with `requires_grad=False`, but will have its in-place changes reported by `autograd` if `x` is needed in backward.
+However, `.data` can be unsafe in some cases. Any changes on `x.data` wouldn't be tracked by `autograd`, and the computed gradients would be incorrect if `x` is needed in a backward pass. A safer alternative is to use [`x.detach()`](https://pytorch.org/docs/master/autograd.html#torch.Tensor.detach), which also returns a `Tensor` that shares data with `requires_grad=False`, but will have its in-place changes reported by `autograd` if `x` is needed in backward.
 
 Here is an example of the difference between `.data` and `x.detach()` (and why we recommend using `detach` in general).
 
@@ -158,7 +158,7 @@ Note that if you don't convert to a Python number when accumulating losses, you 
 
 ## Deprecation of volatile flag
 
-The `volatile` flag is now deprecated and has no effect. Previously, any computation that involves a `Variable` with `volatile=True` wouldn't be tracked by `autograd`. This has now been replaced by a [set of more flexible context managers](http://pytorch.org/docs/0.4.0/torch.html#locally-disabling-gradient-computation) including `torch.no_grad()`, `torch.set_grad_enabled(grad_mode)`, and others.
+The `volatile` flag is now deprecated and has no effect. Previously, any computation that involves a `Variable` with `volatile=True` wouldn't be tracked by `autograd`. This has now been replaced by a [set of more flexible context managers](https://pytorch.org/docs/0.4.0/torch.html#locally-disabling-gradient-computation) including `torch.no_grad()`, `torch.set_grad_enabled(grad_mode)`, and others.
 
 ```python
 >>> x = torch.zeros(1, requires_grad=True)
@@ -182,15 +182,15 @@ True
 False
 ```
 
-## [`dtypes`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype), [`devices`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) and NumPy-style creation functions
+## [`dtypes`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype), [`devices`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) and NumPy-style creation functions
 
 In previous versions of PyTorch, we used to specify data type (e.g. float vs double), device type (cpu vs cuda) and layout (dense vs sparse) together as a "tensor type". For example, `torch.cuda.sparse.DoubleTensor` was the `Tensor` type respresenting the `double` data type, living on CUDA devices, and with [COO sparse tensor](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_(COO)) layout.
 
-In this release, we introduce [`torch.dtype`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype), [`torch.device`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) and [`torch.layout`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties via NumPy-style creation functions.
+In this release, we introduce [`torch.dtype`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype), [`torch.device`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) and [`torch.layout`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout) classes to allow better management of these properties via NumPy-style creation functions.
 
-### [`torch.dtype`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype)
+### [`torch.dtype`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype)
 
-Below is a complete list of available [`torch.dtype`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype)s (data types) and their corresponding tensor types.
+Below is a complete list of available [`torch.dtype`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.dtype)s (data types) and their corresponding tensor types.
 
 | Data | `type torch.dtype` | Tensor types |
 |------|------------------|--------------|
@@ -205,23 +205,23 @@ Below is a complete list of available [`torch.dtype`](http://pytorch.org/docs/0.
 
 The dtype of a tensor can be access via its `dtype` attribute.
 
-### [`torch.device`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device)
+### [`torch.device`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device)
 
-A [`torch.device`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) contains a device type (`'cpu'` or `'cuda'`) and optional device ordinal (id) for the device type. It can be initilized with `torch.device('{device_type}')` or `torch.device('{device_type}:{device_ordinal}')`.
+A [`torch.device`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) contains a device type (`'cpu'` or `'cuda'`) and optional device ordinal (id) for the device type. It can be initilized with `torch.device('{device_type}')` or `torch.device('{device_type}:{device_ordinal}')`.
 
 If the device ordinal is not present, this represents the current device for the device type; e.g., `torch.device('cuda')` is equivalent to `torch.device('cuda:X')` where `X` is the result of `torch.cuda.current_device()`.
 
 The device of a tensor can be accessed via its `device` attribute.
 
-### [`torch.layout`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout)
+### [`torch.layout`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout)
 
-[`torch.layout`](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout) represents the data layout of a [`Tensor`](http://pytorch.org/docs/0.4.0/tensors.html). Currently `torch.strided` (dense tensors, the default) and `torch.sparse_coo` (sparse tensors with COO format) are supported.
+[`torch.layout`](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.layout) represents the data layout of a [`Tensor`](https://pytorch.org/docs/0.4.0/tensors.html). Currently `torch.strided` (dense tensors, the default) and `torch.sparse_coo` (sparse tensors with COO format) are supported.
 
 The layout of a tensor can be access via its `layout` attribute.
 
 ### Creating Tensors
 
-[Methods that create a](http://pytorch.org/docs/0.4.0/torch.html#creation-ops) [`Tensor`](http://pytorch.org/docs/0.4.0/tensors.html) now also take in `dtype`, `device`, `layout`, and `requires_grad` options to specify the desired attributes on the returned `Tensor`. For example,
+[Methods that create a](https://pytorch.org/docs/0.4.0/torch.html#creation-ops) [`Tensor`](https://pytorch.org/docs/0.4.0/tensors.html) now also take in `dtype`, `device`, `layout`, and `requires_grad` options to specify the desired attributes on the returned `Tensor`. For example,
 
 ```python
 >>> device = torch.device("cuda:1")
@@ -236,9 +236,9 @@ False
 True
 ```
 
-##### [`torch.tensor(data, ...)`](http://pytorch.org/docs/0.4.0/torch.html#torch.tensor)
+##### [`torch.tensor(data, ...)`](https://pytorch.org/docs/0.4.0/torch.html#torch.tensor)
 
-[`torch.tensor`](http://pytorch.org/docs/0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](http://pytorch.org/docs/0.4.0/torch.html#creation-ops). It takes in array-like data of all kinds and copies the contained values into a new `Tensor`. As mentioned earlier, [`torch.tensor`](http://pytorch.org/docs/0.4.0/torch.html#torch.tensor) is the PyTorch equivalent of NumPy's `numpy.array`constructor. Unlike the `torch.*Tensor` methods, you can also create zero-dimensional `Tensor`s (aka scalars) this way (a single python number is treated as a Size in the `torch.*Tensor methods`). Moreover, if a `dtype` argument isn't given, it will infer the suitable `dtype` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
+[`torch.tensor`](https://pytorch.org/docs/0.4.0/torch.html#torch.tensor) is one of the newly added [tensor creation methods](https://pytorch.org/docs/0.4.0/torch.html#creation-ops). It takes in array-like data of all kinds and copies the contained values into a new `Tensor`. As mentioned earlier, [`torch.tensor`](https://pytorch.org/docs/0.4.0/torch.html#torch.tensor) is the PyTorch equivalent of NumPy's `numpy.array`constructor. Unlike the `torch.*Tensor` methods, you can also create zero-dimensional `Tensor`s (aka scalars) this way (a single python number is treated as a Size in the `torch.*Tensor methods`). Moreover, if a `dtype` argument isn't given, it will infer the suitable `dtype` given the data. It is the recommended way to create a tensor from existing data like a Python list. For example,
 
 ```python
 >>> cuda = torch.device("cuda")
@@ -280,22 +280,22 @@ To specify the desired shape, you can either use a tuple (e.g., `torch.zeros((2,
 
 | Name | Returned `Tensor` | `torch.*_like` variant | `tensor.new_*` variant |
 |------|-----------------|----------------------|----------------------|
-| [`torch.empty`](http://pytorch.org/docs/0.4.0/torch.html#torch.empty) | unintialized memory | ✔ | ✔ |
-| [`torch.zeros`](http://pytorch.org/docs/0.4.0/torch.html#torch.zeros) | all zeros | ✔ | ✔ |
-| [`torch.ones`](http://pytorch.org/docs/0.4.0/torch.html#torch.ones) | all ones | ✔ | ✔ |
-| [`torch.full`](http://pytorch.org/docs/0.4.0/torch.html#torch.full) | filled with a given value | ✔ | ✔ |
-| [`torch.rand`](http://pytorch.org/docs/0.4.0/torch.html#torch.rand) | i.i.d. continuous Uniform[0, 1) | ✔ |
-| [`torch.randn`](http://pytorch.org/docs/0.4.0/torch.html#torch.randn) | i.i.d. `Normal(0, 1)` | ✔ |
-| [`torch.randint`](http://pytorch.org/docs/0.4.0/torch.html#torch.randint) | i.i.d. discrete Uniform in given range | ✔ |
-| [`torch.randperm`](http://pytorch.org/docs/0.4.0/torch.html#torch.randperm) | random permutation of `{0, 1, ..., n - 1}` |
-| [`torch.tensor`](http://pytorch.org/docs/0.4.0/torch.html#torch.tensor) | copied from existing data (list, NumPy ndarray, etc.) | | ✔ |
-| [`torch.from_numpy`*](http://pytorch.org/docs/0.4.0/torch.html#torch.from_numpy) | from NumPy `ndarray` (sharing storage without copying) |
-| [`torch.arange`](http://pytorch.org/docs/0.4.0/torch.html#torch.arange), [`torch.range`](http://pytorch.org/docs/0.4.0/torch.html#torch.range), and [`torch.linspace`](http://pytorch.org/docs/0.4.0/torch.html#torch.linspace) | uniformly spaced values in a given range |
-| [`torch.logspace`](http://pytorch.org/docs/0.4.0/torch.html#torch.logspace) | logarithmically spaced values in a given range |
-| [`torch.eye`](http://pytorch.org/docs/0.4.0/torch.html#torch.eye) | identity matrix |
+| [`torch.empty`](https://pytorch.org/docs/0.4.0/torch.html#torch.empty) | unintialized memory | ✔ | ✔ |
+| [`torch.zeros`](https://pytorch.org/docs/0.4.0/torch.html#torch.zeros) | all zeros | ✔ | ✔ |
+| [`torch.ones`](https://pytorch.org/docs/0.4.0/torch.html#torch.ones) | all ones | ✔ | ✔ |
+| [`torch.full`](https://pytorch.org/docs/0.4.0/torch.html#torch.full) | filled with a given value | ✔ | ✔ |
+| [`torch.rand`](https://pytorch.org/docs/0.4.0/torch.html#torch.rand) | i.i.d. continuous Uniform[0, 1) | ✔ |
+| [`torch.randn`](https://pytorch.org/docs/0.4.0/torch.html#torch.randn) | i.i.d. `Normal(0, 1)` | ✔ |
+| [`torch.randint`](https://pytorch.org/docs/0.4.0/torch.html#torch.randint) | i.i.d. discrete Uniform in given range | ✔ |
+| [`torch.randperm`](https://pytorch.org/docs/0.4.0/torch.html#torch.randperm) | random permutation of `{0, 1, ..., n - 1}` |
+| [`torch.tensor`](https://pytorch.org/docs/0.4.0/torch.html#torch.tensor) | copied from existing data (list, NumPy ndarray, etc.) | | ✔ |
+| [`torch.from_numpy`*](https://pytorch.org/docs/0.4.0/torch.html#torch.from_numpy) | from NumPy `ndarray` (sharing storage without copying) |
+| [`torch.arange`](https://pytorch.org/docs/0.4.0/torch.html#torch.arange), [`torch.range`](https://pytorch.org/docs/0.4.0/torch.html#torch.range), and [`torch.linspace`](https://pytorch.org/docs/0.4.0/torch.html#torch.linspace) | uniformly spaced values in a given range |
+| [`torch.logspace`](https://pytorch.org/docs/0.4.0/torch.html#torch.logspace) | logarithmically spaced values in a given range |
+| [`torch.eye`](https://pytorch.org/docs/0.4.0/torch.html#torch.eye) | identity matrix |
 
 
-*: [`torch.from_numpy`](http://pytorch.org/docs/0.4.0/torch.html#torch.from_numpy) only takes in a NumPy `ndarray` as its input argument.
+*: [`torch.from_numpy`](https://pytorch.org/docs/0.4.0/torch.html#torch.from_numpy) only takes in a NumPy `ndarray` as its input argument.
 
 
 ## Writing device-agnostic code
@@ -304,7 +304,7 @@ Previous versions of PyTorch made it difficult to write code that was device agn
 
 PyTorch 0.4.0 makes this easier in two ways:
 
-- The `device` attribute of a Tensor gives the [torch.device](http://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) for all Tensors (`get_device` only works for CUDA tensors)
+- The `device` attribute of a Tensor gives the [torch.device](https://pytorch.org/docs/0.4.0/tensor_attributes.html#torch.torch.device) for all Tensors (`get_device` only works for CUDA tensors)
 - The `to` method of `Tensors` and `Modules` can be used to easily move objects to different devices (instead of having to call `cpu()` or `cuda()` based on the context)
 
 We recommend the following pattern:
@@ -374,6 +374,6 @@ To get a flavor of the overall recommended changes in 0.4.0, let's look at a qui
           ...
   ```
 
-Thank you for reading! Please refer to our [documentation](http://pytorch.org/docs/0.4.0/index.html) and [release notes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0) for more details.
+Thank you for reading! Please refer to our [documentation](https://pytorch.org/docs/0.4.0/index.html) and [release notes](https://github.com/pytorch/pytorch/releases/tag/v0.4.0) for more details.
 
 Happy PyTorch-ing!

--- a/docs/0.1.12/_modules/index.html
+++ b/docs/0.1.12/_modules/index.html
@@ -71,7 +71,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch.html
+++ b/docs/0.1.12/_modules/torch.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/_tensor_str.html
+++ b/docs/0.1.12/_modules/torch/_tensor_str.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/_utils.html
+++ b/docs/0.1.12/_modules/torch/_utils.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/autograd.html
+++ b/docs/0.1.12/_modules/torch/autograd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/autograd/function.html
+++ b/docs/0.1.12/_modules/torch/autograd/function.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/autograd/variable.html
+++ b/docs/0.1.12/_modules/torch/autograd/variable.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/cuda.html
+++ b/docs/0.1.12/_modules/torch/cuda.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/cuda/comm.html
+++ b/docs/0.1.12/_modules/torch/cuda/comm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/cuda/streams.html
+++ b/docs/0.1.12/_modules/torch/cuda/streams.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/functional.html
+++ b/docs/0.1.12/_modules/torch/functional.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/multiprocessing.html
+++ b/docs/0.1.12/_modules/torch/multiprocessing.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/functional.html
+++ b/docs/0.1.12/_modules/torch/nn/functional.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/init.html
+++ b/docs/0.1.12/_modules/torch/nn/init.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/activation.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/activation.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/batchnorm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/container.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/container.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/conv.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/conv.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/distance.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/distance.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/dropout.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/dropout.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/instancenorm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/linear.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/linear.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/loss.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/loss.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/module.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/module.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/pixelshuffle.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/pooling.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/pooling.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/rnn.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/rnn.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/sparse.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/sparse.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/modules/upsampling.html
+++ b/docs/0.1.12/_modules/torch/nn/modules/upsampling.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/0.1.12/_modules/torch/nn/parallel/data_parallel.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/parameter.html
+++ b/docs/0.1.12/_modules/torch/nn/parameter.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/0.1.12/_modules/torch/nn/utils/clip_grad.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/nn/utils/rnn.html
+++ b/docs/0.1.12/_modules/torch/nn/utils/rnn.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/adadelta.html
+++ b/docs/0.1.12/_modules/torch/optim/adadelta.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/adagrad.html
+++ b/docs/0.1.12/_modules/torch/optim/adagrad.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/adam.html
+++ b/docs/0.1.12/_modules/torch/optim/adam.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/adamax.html
+++ b/docs/0.1.12/_modules/torch/optim/adamax.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/asgd.html
+++ b/docs/0.1.12/_modules/torch/optim/asgd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/lbfgs.html
+++ b/docs/0.1.12/_modules/torch/optim/lbfgs.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/optimizer.html
+++ b/docs/0.1.12/_modules/torch/optim/optimizer.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/rmsprop.html
+++ b/docs/0.1.12/_modules/torch/optim/rmsprop.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/rprop.html
+++ b/docs/0.1.12/_modules/torch/optim/rprop.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/optim/sgd.html
+++ b/docs/0.1.12/_modules/torch/optim/sgd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/serialization.html
+++ b/docs/0.1.12/_modules/torch/serialization.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/sparse.html
+++ b/docs/0.1.12/_modules/torch/sparse.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/storage.html
+++ b/docs/0.1.12/_modules/torch/storage.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/tensor.html
+++ b/docs/0.1.12/_modules/torch/tensor.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/utils/data/dataloader.html
+++ b/docs/0.1.12/_modules/torch/utils/data/dataloader.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/utils/data/dataset.html
+++ b/docs/0.1.12/_modules/torch/utils/data/dataset.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/utils/data/sampler.html
+++ b/docs/0.1.12/_modules/torch/utils/data/sampler.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/utils/ffi.html
+++ b/docs/0.1.12/_modules/torch/utils/ffi.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/_modules/torch/utils/model_zoo.html
+++ b/docs/0.1.12/_modules/torch/utils/model_zoo.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/autograd.html
+++ b/docs/0.1.12/autograd.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/cuda.html
+++ b/docs/0.1.12/cuda.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/data.html
+++ b/docs/0.1.12/data.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/ffi.html
+++ b/docs/0.1.12/ffi.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/genindex.html
+++ b/docs/0.1.12/genindex.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/index.html
+++ b/docs/0.1.12/index.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/legacy.html
+++ b/docs/0.1.12/legacy.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/model_zoo.html
+++ b/docs/0.1.12/model_zoo.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/multiprocessing.html
+++ b/docs/0.1.12/multiprocessing.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/nn.html
+++ b/docs/0.1.12/nn.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/notes/autograd.html
+++ b/docs/0.1.12/notes/autograd.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/notes/cuda.html
+++ b/docs/0.1.12/notes/cuda.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/notes/extending.html
+++ b/docs/0.1.12/notes/extending.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/notes/multiprocessing.html
+++ b/docs/0.1.12/notes/multiprocessing.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/notes/serialization.html
+++ b/docs/0.1.12/notes/serialization.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/optim.html
+++ b/docs/0.1.12/optim.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/py-modindex.html
+++ b/docs/0.1.12/py-modindex.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/search.html
+++ b/docs/0.1.12/search.html
@@ -71,7 +71,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/sparse.html
+++ b/docs/0.1.12/sparse.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/storage.html
+++ b/docs/0.1.12/storage.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/tensors.html
+++ b/docs/0.1.12/tensors.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torch.html
+++ b/docs/0.1.12/torch.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torchvision/datasets.html
+++ b/docs/0.1.12/torchvision/datasets.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torchvision/models.html
+++ b/docs/0.1.12/torchvision/models.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torchvision/torchvision.html
+++ b/docs/0.1.12/torchvision/torchvision.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torchvision/transforms.html
+++ b/docs/0.1.12/torchvision/transforms.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.1.12/torchvision/utils.html
+++ b/docs/0.1.12/torchvision/utils.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-<a href="http://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
+<a href="https://pytorch.org/docs/versions.html">0.1.12_2 &#x25BC</a>                
               </div>
             
           

--- a/docs/0.2.0/_modules/index.html
+++ b/docs/0.2.0/_modules/index.html
@@ -71,7 +71,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch.html
+++ b/docs/0.2.0/_modules/torch.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/_tensor_str.html
+++ b/docs/0.2.0/_modules/torch/_tensor_str.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/_utils.html
+++ b/docs/0.2.0/_modules/torch/_utils.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/autograd.html
+++ b/docs/0.2.0/_modules/torch/autograd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/autograd/function.html
+++ b/docs/0.2.0/_modules/torch/autograd/function.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/autograd/variable.html
+++ b/docs/0.2.0/_modules/torch/autograd/variable.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/cuda.html
+++ b/docs/0.2.0/_modules/torch/cuda.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/cuda/comm.html
+++ b/docs/0.2.0/_modules/torch/cuda/comm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/cuda/nvtx.html
+++ b/docs/0.2.0/_modules/torch/cuda/nvtx.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/cuda/streams.html
+++ b/docs/0.2.0/_modules/torch/cuda/streams.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/distributed.html
+++ b/docs/0.2.0/_modules/torch/distributed.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/functional.html
+++ b/docs/0.2.0/_modules/torch/functional.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/multiprocessing.html
+++ b/docs/0.2.0/_modules/torch/multiprocessing.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/functional.html
+++ b/docs/0.2.0/_modules/torch/nn/functional.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/init.html
+++ b/docs/0.2.0/_modules/torch/nn/init.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/activation.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/activation.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/batchnorm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/container.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/container.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/conv.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/conv.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/distance.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/distance.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/dropout.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/dropout.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/instancenorm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/linear.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/linear.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/loss.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/loss.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/module.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/module.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/padding.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/padding.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/pixelshuffle.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/pooling.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/pooling.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/rnn.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/rnn.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/sparse.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/sparse.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/modules/upsampling.html
+++ b/docs/0.2.0/_modules/torch/nn/modules/upsampling.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/0.2.0/_modules/torch/nn/parallel/data_parallel.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/parameter.html
+++ b/docs/0.2.0/_modules/torch/nn/parameter.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/0.2.0/_modules/torch/nn/utils/clip_grad.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/utils/rnn.html
+++ b/docs/0.2.0/_modules/torch/nn/utils/rnn.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/0.2.0/_modules/torch/nn/utils/weight_norm.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/adadelta.html
+++ b/docs/0.2.0/_modules/torch/optim/adadelta.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/adagrad.html
+++ b/docs/0.2.0/_modules/torch/optim/adagrad.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/adam.html
+++ b/docs/0.2.0/_modules/torch/optim/adam.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/adamax.html
+++ b/docs/0.2.0/_modules/torch/optim/adamax.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/asgd.html
+++ b/docs/0.2.0/_modules/torch/optim/asgd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/lbfgs.html
+++ b/docs/0.2.0/_modules/torch/optim/lbfgs.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/lr_scheduler.html
+++ b/docs/0.2.0/_modules/torch/optim/lr_scheduler.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/optimizer.html
+++ b/docs/0.2.0/_modules/torch/optim/optimizer.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/rmsprop.html
+++ b/docs/0.2.0/_modules/torch/optim/rmsprop.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/rprop.html
+++ b/docs/0.2.0/_modules/torch/optim/rprop.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/optim/sgd.html
+++ b/docs/0.2.0/_modules/torch/optim/sgd.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/serialization.html
+++ b/docs/0.2.0/_modules/torch/serialization.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/sparse.html
+++ b/docs/0.2.0/_modules/torch/sparse.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/storage.html
+++ b/docs/0.2.0/_modules/torch/storage.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/tensor.html
+++ b/docs/0.2.0/_modules/torch/tensor.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/data/dataloader.html
+++ b/docs/0.2.0/_modules/torch/utils/data/dataloader.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/data/dataset.html
+++ b/docs/0.2.0/_modules/torch/utils/data/dataset.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/data/distributed.html
+++ b/docs/0.2.0/_modules/torch/utils/data/distributed.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/data/sampler.html
+++ b/docs/0.2.0/_modules/torch/utils/data/sampler.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/ffi.html
+++ b/docs/0.2.0/_modules/torch/utils/ffi.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torch/utils/model_zoo.html
+++ b/docs/0.2.0/_modules/torch/utils/model_zoo.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision.html
+++ b/docs/0.2.0/_modules/torchvision.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/cifar.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/cifar.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/coco.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/coco.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/folder.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/folder.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/lsun.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/lsun.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/mnist.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/mnist.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/phototour.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/phototour.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/stl10.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/stl10.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/datasets/svhn.html
+++ b/docs/0.2.0/_modules/torchvision/datasets/svhn.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/alexnet.html
+++ b/docs/0.2.0/_modules/torchvision/models/alexnet.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/densenet.html
+++ b/docs/0.2.0/_modules/torchvision/models/densenet.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/inception.html
+++ b/docs/0.2.0/_modules/torchvision/models/inception.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/resnet.html
+++ b/docs/0.2.0/_modules/torchvision/models/resnet.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/squeezenet.html
+++ b/docs/0.2.0/_modules/torchvision/models/squeezenet.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/models/vgg.html
+++ b/docs/0.2.0/_modules/torchvision/models/vgg.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/transforms.html
+++ b/docs/0.2.0/_modules/torchvision/transforms.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/_modules/torchvision/utils.html
+++ b/docs/0.2.0/_modules/torchvision/utils.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/autograd.html
+++ b/docs/0.2.0/autograd.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/cuda.html
+++ b/docs/0.2.0/cuda.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/data.html
+++ b/docs/0.2.0/data.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/distributed.html
+++ b/docs/0.2.0/distributed.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/ffi.html
+++ b/docs/0.2.0/ffi.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/genindex.html
+++ b/docs/0.2.0/genindex.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/index.html
+++ b/docs/0.2.0/index.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/legacy.html
+++ b/docs/0.2.0/legacy.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/model_zoo.html
+++ b/docs/0.2.0/model_zoo.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/multiprocessing.html
+++ b/docs/0.2.0/multiprocessing.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/nn.html
+++ b/docs/0.2.0/nn.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/autograd.html
+++ b/docs/0.2.0/notes/autograd.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/broadcasting.html
+++ b/docs/0.2.0/notes/broadcasting.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/cuda.html
+++ b/docs/0.2.0/notes/cuda.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/extending.html
+++ b/docs/0.2.0/notes/extending.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/multiprocessing.html
+++ b/docs/0.2.0/notes/multiprocessing.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/notes/serialization.html
+++ b/docs/0.2.0/notes/serialization.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/optim.html
+++ b/docs/0.2.0/optim.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/py-modindex.html
+++ b/docs/0.2.0/py-modindex.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/search.html
+++ b/docs/0.2.0/search.html
@@ -71,7 +71,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/sparse.html
+++ b/docs/0.2.0/sparse.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/storage.html
+++ b/docs/0.2.0/storage.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/tensors.html
+++ b/docs/0.2.0/tensors.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torch.html
+++ b/docs/0.2.0/torch.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torchvision/datasets.html
+++ b/docs/0.2.0/torchvision/datasets.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torchvision/models.html
+++ b/docs/0.2.0/torchvision/models.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torchvision/torchvision.html
+++ b/docs/0.2.0/torchvision/torchvision.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torchvision/transforms.html
+++ b/docs/0.2.0/torchvision/transforms.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.2.0/torchvision/utils.html
+++ b/docs/0.2.0/torchvision/utils.html
@@ -72,7 +72,7 @@
             
             
               <div class="version">
-                <a href="http://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
+                <a href="https://pytorch.org/docs/versions.html"> 0.2.0_1 &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/index.html
+++ b/docs/0.3.0/_modules/index.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch.html
+++ b/docs/0.3.0/_modules/torch.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/_tensor_str.html
+++ b/docs/0.3.0/_modules/torch/_tensor_str.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/_utils.html
+++ b/docs/0.3.0/_modules/torch/_utils.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/autograd.html
+++ b/docs/0.3.0/_modules/torch/autograd.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/autograd/function.html
+++ b/docs/0.3.0/_modules/torch/autograd/function.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/autograd/profiler.html
+++ b/docs/0.3.0/_modules/torch/autograd/profiler.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/autograd/variable.html
+++ b/docs/0.3.0/_modules/torch/autograd/variable.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -836,7 +836,7 @@
 
         <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span><span class="n">trim</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;&quot;&quot;reinforce() was removed.</span>
 <span class="s2">            Use torch.distributions instead.</span>
-<span class="s2">            See http://pytorch.org/docs/master/distributions.html</span>
+<span class="s2">            See https://pytorch.org/docs/master/distributions.html</span>
 
 <span class="s2">            Instead of:</span>
 

--- a/docs/0.3.0/_modules/torch/cuda.html
+++ b/docs/0.3.0/_modules/torch/cuda.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -690,7 +690,7 @@
 <span class="s2">The NVIDIA driver on your system is too old (found version </span><span class="si">{}</span><span class="s2">).</span>
 <span class="s2">Please update your GPU driver by downloading and installing a new</span>
 <span class="s2">version from the URL: http://www.nvidia.com/Download/index.aspx</span>
-<span class="s2">Alternatively, go to: http://pytorch.org to install</span>
+<span class="s2">Alternatively, go to: https://pytorch.org to install</span>
 <span class="s2">a PyTorch version that has been compiled with your version</span>
 <span class="s2">of the CUDA driver.&quot;&quot;&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">torch</span><span class="o">.</span><span class="n">_C</span><span class="o">.</span><span class="n">_cuda_getDriverVersion</span><span class="p">())))</span>
 
@@ -700,7 +700,7 @@
 <span class="s2">    Found GPU</span><span class="si">%d</span><span class="s2"> </span><span class="si">%s</span><span class="s2"> which requires CUDA_VERSION &gt;= </span><span class="si">%d</span><span class="s2"> for</span>
 <span class="s2">     optimal performance and fast startup time, but your PyTorch was compiled</span>
 <span class="s2">     with CUDA_VERSION </span><span class="si">%d</span><span class="s2">. Please install the correct PyTorch binary</span>
-<span class="s2">     using instructions from http://pytorch.org</span>
+<span class="s2">     using instructions from https://pytorch.org</span>
 <span class="s2">    &quot;&quot;&quot;</span>
 
     <span class="n">CUDA_VERSION</span> <span class="o">=</span> <span class="n">torch</span><span class="o">.</span><span class="n">_C</span><span class="o">.</span><span class="n">_cuda_getCompiledVersion</span><span class="p">()</span>

--- a/docs/0.3.0/_modules/torch/cuda/comm.html
+++ b/docs/0.3.0/_modules/torch/cuda/comm.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/cuda/nvtx.html
+++ b/docs/0.3.0/_modules/torch/cuda/nvtx.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/cuda/random.html
+++ b/docs/0.3.0/_modules/torch/cuda/random.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/cuda/streams.html
+++ b/docs/0.3.0/_modules/torch/cuda/streams.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/distributed.html
+++ b/docs/0.3.0/_modules/torch/distributed.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/distributions.html
+++ b/docs/0.3.0/_modules/torch/distributions.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/functional.html
+++ b/docs/0.3.0/_modules/torch/functional.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/multiprocessing.html
+++ b/docs/0.3.0/_modules/torch/multiprocessing.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/functional.html
+++ b/docs/0.3.0/_modules/torch/nn/functional.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/init.html
+++ b/docs/0.3.0/_modules/torch/nn/init.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/activation.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/activation.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/batchnorm.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/container.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/container.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/conv.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/conv.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/distance.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/distance.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/dropout.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/dropout.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/instancenorm.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/linear.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/linear.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/loss.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/loss.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/module.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/module.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/padding.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/padding.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/pixelshuffle.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/pooling.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/pooling.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/rnn.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/rnn.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/sparse.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/sparse.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/modules/upsampling.html
+++ b/docs/0.3.0/_modules/torch/nn/modules/upsampling.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/0.3.0/_modules/torch/nn/parallel/data_parallel.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/parallel/distributed.html
+++ b/docs/0.3.0/_modules/torch/nn/parallel/distributed.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/parameter.html
+++ b/docs/0.3.0/_modules/torch/nn/parameter.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/0.3.0/_modules/torch/nn/utils/clip_grad.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/utils/rnn.html
+++ b/docs/0.3.0/_modules/torch/nn/utils/rnn.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/0.3.0/_modules/torch/nn/utils/weight_norm.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/onnx.html
+++ b/docs/0.3.0/_modules/torch/onnx.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/adadelta.html
+++ b/docs/0.3.0/_modules/torch/optim/adadelta.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/adagrad.html
+++ b/docs/0.3.0/_modules/torch/optim/adagrad.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/adam.html
+++ b/docs/0.3.0/_modules/torch/optim/adam.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/adamax.html
+++ b/docs/0.3.0/_modules/torch/optim/adamax.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/asgd.html
+++ b/docs/0.3.0/_modules/torch/optim/asgd.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/lbfgs.html
+++ b/docs/0.3.0/_modules/torch/optim/lbfgs.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/lr_scheduler.html
+++ b/docs/0.3.0/_modules/torch/optim/lr_scheduler.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/optimizer.html
+++ b/docs/0.3.0/_modules/torch/optim/optimizer.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/rmsprop.html
+++ b/docs/0.3.0/_modules/torch/optim/rmsprop.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/rprop.html
+++ b/docs/0.3.0/_modules/torch/optim/rprop.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/sgd.html
+++ b/docs/0.3.0/_modules/torch/optim/sgd.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/optim/sparse_adam.html
+++ b/docs/0.3.0/_modules/torch/optim/sparse_adam.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/random.html
+++ b/docs/0.3.0/_modules/torch/random.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/serialization.html
+++ b/docs/0.3.0/_modules/torch/serialization.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/sparse.html
+++ b/docs/0.3.0/_modules/torch/sparse.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/storage.html
+++ b/docs/0.3.0/_modules/torch/storage.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/tensor.html
+++ b/docs/0.3.0/_modules/torch/tensor.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/data/dataloader.html
+++ b/docs/0.3.0/_modules/torch/utils/data/dataloader.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/data/dataset.html
+++ b/docs/0.3.0/_modules/torch/utils/data/dataset.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/data/distributed.html
+++ b/docs/0.3.0/_modules/torch/utils/data/distributed.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/data/sampler.html
+++ b/docs/0.3.0/_modules/torch/utils/data/sampler.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/ffi.html
+++ b/docs/0.3.0/_modules/torch/utils/ffi.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torch/utils/model_zoo.html
+++ b/docs/0.3.0/_modules/torch/utils/model_zoo.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision.html
+++ b/docs/0.3.0/_modules/torchvision.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/cifar.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/cifar.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/coco.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/coco.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/folder.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/folder.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/lsun.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/lsun.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/mnist.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/mnist.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/phototour.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/phototour.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/stl10.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/stl10.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/datasets/svhn.html
+++ b/docs/0.3.0/_modules/torchvision/datasets/svhn.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/alexnet.html
+++ b/docs/0.3.0/_modules/torchvision/models/alexnet.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/densenet.html
+++ b/docs/0.3.0/_modules/torchvision/models/densenet.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/inception.html
+++ b/docs/0.3.0/_modules/torchvision/models/inception.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/resnet.html
+++ b/docs/0.3.0/_modules/torchvision/models/resnet.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/squeezenet.html
+++ b/docs/0.3.0/_modules/torchvision/models/squeezenet.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/models/vgg.html
+++ b/docs/0.3.0/_modules/torchvision/models/vgg.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/transforms/transforms.html
+++ b/docs/0.3.0/_modules/torchvision/transforms/transforms.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/_modules/torchvision/utils.html
+++ b/docs/0.3.0/_modules/torchvision/utils.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/autograd.html
+++ b/docs/0.3.0/autograd.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/cuda.html
+++ b/docs/0.3.0/cuda.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/data.html
+++ b/docs/0.3.0/data.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/distributed.html
+++ b/docs/0.3.0/distributed.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/distributions.html
+++ b/docs/0.3.0/distributions.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/ffi.html
+++ b/docs/0.3.0/ffi.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/genindex.html
+++ b/docs/0.3.0/genindex.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/index.html
+++ b/docs/0.3.0/index.html
@@ -74,7 +74,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/legacy.html
+++ b/docs/0.3.0/legacy.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/model_zoo.html
+++ b/docs/0.3.0/model_zoo.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/multiprocessing.html
+++ b/docs/0.3.0/multiprocessing.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/nn.html
+++ b/docs/0.3.0/nn.html
@@ -75,7 +75,7 @@
 
 
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
 
 

--- a/docs/0.3.0/notes/autograd.html
+++ b/docs/0.3.0/notes/autograd.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/notes/broadcasting.html
+++ b/docs/0.3.0/notes/broadcasting.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/notes/cuda.html
+++ b/docs/0.3.0/notes/cuda.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/notes/extending.html
+++ b/docs/0.3.0/notes/extending.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/notes/multiprocessing.html
+++ b/docs/0.3.0/notes/multiprocessing.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/notes/serialization.html
+++ b/docs/0.3.0/notes/serialization.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/onnx.html
+++ b/docs/0.3.0/onnx.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/optim.html
+++ b/docs/0.3.0/optim.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/py-modindex.html
+++ b/docs/0.3.0/py-modindex.html
@@ -76,7 +76,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/search.html
+++ b/docs/0.3.0/search.html
@@ -73,7 +73,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/sparse.html
+++ b/docs/0.3.0/sparse.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/storage.html
+++ b/docs/0.3.0/storage.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/tensors.html
+++ b/docs/0.3.0/tensors.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torch.html
+++ b/docs/0.3.0/torch.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torchvision/datasets.html
+++ b/docs/0.3.0/torchvision/datasets.html
@@ -76,7 +76,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torchvision/index.html
+++ b/docs/0.3.0/torchvision/index.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torchvision/models.html
+++ b/docs/0.3.0/torchvision/models.html
@@ -76,7 +76,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torchvision/transforms.html
+++ b/docs/0.3.0/torchvision/transforms.html
@@ -76,7 +76,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.0/torchvision/utils.html
+++ b/docs/0.3.0/torchvision/utils.html
@@ -75,7 +75,7 @@
             
             
               <div class="version">
-                0.3.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/index.html
+++ b/docs/0.3.1/_modules/index.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch.html
+++ b/docs/0.3.1/_modules/torch.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/_tensor_str.html
+++ b/docs/0.3.1/_modules/torch/_tensor_str.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/_utils.html
+++ b/docs/0.3.1/_modules/torch/_utils.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/autograd.html
+++ b/docs/0.3.1/_modules/torch/autograd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/autograd/function.html
+++ b/docs/0.3.1/_modules/torch/autograd/function.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/autograd/profiler.html
+++ b/docs/0.3.1/_modules/torch/autograd/profiler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/autograd/variable.html
+++ b/docs/0.3.1/_modules/torch/autograd/variable.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -790,7 +790,7 @@
 
         <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span><span class="n">trim</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;&quot;&quot;reinforce() was removed.</span>
 <span class="s2">            Use torch.distributions instead.</span>
-<span class="s2">            See http://pytorch.org/docs/master/distributions.html</span>
+<span class="s2">            See https://pytorch.org/docs/master/distributions.html</span>
 
 <span class="s2">            Instead of:</span>
 

--- a/docs/0.3.1/_modules/torch/cuda.html
+++ b/docs/0.3.1/_modules/torch/cuda.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -644,7 +644,7 @@
 <span class="s2">The NVIDIA driver on your system is too old (found version </span><span class="si">{}</span><span class="s2">).</span>
 <span class="s2">Please update your GPU driver by downloading and installing a new</span>
 <span class="s2">version from the URL: http://www.nvidia.com/Download/index.aspx</span>
-<span class="s2">Alternatively, go to: http://pytorch.org to install</span>
+<span class="s2">Alternatively, go to: https://pytorch.org to install</span>
 <span class="s2">a PyTorch version that has been compiled with your version</span>
 <span class="s2">of the CUDA driver.&quot;&quot;&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">torch</span><span class="o">.</span><span class="n">_C</span><span class="o">.</span><span class="n">_cuda_getDriverVersion</span><span class="p">())))</span>
 
@@ -654,7 +654,7 @@
 <span class="s2">    Found GPU</span><span class="si">%d</span><span class="s2"> </span><span class="si">%s</span><span class="s2"> which requires CUDA_VERSION &gt;= </span><span class="si">%d</span><span class="s2"> for</span>
 <span class="s2">     optimal performance and fast startup time, but your PyTorch was compiled</span>
 <span class="s2">     with CUDA_VERSION </span><span class="si">%d</span><span class="s2">. Please install the correct PyTorch binary</span>
-<span class="s2">     using instructions from http://pytorch.org</span>
+<span class="s2">     using instructions from https://pytorch.org</span>
 <span class="s2">    &quot;&quot;&quot;</span>
 
     <span class="n">old_gpu_warn</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;</span>

--- a/docs/0.3.1/_modules/torch/cuda/comm.html
+++ b/docs/0.3.1/_modules/torch/cuda/comm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/cuda/nvtx.html
+++ b/docs/0.3.1/_modules/torch/cuda/nvtx.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/cuda/random.html
+++ b/docs/0.3.1/_modules/torch/cuda/random.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/cuda/streams.html
+++ b/docs/0.3.1/_modules/torch/cuda/streams.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/distributed.html
+++ b/docs/0.3.1/_modules/torch/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/distributions.html
+++ b/docs/0.3.1/_modules/torch/distributions.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/functional.html
+++ b/docs/0.3.1/_modules/torch/functional.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/multiprocessing.html
+++ b/docs/0.3.1/_modules/torch/multiprocessing.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/functional.html
+++ b/docs/0.3.1/_modules/torch/nn/functional.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/init.html
+++ b/docs/0.3.1/_modules/torch/nn/init.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/activation.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/activation.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/batchnorm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/container.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/container.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/conv.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/conv.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/distance.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/distance.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/dropout.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/dropout.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/instancenorm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/linear.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/linear.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/loss.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/loss.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/module.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/module.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/padding.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/padding.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/pixelshuffle.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/pooling.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/pooling.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/rnn.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/rnn.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/sparse.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/sparse.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/modules/upsampling.html
+++ b/docs/0.3.1/_modules/torch/nn/modules/upsampling.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/0.3.1/_modules/torch/nn/parallel/data_parallel.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/parallel/distributed.html
+++ b/docs/0.3.1/_modules/torch/nn/parallel/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/parameter.html
+++ b/docs/0.3.1/_modules/torch/nn/parameter.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/0.3.1/_modules/torch/nn/utils/clip_grad.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/utils/rnn.html
+++ b/docs/0.3.1/_modules/torch/nn/utils/rnn.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/0.3.1/_modules/torch/nn/utils/weight_norm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/onnx.html
+++ b/docs/0.3.1/_modules/torch/onnx.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/adadelta.html
+++ b/docs/0.3.1/_modules/torch/optim/adadelta.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/adagrad.html
+++ b/docs/0.3.1/_modules/torch/optim/adagrad.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/adam.html
+++ b/docs/0.3.1/_modules/torch/optim/adam.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/adamax.html
+++ b/docs/0.3.1/_modules/torch/optim/adamax.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/asgd.html
+++ b/docs/0.3.1/_modules/torch/optim/asgd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/lbfgs.html
+++ b/docs/0.3.1/_modules/torch/optim/lbfgs.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/lr_scheduler.html
+++ b/docs/0.3.1/_modules/torch/optim/lr_scheduler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/optimizer.html
+++ b/docs/0.3.1/_modules/torch/optim/optimizer.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/rmsprop.html
+++ b/docs/0.3.1/_modules/torch/optim/rmsprop.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/rprop.html
+++ b/docs/0.3.1/_modules/torch/optim/rprop.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/sgd.html
+++ b/docs/0.3.1/_modules/torch/optim/sgd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/optim/sparse_adam.html
+++ b/docs/0.3.1/_modules/torch/optim/sparse_adam.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/random.html
+++ b/docs/0.3.1/_modules/torch/random.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/serialization.html
+++ b/docs/0.3.1/_modules/torch/serialization.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/sparse.html
+++ b/docs/0.3.1/_modules/torch/sparse.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/storage.html
+++ b/docs/0.3.1/_modules/torch/storage.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/tensor.html
+++ b/docs/0.3.1/_modules/torch/tensor.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/data/dataloader.html
+++ b/docs/0.3.1/_modules/torch/utils/data/dataloader.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/data/dataset.html
+++ b/docs/0.3.1/_modules/torch/utils/data/dataset.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/data/distributed.html
+++ b/docs/0.3.1/_modules/torch/utils/data/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/data/sampler.html
+++ b/docs/0.3.1/_modules/torch/utils/data/sampler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/ffi.html
+++ b/docs/0.3.1/_modules/torch/utils/ffi.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/_modules/torch/utils/model_zoo.html
+++ b/docs/0.3.1/_modules/torch/utils/model_zoo.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/autograd.html
+++ b/docs/0.3.1/autograd.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/cuda.html
+++ b/docs/0.3.1/cuda.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/data.html
+++ b/docs/0.3.1/data.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/distributed.html
+++ b/docs/0.3.1/distributed.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/distributions.html
+++ b/docs/0.3.1/distributions.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/ffi.html
+++ b/docs/0.3.1/ffi.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/genindex.html
+++ b/docs/0.3.1/genindex.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/index.html
+++ b/docs/0.3.1/index.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/legacy.html
+++ b/docs/0.3.1/legacy.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/model_zoo.html
+++ b/docs/0.3.1/model_zoo.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/multiprocessing.html
+++ b/docs/0.3.1/multiprocessing.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/nn.html
+++ b/docs/0.3.1/nn.html
@@ -64,7 +64,7 @@
 
 
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
 
 

--- a/docs/0.3.1/notes/autograd.html
+++ b/docs/0.3.1/notes/autograd.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/notes/broadcasting.html
+++ b/docs/0.3.1/notes/broadcasting.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/notes/cuda.html
+++ b/docs/0.3.1/notes/cuda.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/notes/extending.html
+++ b/docs/0.3.1/notes/extending.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/notes/multiprocessing.html
+++ b/docs/0.3.1/notes/multiprocessing.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/notes/serialization.html
+++ b/docs/0.3.1/notes/serialization.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/onnx.html
+++ b/docs/0.3.1/onnx.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/optim.html
+++ b/docs/0.3.1/optim.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/py-modindex.html
+++ b/docs/0.3.1/py-modindex.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/search.html
+++ b/docs/0.3.1/search.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/sparse.html
+++ b/docs/0.3.1/sparse.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/storage.html
+++ b/docs/0.3.1/storage.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/tensors.html
+++ b/docs/0.3.1/tensors.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.3.1/torch.html
+++ b/docs/0.3.1/torch.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.3.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.3.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/index.html
+++ b/docs/0.4.0/_modules/index.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch.html
+++ b/docs/0.4.0/_modules/torch.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/_tensor_str.html
+++ b/docs/0.4.0/_modules/torch/_tensor_str.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/_utils.html
+++ b/docs/0.4.0/_modules/torch/_utils.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/autograd.html
+++ b/docs/0.4.0/_modules/torch/autograd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/autograd/function.html
+++ b/docs/0.4.0/_modules/torch/autograd/function.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/autograd/grad_mode.html
+++ b/docs/0.4.0/_modules/torch/autograd/grad_mode.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/autograd/profiler.html
+++ b/docs/0.4.0/_modules/torch/autograd/profiler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/cuda.html
+++ b/docs/0.4.0/_modules/torch/cuda.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -805,7 +805,7 @@
 <span class="s2">The NVIDIA driver on your system is too old (found version </span><span class="si">{}</span><span class="s2">).</span>
 <span class="s2">Please update your GPU driver by downloading and installing a new</span>
 <span class="s2">version from the URL: http://www.nvidia.com/Download/index.aspx</span>
-<span class="s2">Alternatively, go to: http://pytorch.org to install</span>
+<span class="s2">Alternatively, go to: https://pytorch.org to install</span>
 <span class="s2">a PyTorch version that has been compiled with your version</span>
 <span class="s2">of the CUDA driver.&quot;&quot;&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">torch</span><span class="o">.</span><span class="n">_C</span><span class="o">.</span><span class="n">_cuda_getDriverVersion</span><span class="p">())))</span>
 
@@ -815,7 +815,7 @@
 <span class="s2">    Found GPU</span><span class="si">%d</span><span class="s2"> </span><span class="si">%s</span><span class="s2"> which requires CUDA_VERSION &gt;= </span><span class="si">%d</span><span class="s2"> for</span>
 <span class="s2">     optimal performance and fast startup time, but your PyTorch was compiled</span>
 <span class="s2">     with CUDA_VERSION </span><span class="si">%d</span><span class="s2">. Please install the correct PyTorch binary</span>
-<span class="s2">     using instructions from http://pytorch.org</span>
+<span class="s2">     using instructions from https://pytorch.org</span>
 <span class="s2">    &quot;&quot;&quot;</span>
 
     <span class="n">old_gpu_warn</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;</span>

--- a/docs/0.4.0/_modules/torch/cuda/comm.html
+++ b/docs/0.4.0/_modules/torch/cuda/comm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/cuda/nvtx.html
+++ b/docs/0.4.0/_modules/torch/cuda/nvtx.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/cuda/random.html
+++ b/docs/0.4.0/_modules/torch/cuda/random.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/cuda/streams.html
+++ b/docs/0.4.0/_modules/torch/cuda/streams.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributed.html
+++ b/docs/0.4.0/_modules/torch/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/bernoulli.html
+++ b/docs/0.4.0/_modules/torch/distributions/bernoulli.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/beta.html
+++ b/docs/0.4.0/_modules/torch/distributions/beta.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/binomial.html
+++ b/docs/0.4.0/_modules/torch/distributions/binomial.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/categorical.html
+++ b/docs/0.4.0/_modules/torch/distributions/categorical.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/cauchy.html
+++ b/docs/0.4.0/_modules/torch/distributions/cauchy.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/chi2.html
+++ b/docs/0.4.0/_modules/torch/distributions/chi2.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/constraint_registry.html
+++ b/docs/0.4.0/_modules/torch/distributions/constraint_registry.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/constraints.html
+++ b/docs/0.4.0/_modules/torch/distributions/constraints.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/dirichlet.html
+++ b/docs/0.4.0/_modules/torch/distributions/dirichlet.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/distribution.html
+++ b/docs/0.4.0/_modules/torch/distributions/distribution.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/exp_family.html
+++ b/docs/0.4.0/_modules/torch/distributions/exp_family.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/exponential.html
+++ b/docs/0.4.0/_modules/torch/distributions/exponential.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/0.4.0/_modules/torch/distributions/fishersnedecor.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/gamma.html
+++ b/docs/0.4.0/_modules/torch/distributions/gamma.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/geometric.html
+++ b/docs/0.4.0/_modules/torch/distributions/geometric.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/gumbel.html
+++ b/docs/0.4.0/_modules/torch/distributions/gumbel.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/independent.html
+++ b/docs/0.4.0/_modules/torch/distributions/independent.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/kl.html
+++ b/docs/0.4.0/_modules/torch/distributions/kl.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/laplace.html
+++ b/docs/0.4.0/_modules/torch/distributions/laplace.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/log_normal.html
+++ b/docs/0.4.0/_modules/torch/distributions/log_normal.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/multinomial.html
+++ b/docs/0.4.0/_modules/torch/distributions/multinomial.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/0.4.0/_modules/torch/distributions/multivariate_normal.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/normal.html
+++ b/docs/0.4.0/_modules/torch/distributions/normal.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/0.4.0/_modules/torch/distributions/one_hot_categorical.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/pareto.html
+++ b/docs/0.4.0/_modules/torch/distributions/pareto.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/poisson.html
+++ b/docs/0.4.0/_modules/torch/distributions/poisson.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/0.4.0/_modules/torch/distributions/relaxed_bernoulli.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/0.4.0/_modules/torch/distributions/relaxed_categorical.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/studentT.html
+++ b/docs/0.4.0/_modules/torch/distributions/studentT.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/0.4.0/_modules/torch/distributions/transformed_distribution.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/transforms.html
+++ b/docs/0.4.0/_modules/torch/distributions/transforms.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/distributions/uniform.html
+++ b/docs/0.4.0/_modules/torch/distributions/uniform.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/functional.html
+++ b/docs/0.4.0/_modules/torch/functional.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/multiprocessing.html
+++ b/docs/0.4.0/_modules/torch/multiprocessing.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/functional.html
+++ b/docs/0.4.0/_modules/torch/nn/functional.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/init.html
+++ b/docs/0.4.0/_modules/torch/nn/init.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/activation.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/activation.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/batchnorm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/container.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/container.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/conv.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/conv.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/distance.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/distance.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/dropout.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/dropout.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/instancenorm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/linear.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/linear.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/loss.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/loss.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -917,7 +917,7 @@
     <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">weight</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">size_average</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">ignore_index</span><span class="o">=-</span><span class="mi">100</span><span class="p">,</span> <span class="n">reduce</span><span class="o">=</span><span class="kc">True</span><span class="p">):</span>
         <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;NLLLoss2d has been deprecated. &quot;</span>
                       <span class="s2">&quot;Please use NLLLoss instead as a drop-in replacement and see &quot;</span>
-                      <span class="s2">&quot;http://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.&quot;</span><span class="p">)</span>
+                      <span class="s2">&quot;https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.&quot;</span><span class="p">)</span>
         <span class="nb">super</span><span class="p">(</span><span class="n">NLLLoss2d</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">weight</span><span class="p">,</span> <span class="n">size_average</span><span class="p">,</span> <span class="n">ignore_index</span><span class="p">,</span> <span class="n">reduce</span><span class="p">)</span>
 
 

--- a/docs/0.4.0/_modules/torch/nn/modules/module.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/module.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/normalization.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/normalization.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/padding.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/padding.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/pixelshuffle.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/pooling.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/pooling.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/rnn.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/rnn.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/sparse.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/sparse.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/modules/upsampling.html
+++ b/docs/0.4.0/_modules/torch/nn/modules/upsampling.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/0.4.0/_modules/torch/nn/parallel/data_parallel.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/parallel/distributed.html
+++ b/docs/0.4.0/_modules/torch/nn/parallel/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/parameter.html
+++ b/docs/0.4.0/_modules/torch/nn/parameter.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/0.4.0/_modules/torch/nn/utils/clip_grad.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/utils/rnn.html
+++ b/docs/0.4.0/_modules/torch/nn/utils/rnn.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/0.4.0/_modules/torch/nn/utils/weight_norm.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/onnx.html
+++ b/docs/0.4.0/_modules/torch/onnx.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/adadelta.html
+++ b/docs/0.4.0/_modules/torch/optim/adadelta.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/adagrad.html
+++ b/docs/0.4.0/_modules/torch/optim/adagrad.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/adam.html
+++ b/docs/0.4.0/_modules/torch/optim/adam.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/adamax.html
+++ b/docs/0.4.0/_modules/torch/optim/adamax.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/asgd.html
+++ b/docs/0.4.0/_modules/torch/optim/asgd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/lbfgs.html
+++ b/docs/0.4.0/_modules/torch/optim/lbfgs.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/lr_scheduler.html
+++ b/docs/0.4.0/_modules/torch/optim/lr_scheduler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/optimizer.html
+++ b/docs/0.4.0/_modules/torch/optim/optimizer.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/rmsprop.html
+++ b/docs/0.4.0/_modules/torch/optim/rmsprop.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/rprop.html
+++ b/docs/0.4.0/_modules/torch/optim/rprop.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/sgd.html
+++ b/docs/0.4.0/_modules/torch/optim/sgd.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/optim/sparse_adam.html
+++ b/docs/0.4.0/_modules/torch/optim/sparse_adam.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/random.html
+++ b/docs/0.4.0/_modules/torch/random.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/serialization.html
+++ b/docs/0.4.0/_modules/torch/serialization.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/sparse.html
+++ b/docs/0.4.0/_modules/torch/sparse.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/storage.html
+++ b/docs/0.4.0/_modules/torch/storage.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/tensor.html
+++ b/docs/0.4.0/_modules/torch/tensor.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -856,7 +856,7 @@
 
         <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span><span class="n">trim</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;&quot;&quot;reinforce() was removed.</span>
 <span class="s2">            Use torch.distributions instead.</span>
-<span class="s2">            See http://pytorch.org/docs/master/distributions.html</span>
+<span class="s2">            See https://pytorch.org/docs/master/distributions.html</span>
 
 <span class="s2">            Instead of:</span>
 

--- a/docs/0.4.0/_modules/torch/utils/checkpoint.html
+++ b/docs/0.4.0/_modules/torch/utils/checkpoint.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/cpp_extension.html
+++ b/docs/0.4.0/_modules/torch/utils/cpp_extension.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/data/dataloader.html
+++ b/docs/0.4.0/_modules/torch/utils/data/dataloader.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/data/dataset.html
+++ b/docs/0.4.0/_modules/torch/utils/data/dataset.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/data/distributed.html
+++ b/docs/0.4.0/_modules/torch/utils/data/distributed.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/data/sampler.html
+++ b/docs/0.4.0/_modules/torch/utils/data/sampler.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/ffi.html
+++ b/docs/0.4.0/_modules/torch/utils/ffi.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torch/utils/model_zoo.html
+++ b/docs/0.4.0/_modules/torch/utils/model_zoo.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision.html
+++ b/docs/0.4.0/_modules/torchvision.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/cifar.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/cifar.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/coco.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/coco.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/folder.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/folder.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/lsun.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/lsun.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/mnist.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/mnist.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/phototour.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/phototour.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/stl10.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/stl10.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/datasets/svhn.html
+++ b/docs/0.4.0/_modules/torchvision/datasets/svhn.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/alexnet.html
+++ b/docs/0.4.0/_modules/torchvision/models/alexnet.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/densenet.html
+++ b/docs/0.4.0/_modules/torchvision/models/densenet.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/inception.html
+++ b/docs/0.4.0/_modules/torchvision/models/inception.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/resnet.html
+++ b/docs/0.4.0/_modules/torchvision/models/resnet.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/squeezenet.html
+++ b/docs/0.4.0/_modules/torchvision/models/squeezenet.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/models/vgg.html
+++ b/docs/0.4.0/_modules/torchvision/models/vgg.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/transforms/transforms.html
+++ b/docs/0.4.0/_modules/torchvision/transforms/transforms.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/_modules/torchvision/utils.html
+++ b/docs/0.4.0/_modules/torchvision/utils.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/autograd.html
+++ b/docs/0.4.0/autograd.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/bottleneck.html
+++ b/docs/0.4.0/bottleneck.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/checkpoint.html
+++ b/docs/0.4.0/checkpoint.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/cpp_extension.html
+++ b/docs/0.4.0/cpp_extension.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/cuda.html
+++ b/docs/0.4.0/cuda.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/data.html
+++ b/docs/0.4.0/data.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/distributed.html
+++ b/docs/0.4.0/distributed.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/distributions.html
+++ b/docs/0.4.0/distributions.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/ffi.html
+++ b/docs/0.4.0/ffi.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/genindex.html
+++ b/docs/0.4.0/genindex.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/index.html
+++ b/docs/0.4.0/index.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/legacy.html
+++ b/docs/0.4.0/legacy.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/model_zoo.html
+++ b/docs/0.4.0/model_zoo.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/multiprocessing.html
+++ b/docs/0.4.0/multiprocessing.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/nn.html
+++ b/docs/0.4.0/nn.html
@@ -64,7 +64,7 @@
 
 
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
 
 

--- a/docs/0.4.0/notes/autograd.html
+++ b/docs/0.4.0/notes/autograd.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/broadcasting.html
+++ b/docs/0.4.0/notes/broadcasting.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/cuda.html
+++ b/docs/0.4.0/notes/cuda.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/extending.html
+++ b/docs/0.4.0/notes/extending.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/faq.html
+++ b/docs/0.4.0/notes/faq.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/multiprocessing.html
+++ b/docs/0.4.0/notes/multiprocessing.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/serialization.html
+++ b/docs/0.4.0/notes/serialization.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/notes/windows.html
+++ b/docs/0.4.0/notes/windows.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/onnx.html
+++ b/docs/0.4.0/onnx.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/optim.html
+++ b/docs/0.4.0/optim.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/py-modindex.html
+++ b/docs/0.4.0/py-modindex.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/search.html
+++ b/docs/0.4.0/search.html
@@ -62,7 +62,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/sparse.html
+++ b/docs/0.4.0/sparse.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/storage.html
+++ b/docs/0.4.0/storage.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/tensor_attributes.html
+++ b/docs/0.4.0/tensor_attributes.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/tensors.html
+++ b/docs/0.4.0/tensors.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torch.html
+++ b/docs/0.4.0/torch.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torchvision/datasets.html
+++ b/docs/0.4.0/torchvision/datasets.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torchvision/index.html
+++ b/docs/0.4.0/torchvision/index.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torchvision/models.html
+++ b/docs/0.4.0/torchvision/models.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torchvision/transforms.html
+++ b/docs/0.4.0/torchvision/transforms.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/0.4.0/torchvision/utils.html
+++ b/docs/0.4.0/torchvision/utils.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.0 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.0 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/master/_modules/index.html
+++ b/docs/master/_modules/index.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch.html
+++ b/docs/master/_modules/torch.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/_tensor_str.html
+++ b/docs/master/_modules/torch/_tensor_str.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/_utils.html
+++ b/docs/master/_modules/torch/_utils.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd.html
+++ b/docs/master/_modules/torch/autograd.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd/anomaly_mode.html
+++ b/docs/master/_modules/torch/autograd/anomaly_mode.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd/function.html
+++ b/docs/master/_modules/torch/autograd/function.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd/grad_mode.html
+++ b/docs/master/_modules/torch/autograd/grad_mode.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd/gradcheck.html
+++ b/docs/master/_modules/torch/autograd/gradcheck.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/autograd/profiler.html
+++ b/docs/master/_modules/torch/autograd/profiler.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/cuda.html
+++ b/docs/master/_modules/torch/cuda.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/cuda/comm.html
+++ b/docs/master/_modules/torch/cuda/comm.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/cuda/nvtx.html
+++ b/docs/master/_modules/torch/cuda/nvtx.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/cuda/random.html
+++ b/docs/master/_modules/torch/cuda/random.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/cuda/streams.html
+++ b/docs/master/_modules/torch/cuda/streams.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributed.html
+++ b/docs/master/_modules/torch/distributed.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributed/deprecated.html
+++ b/docs/master/_modules/torch/distributed/deprecated.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributed/distributed_c10d.html
+++ b/docs/master/_modules/torch/distributed/distributed_c10d.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/bernoulli.html
+++ b/docs/master/_modules/torch/distributions/bernoulli.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/beta.html
+++ b/docs/master/_modules/torch/distributions/beta.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/binomial.html
+++ b/docs/master/_modules/torch/distributions/binomial.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/categorical.html
+++ b/docs/master/_modules/torch/distributions/categorical.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/cauchy.html
+++ b/docs/master/_modules/torch/distributions/cauchy.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/chi2.html
+++ b/docs/master/_modules/torch/distributions/chi2.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/constraint_registry.html
+++ b/docs/master/_modules/torch/distributions/constraint_registry.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/constraints.html
+++ b/docs/master/_modules/torch/distributions/constraints.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/dirichlet.html
+++ b/docs/master/_modules/torch/distributions/dirichlet.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/distribution.html
+++ b/docs/master/_modules/torch/distributions/distribution.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/exp_family.html
+++ b/docs/master/_modules/torch/distributions/exp_family.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/exponential.html
+++ b/docs/master/_modules/torch/distributions/exponential.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/master/_modules/torch/distributions/fishersnedecor.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/gamma.html
+++ b/docs/master/_modules/torch/distributions/gamma.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/geometric.html
+++ b/docs/master/_modules/torch/distributions/geometric.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/gumbel.html
+++ b/docs/master/_modules/torch/distributions/gumbel.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/half_cauchy.html
+++ b/docs/master/_modules/torch/distributions/half_cauchy.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/half_normal.html
+++ b/docs/master/_modules/torch/distributions/half_normal.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/independent.html
+++ b/docs/master/_modules/torch/distributions/independent.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/kl.html
+++ b/docs/master/_modules/torch/distributions/kl.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/laplace.html
+++ b/docs/master/_modules/torch/distributions/laplace.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/log_normal.html
+++ b/docs/master/_modules/torch/distributions/log_normal.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/lowrank_multivariate_normal.html
+++ b/docs/master/_modules/torch/distributions/lowrank_multivariate_normal.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/multinomial.html
+++ b/docs/master/_modules/torch/distributions/multinomial.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/master/_modules/torch/distributions/multivariate_normal.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/negative_binomial.html
+++ b/docs/master/_modules/torch/distributions/negative_binomial.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/normal.html
+++ b/docs/master/_modules/torch/distributions/normal.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/master/_modules/torch/distributions/one_hot_categorical.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/pareto.html
+++ b/docs/master/_modules/torch/distributions/pareto.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/poisson.html
+++ b/docs/master/_modules/torch/distributions/poisson.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/master/_modules/torch/distributions/relaxed_bernoulli.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/master/_modules/torch/distributions/relaxed_categorical.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/studentT.html
+++ b/docs/master/_modules/torch/distributions/studentT.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/master/_modules/torch/distributions/transformed_distribution.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/transforms.html
+++ b/docs/master/_modules/torch/distributions/transforms.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/uniform.html
+++ b/docs/master/_modules/torch/distributions/uniform.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/distributions/weibull.html
+++ b/docs/master/_modules/torch/distributions/weibull.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/functional.html
+++ b/docs/master/_modules/torch/functional.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/hub.html
+++ b/docs/master/_modules/torch/hub.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/jit.html
+++ b/docs/master/_modules/torch/jit.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/multiprocessing.html
+++ b/docs/master/_modules/torch/multiprocessing.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/multiprocessing/spawn.html
+++ b/docs/master/_modules/torch/multiprocessing/spawn.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/functional.html
+++ b/docs/master/_modules/torch/nn/functional.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/init.html
+++ b/docs/master/_modules/torch/nn/init.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/activation.html
+++ b/docs/master/_modules/torch/nn/modules/activation.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/adaptive.html
+++ b/docs/master/_modules/torch/nn/modules/adaptive.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/master/_modules/torch/nn/modules/batchnorm.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/container.html
+++ b/docs/master/_modules/torch/nn/modules/container.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/conv.html
+++ b/docs/master/_modules/torch/nn/modules/conv.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/distance.html
+++ b/docs/master/_modules/torch/nn/modules/distance.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/dropout.html
+++ b/docs/master/_modules/torch/nn/modules/dropout.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/fold.html
+++ b/docs/master/_modules/torch/nn/modules/fold.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/master/_modules/torch/nn/modules/instancenorm.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/linear.html
+++ b/docs/master/_modules/torch/nn/modules/linear.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/loss.html
+++ b/docs/master/_modules/torch/nn/modules/loss.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/module.html
+++ b/docs/master/_modules/torch/nn/modules/module.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/normalization.html
+++ b/docs/master/_modules/torch/nn/modules/normalization.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/padding.html
+++ b/docs/master/_modules/torch/nn/modules/padding.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/master/_modules/torch/nn/modules/pixelshuffle.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/pooling.html
+++ b/docs/master/_modules/torch/nn/modules/pooling.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/rnn.html
+++ b/docs/master/_modules/torch/nn/modules/rnn.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/sparse.html
+++ b/docs/master/_modules/torch/nn/modules/sparse.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/modules/upsampling.html
+++ b/docs/master/_modules/torch/nn/modules/upsampling.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/master/_modules/torch/nn/parallel/data_parallel.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/parallel/distributed.html
+++ b/docs/master/_modules/torch/nn/parallel/distributed.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/parallel/distributed_cpu.html
+++ b/docs/master/_modules/torch/nn/parallel/distributed_cpu.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/parameter.html
+++ b/docs/master/_modules/torch/nn/parameter.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/master/_modules/torch/nn/utils/clip_grad.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/utils/convert_parameters.html
+++ b/docs/master/_modules/torch/nn/utils/convert_parameters.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/utils/rnn.html
+++ b/docs/master/_modules/torch/nn/utils/rnn.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/utils/spectral_norm.html
+++ b/docs/master/_modules/torch/nn/utils/spectral_norm.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/master/_modules/torch/nn/utils/weight_norm.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/onnx.html
+++ b/docs/master/_modules/torch/onnx.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/adadelta.html
+++ b/docs/master/_modules/torch/optim/adadelta.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/adagrad.html
+++ b/docs/master/_modules/torch/optim/adagrad.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/adam.html
+++ b/docs/master/_modules/torch/optim/adam.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/adamax.html
+++ b/docs/master/_modules/torch/optim/adamax.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/asgd.html
+++ b/docs/master/_modules/torch/optim/asgd.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/lbfgs.html
+++ b/docs/master/_modules/torch/optim/lbfgs.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/lr_scheduler.html
+++ b/docs/master/_modules/torch/optim/lr_scheduler.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/optimizer.html
+++ b/docs/master/_modules/torch/optim/optimizer.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/rmsprop.html
+++ b/docs/master/_modules/torch/optim/rmsprop.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/rprop.html
+++ b/docs/master/_modules/torch/optim/rprop.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/sgd.html
+++ b/docs/master/_modules/torch/optim/sgd.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/optim/sparse_adam.html
+++ b/docs/master/_modules/torch/optim/sparse_adam.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/random.html
+++ b/docs/master/_modules/torch/random.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/serialization.html
+++ b/docs/master/_modules/torch/serialization.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/sparse.html
+++ b/docs/master/_modules/torch/sparse.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/storage.html
+++ b/docs/master/_modules/torch/storage.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/tensor.html
+++ b/docs/master/_modules/torch/tensor.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/checkpoint.html
+++ b/docs/master/_modules/torch/utils/checkpoint.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/cpp_extension.html
+++ b/docs/master/_modules/torch/utils/cpp_extension.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/data/dataloader.html
+++ b/docs/master/_modules/torch/utils/data/dataloader.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/data/dataset.html
+++ b/docs/master/_modules/torch/utils/data/dataset.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/data/distributed.html
+++ b/docs/master/_modules/torch/utils/data/distributed.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/data/sampler.html
+++ b/docs/master/_modules/torch/utils/data/sampler.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torch/utils/model_zoo.html
+++ b/docs/master/_modules/torch/utils/model_zoo.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision.html
+++ b/docs/master/_modules/torchvision.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/cifar.html
+++ b/docs/master/_modules/torchvision/datasets/cifar.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/coco.html
+++ b/docs/master/_modules/torchvision/datasets/coco.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/folder.html
+++ b/docs/master/_modules/torchvision/datasets/folder.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/lsun.html
+++ b/docs/master/_modules/torchvision/datasets/lsun.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/mnist.html
+++ b/docs/master/_modules/torchvision/datasets/mnist.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/phototour.html
+++ b/docs/master/_modules/torchvision/datasets/phototour.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/stl10.html
+++ b/docs/master/_modules/torchvision/datasets/stl10.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/datasets/svhn.html
+++ b/docs/master/_modules/torchvision/datasets/svhn.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/alexnet.html
+++ b/docs/master/_modules/torchvision/models/alexnet.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/densenet.html
+++ b/docs/master/_modules/torchvision/models/densenet.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/inception.html
+++ b/docs/master/_modules/torchvision/models/inception.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/resnet.html
+++ b/docs/master/_modules/torchvision/models/resnet.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/squeezenet.html
+++ b/docs/master/_modules/torchvision/models/squeezenet.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/models/vgg.html
+++ b/docs/master/_modules/torchvision/models/vgg.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/transforms/functional.html
+++ b/docs/master/_modules/torchvision/transforms/functional.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/transforms/transforms.html
+++ b/docs/master/_modules/torchvision/transforms/transforms.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/_modules/torchvision/utils.html
+++ b/docs/master/_modules/torchvision/utils.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/autograd.html
+++ b/docs/master/autograd.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/bottleneck.html
+++ b/docs/master/bottleneck.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/checkpoint.html
+++ b/docs/master/checkpoint.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cpp_extension.html
+++ b/docs/master/cpp_extension.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cuda.html
+++ b/docs/master/cuda.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cuda_deterministic.html
+++ b/docs/master/cuda_deterministic.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cuda_deterministic_backward.html
+++ b/docs/master/cuda_deterministic_backward.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cudnn_deterministic.html
+++ b/docs/master/cudnn_deterministic.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/cudnn_persistent_rnn.html
+++ b/docs/master/cudnn_persistent_rnn.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/data.html
+++ b/docs/master/data.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/distributed.html
+++ b/docs/master/distributed.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/distributed_deprecated.html
+++ b/docs/master/distributed_deprecated.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/distributions.html
+++ b/docs/master/distributions.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/dlpack.html
+++ b/docs/master/dlpack.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/ffi.html
+++ b/docs/master/ffi.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/genindex.html
+++ b/docs/master/genindex.html
@@ -109,7 +109,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/hub.html
+++ b/docs/master/hub.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/index.html
+++ b/docs/master/index.html
@@ -109,7 +109,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/jit.html
+++ b/docs/master/jit.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/legacy.html
+++ b/docs/master/legacy.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/model_zoo.html
+++ b/docs/master/model_zoo.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/multiprocessing.html
+++ b/docs/master/multiprocessing.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/nn.html
+++ b/docs/master/nn.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/autograd.html
+++ b/docs/master/notes/autograd.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/broadcasting.html
+++ b/docs/master/notes/broadcasting.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/cuda.html
+++ b/docs/master/notes/cuda.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/extending.html
+++ b/docs/master/notes/extending.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/faq.html
+++ b/docs/master/notes/faq.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/multiprocessing.html
+++ b/docs/master/notes/multiprocessing.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/randomness.html
+++ b/docs/master/notes/randomness.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/serialization.html
+++ b/docs/master/notes/serialization.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/notes/windows.html
+++ b/docs/master/notes/windows.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/onnx.html
+++ b/docs/master/onnx.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/optim.html
+++ b/docs/master/optim.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/py-modindex.html
+++ b/docs/master/py-modindex.html
@@ -111,7 +111,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/search.html
+++ b/docs/master/search.html
@@ -108,7 +108,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/sparse.html
+++ b/docs/master/sparse.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/storage.html
+++ b/docs/master/storage.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/tensor_attributes.html
+++ b/docs/master/tensor_attributes.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/tensors.html
+++ b/docs/master/tensors.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torch.html
+++ b/docs/master/torch.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torchvision/datasets.html
+++ b/docs/master/torchvision/datasets.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torchvision/index.html
+++ b/docs/master/torchvision/index.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torchvision/models.html
+++ b/docs/master/torchvision/models.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torchvision/transforms.html
+++ b/docs/master/torchvision/transforms.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/torchvision/utils.html
+++ b/docs/master/torchvision/utils.html
@@ -109,7 +109,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/master/type_info.html
+++ b/docs/master/type_info.html
@@ -110,7 +110,7 @@
               
               
                 <div class="version">
-                  <a href="http://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
+                  <a href="https://pytorch.org/docs/versions.html">master (1.0.0a0+6b48522 ) &#x25BC</a>
                 </div>
               
             

--- a/docs/stable/_modules/index.html
+++ b/docs/stable/_modules/index.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch.html
+++ b/docs/stable/_modules/torch.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/_tensor_str.html
+++ b/docs/stable/_modules/torch/_tensor_str.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/_utils.html
+++ b/docs/stable/_modules/torch/_utils.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd.html
+++ b/docs/stable/_modules/torch/autograd.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd/anomaly_mode.html
+++ b/docs/stable/_modules/torch/autograd/anomaly_mode.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd/function.html
+++ b/docs/stable/_modules/torch/autograd/function.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd/grad_mode.html
+++ b/docs/stable/_modules/torch/autograd/grad_mode.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd/gradcheck.html
+++ b/docs/stable/_modules/torch/autograd/gradcheck.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/autograd/profiler.html
+++ b/docs/stable/_modules/torch/autograd/profiler.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/cuda.html
+++ b/docs/stable/_modules/torch/cuda.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -833,7 +833,7 @@
 <span class="s2">The NVIDIA driver on your system is too old (found version </span><span class="si">{}</span><span class="s2">).</span>
 <span class="s2">Please update your GPU driver by downloading and installing a new</span>
 <span class="s2">version from the URL: http://www.nvidia.com/Download/index.aspx</span>
-<span class="s2">Alternatively, go to: http://pytorch.org to install</span>
+<span class="s2">Alternatively, go to: https://pytorch.org to install</span>
 <span class="s2">a PyTorch version that has been compiled with your version</span>
 <span class="s2">of the CUDA driver.&quot;&quot;&quot;</span><span class="o">.</span><span class="n">format</span><span class="p">(</span><span class="nb">str</span><span class="p">(</span><span class="n">torch</span><span class="o">.</span><span class="n">_C</span><span class="o">.</span><span class="n">_cuda_getDriverVersion</span><span class="p">())))</span>
 
@@ -843,7 +843,7 @@
 <span class="s2">    Found GPU</span><span class="si">%d</span><span class="s2"> </span><span class="si">%s</span><span class="s2"> which requires CUDA_VERSION &gt;= </span><span class="si">%d</span><span class="s2"> for</span>
 <span class="s2">     optimal performance and fast startup time, but your PyTorch was compiled</span>
 <span class="s2">     with CUDA_VERSION </span><span class="si">%d</span><span class="s2">. Please install the correct PyTorch binary</span>
-<span class="s2">     using instructions from http://pytorch.org</span>
+<span class="s2">     using instructions from https://pytorch.org</span>
 <span class="s2">    &quot;&quot;&quot;</span>
 
     <span class="n">old_gpu_warn</span> <span class="o">=</span> <span class="s2">&quot;&quot;&quot;</span>

--- a/docs/stable/_modules/torch/cuda/comm.html
+++ b/docs/stable/_modules/torch/cuda/comm.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/cuda/nvtx.html
+++ b/docs/stable/_modules/torch/cuda/nvtx.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/cuda/random.html
+++ b/docs/stable/_modules/torch/cuda/random.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/cuda/streams.html
+++ b/docs/stable/_modules/torch/cuda/streams.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributed.html
+++ b/docs/stable/_modules/torch/distributed.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/bernoulli.html
+++ b/docs/stable/_modules/torch/distributions/bernoulli.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/beta.html
+++ b/docs/stable/_modules/torch/distributions/beta.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/binomial.html
+++ b/docs/stable/_modules/torch/distributions/binomial.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/categorical.html
+++ b/docs/stable/_modules/torch/distributions/categorical.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/cauchy.html
+++ b/docs/stable/_modules/torch/distributions/cauchy.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/chi2.html
+++ b/docs/stable/_modules/torch/distributions/chi2.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/constraint_registry.html
+++ b/docs/stable/_modules/torch/distributions/constraint_registry.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/constraints.html
+++ b/docs/stable/_modules/torch/distributions/constraints.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/dirichlet.html
+++ b/docs/stable/_modules/torch/distributions/dirichlet.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/distribution.html
+++ b/docs/stable/_modules/torch/distributions/distribution.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/exp_family.html
+++ b/docs/stable/_modules/torch/distributions/exp_family.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/exponential.html
+++ b/docs/stable/_modules/torch/distributions/exponential.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/stable/_modules/torch/distributions/fishersnedecor.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/gamma.html
+++ b/docs/stable/_modules/torch/distributions/gamma.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/geometric.html
+++ b/docs/stable/_modules/torch/distributions/geometric.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/gumbel.html
+++ b/docs/stable/_modules/torch/distributions/gumbel.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/half_cauchy.html
+++ b/docs/stable/_modules/torch/distributions/half_cauchy.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/half_normal.html
+++ b/docs/stable/_modules/torch/distributions/half_normal.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/independent.html
+++ b/docs/stable/_modules/torch/distributions/independent.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/kl.html
+++ b/docs/stable/_modules/torch/distributions/kl.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/laplace.html
+++ b/docs/stable/_modules/torch/distributions/laplace.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/log_normal.html
+++ b/docs/stable/_modules/torch/distributions/log_normal.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/multinomial.html
+++ b/docs/stable/_modules/torch/distributions/multinomial.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/stable/_modules/torch/distributions/multivariate_normal.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/normal.html
+++ b/docs/stable/_modules/torch/distributions/normal.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/stable/_modules/torch/distributions/one_hot_categorical.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/pareto.html
+++ b/docs/stable/_modules/torch/distributions/pareto.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/poisson.html
+++ b/docs/stable/_modules/torch/distributions/poisson.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/stable/_modules/torch/distributions/relaxed_bernoulli.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/stable/_modules/torch/distributions/relaxed_categorical.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/studentT.html
+++ b/docs/stable/_modules/torch/distributions/studentT.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/stable/_modules/torch/distributions/transformed_distribution.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/transforms.html
+++ b/docs/stable/_modules/torch/distributions/transforms.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/distributions/uniform.html
+++ b/docs/stable/_modules/torch/distributions/uniform.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/functional.html
+++ b/docs/stable/_modules/torch/functional.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/multiprocessing.html
+++ b/docs/stable/_modules/torch/multiprocessing.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/functional.html
+++ b/docs/stable/_modules/torch/nn/functional.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/init.html
+++ b/docs/stable/_modules/torch/nn/init.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/activation.html
+++ b/docs/stable/_modules/torch/nn/modules/activation.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/adaptive.html
+++ b/docs/stable/_modules/torch/nn/modules/adaptive.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/stable/_modules/torch/nn/modules/batchnorm.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/container.html
+++ b/docs/stable/_modules/torch/nn/modules/container.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/conv.html
+++ b/docs/stable/_modules/torch/nn/modules/conv.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/distance.html
+++ b/docs/stable/_modules/torch/nn/modules/distance.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/dropout.html
+++ b/docs/stable/_modules/torch/nn/modules/dropout.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/fold.html
+++ b/docs/stable/_modules/torch/nn/modules/fold.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/stable/_modules/torch/nn/modules/instancenorm.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/linear.html
+++ b/docs/stable/_modules/torch/nn/modules/linear.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/loss.html
+++ b/docs/stable/_modules/torch/nn/modules/loss.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -953,7 +953,7 @@
                  <span class="n">reduce</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span> <span class="n">reduction</span><span class="o">=</span><span class="s1">&#39;elementwise_mean&#39;</span><span class="p">):</span>
         <span class="n">warnings</span><span class="o">.</span><span class="n">warn</span><span class="p">(</span><span class="s2">&quot;NLLLoss2d has been deprecated. &quot;</span>
                       <span class="s2">&quot;Please use NLLLoss instead as a drop-in replacement and see &quot;</span>
-                      <span class="s2">&quot;http://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.&quot;</span><span class="p">)</span>
+                      <span class="s2">&quot;https://pytorch.org/docs/master/nn.html#torch.nn.NLLLoss for more details.&quot;</span><span class="p">)</span>
         <span class="nb">super</span><span class="p">(</span><span class="n">NLLLoss2d</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="fm">__init__</span><span class="p">(</span><span class="n">weight</span><span class="p">,</span> <span class="n">size_average</span><span class="p">,</span> <span class="n">ignore_index</span><span class="p">,</span> <span class="n">reduce</span><span class="p">,</span> <span class="n">reduction</span><span class="p">)</span>
 
 

--- a/docs/stable/_modules/torch/nn/modules/module.html
+++ b/docs/stable/_modules/torch/nn/modules/module.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/normalization.html
+++ b/docs/stable/_modules/torch/nn/modules/normalization.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/padding.html
+++ b/docs/stable/_modules/torch/nn/modules/padding.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/stable/_modules/torch/nn/modules/pixelshuffle.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/pooling.html
+++ b/docs/stable/_modules/torch/nn/modules/pooling.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/rnn.html
+++ b/docs/stable/_modules/torch/nn/modules/rnn.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/sparse.html
+++ b/docs/stable/_modules/torch/nn/modules/sparse.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/modules/upsampling.html
+++ b/docs/stable/_modules/torch/nn/modules/upsampling.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/stable/_modules/torch/nn/parallel/data_parallel.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/parallel/distributed.html
+++ b/docs/stable/_modules/torch/nn/parallel/distributed.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/parameter.html
+++ b/docs/stable/_modules/torch/nn/parameter.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/stable/_modules/torch/nn/utils/clip_grad.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/utils/convert_parameters.html
+++ b/docs/stable/_modules/torch/nn/utils/convert_parameters.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/utils/rnn.html
+++ b/docs/stable/_modules/torch/nn/utils/rnn.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/utils/spectral_norm.html
+++ b/docs/stable/_modules/torch/nn/utils/spectral_norm.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/stable/_modules/torch/nn/utils/weight_norm.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/onnx.html
+++ b/docs/stable/_modules/torch/onnx.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/adadelta.html
+++ b/docs/stable/_modules/torch/optim/adadelta.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/adagrad.html
+++ b/docs/stable/_modules/torch/optim/adagrad.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/adam.html
+++ b/docs/stable/_modules/torch/optim/adam.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/adamax.html
+++ b/docs/stable/_modules/torch/optim/adamax.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/asgd.html
+++ b/docs/stable/_modules/torch/optim/asgd.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/lbfgs.html
+++ b/docs/stable/_modules/torch/optim/lbfgs.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/lr_scheduler.html
+++ b/docs/stable/_modules/torch/optim/lr_scheduler.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/optimizer.html
+++ b/docs/stable/_modules/torch/optim/optimizer.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/rmsprop.html
+++ b/docs/stable/_modules/torch/optim/rmsprop.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/rprop.html
+++ b/docs/stable/_modules/torch/optim/rprop.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/sgd.html
+++ b/docs/stable/_modules/torch/optim/sgd.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/optim/sparse_adam.html
+++ b/docs/stable/_modules/torch/optim/sparse_adam.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/random.html
+++ b/docs/stable/_modules/torch/random.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/serialization.html
+++ b/docs/stable/_modules/torch/serialization.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/sparse.html
+++ b/docs/stable/_modules/torch/sparse.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/storage.html
+++ b/docs/stable/_modules/torch/storage.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/tensor.html
+++ b/docs/stable/_modules/torch/tensor.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           
@@ -886,7 +886,7 @@
 
         <span class="k">raise</span> <span class="ne">RuntimeError</span><span class="p">(</span><span class="n">trim</span><span class="p">(</span><span class="sa">r</span><span class="s2">&quot;&quot;&quot;reinforce() was removed.</span>
 <span class="s2">            Use torch.distributions instead.</span>
-<span class="s2">            See http://pytorch.org/docs/master/distributions.html</span>
+<span class="s2">            See https://pytorch.org/docs/master/distributions.html</span>
 
 <span class="s2">            Instead of:</span>
 

--- a/docs/stable/_modules/torch/utils/checkpoint.html
+++ b/docs/stable/_modules/torch/utils/checkpoint.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/cpp_extension.html
+++ b/docs/stable/_modules/torch/utils/cpp_extension.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/data/dataloader.html
+++ b/docs/stable/_modules/torch/utils/data/dataloader.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/data/dataset.html
+++ b/docs/stable/_modules/torch/utils/data/dataset.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/data/distributed.html
+++ b/docs/stable/_modules/torch/utils/data/distributed.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/data/sampler.html
+++ b/docs/stable/_modules/torch/utils/data/sampler.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/ffi.html
+++ b/docs/stable/_modules/torch/utils/ffi.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/_modules/torch/utils/model_zoo.html
+++ b/docs/stable/_modules/torch/utils/model_zoo.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/autograd.html
+++ b/docs/stable/autograd.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/bottleneck.html
+++ b/docs/stable/bottleneck.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/checkpoint.html
+++ b/docs/stable/checkpoint.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/cpp_extension.html
+++ b/docs/stable/cpp_extension.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/cuda.html
+++ b/docs/stable/cuda.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/data.html
+++ b/docs/stable/data.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/distributed.html
+++ b/docs/stable/distributed.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/distributions.html
+++ b/docs/stable/distributions.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/dlpack.html
+++ b/docs/stable/dlpack.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/ffi.html
+++ b/docs/stable/ffi.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/genindex.html
+++ b/docs/stable/genindex.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/index.html
+++ b/docs/stable/index.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/legacy.html
+++ b/docs/stable/legacy.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/model_zoo.html
+++ b/docs/stable/model_zoo.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/multiprocessing.html
+++ b/docs/stable/multiprocessing.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/nn.html
+++ b/docs/stable/nn.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/autograd.html
+++ b/docs/stable/notes/autograd.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/broadcasting.html
+++ b/docs/stable/notes/broadcasting.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/cuda.html
+++ b/docs/stable/notes/cuda.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/extending.html
+++ b/docs/stable/notes/extending.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/faq.html
+++ b/docs/stable/notes/faq.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/multiprocessing.html
+++ b/docs/stable/notes/multiprocessing.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/serialization.html
+++ b/docs/stable/notes/serialization.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/notes/windows.html
+++ b/docs/stable/notes/windows.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/onnx.html
+++ b/docs/stable/onnx.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/optim.html
+++ b/docs/stable/optim.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/py-modindex.html
+++ b/docs/stable/py-modindex.html
@@ -66,7 +66,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/search.html
+++ b/docs/stable/search.html
@@ -63,7 +63,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/sparse.html
+++ b/docs/stable/sparse.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/storage.html
+++ b/docs/stable/storage.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/tensor_attributes.html
+++ b/docs/stable/tensor_attributes.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/tensors.html
+++ b/docs/stable/tensors.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torch.html
+++ b/docs/stable/torch.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torchvision/datasets.html
+++ b/docs/stable/torchvision/datasets.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torchvision/index.html
+++ b/docs/stable/torchvision/index.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torchvision/models.html
+++ b/docs/stable/torchvision/models.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torchvision/transforms.html
+++ b/docs/stable/torchvision/transforms.html
@@ -65,7 +65,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           

--- a/docs/stable/torchvision/utils.html
+++ b/docs/stable/torchvision/utils.html
@@ -64,7 +64,7 @@
             
             
               <div class="version">
-                0.4.1 <br/> <a href="http://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
+                0.4.1 <br/> <a href="https://pytorch.org/docs/versions.html"> version selector &#x25BC</a>
               </div>
             
           


### PR DESCRIPTION
Ref: https://github.com/pytorch/pytorch/issues/13951