### PR TITLE
Remove font-display property

### DIFF
--- a/_sass/fonts.scss
+++ b/_sass/fonts.scss
@@ -2,7 +2,6 @@
   font-family: FreightSans;
   font-weight: 400;
   font-style: normal;
-  font-display: swap;
   src:
     url($baseurl + "/assets/fonts/FreightSans/freight-sans-regular.woff2")
       format("woff2"),
@@ -14,7 +13,6 @@
   font-family: FreightSans;
   font-weight: 300;
   font-style: normal;
-  font-display: swap;
   src:
     url($baseurl + "/assets/fonts/FreightSans/freight-sans-light.woff2")
       format("woff2"),
@@ -26,7 +24,6 @@
   font-family: IBMPlexMono;
   font-weight: 600;
   font-style: normal;
-  font-display: swap;
   unicode-range: u+0020-007f;
   src: local("IBMPlexMono-SemiBold"),
     url($baseurl + "/assets/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2")
@@ -39,7 +36,6 @@
   font-family: IBMPlexMono;
   font-weight: 500;
   font-style: normal;
-  font-display: swap;
   unicode-range: u+0020-007f;
   src: local("IBMPlexMono-Medium"),
     url($baseurl + "/assets/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2")
@@ -52,7 +48,6 @@
   font-family: IBMPlexMono;
   font-weight: 400;
   font-style: normal;
-  font-display: swap;
   unicode-range: u+0020-007f;
   src: local("IBMPlexMono-Regular"),
     url($baseurl + "/assets/fonts/IBMPlexMono/IBMPlexMono-Regular.woff2")
@@ -65,7 +60,6 @@
   font-family: IBMPlexMono;
   font-weight: 300;
   font-style: normal;
-  font-display: swap;
   unicode-range: u+0020-007f;
   src: local("IBMPlexMono-Light"),
     url($baseurl + "/assets/fonts/IBMPlexMono/IBMPlexMono-Light.woff2")


### PR DESCRIPTION
This PR addresses the flashing text/font reload issue by removing the `font-display` property from `fonts.scss`. Here is a preview that includes the new ecosystem join form: [https://5bf4549ab3127429520dbacc--shiftlab-pytorch-github-io.netlify.com/ecosystem/join](https://5bf4549ab3127429520dbacc--shiftlab-pytorch-github-io.netlify.com/ecosystem/join).