### PR TITLE
Add experimental badge to ecosystem cards

### DIFF
--- a/_ecosystem/allennlp.md
+++ b/_ecosystem/allennlp.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: AllenNLP
 summary: AllenNLP is an open-source research library built on PyTorch for designing and evaluating deep learning models for NLP.
-external: true
 link: https://allennlp.org/
 order: 1
 summary-home: AllenNLP is an open-source research library built on PyTorch for designing and evaluating deep learning models for NLP.

--- a/_ecosystem/elf.md
+++ b/_ecosystem/elf.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: ELF
 summary: ELF is a platform for game research that allows developers to train and test their algorithms in various game environments.
-external: true
 link: https://github.com/pytorch/elf
 logo-class: reasoning
 order: 2

--- a/_ecosystem/fastai
+++ b/_ecosystem/fastai
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: fastai
 summary: fastai is a library that simplifies training fast and accurate neural nets using modern best practices.
-external: true
 link: https://docs.fast.ai
 order: 10
 summary-home: fastai is a library that simplifies training fast and accurate neural nets using modern best practices.

--- a/_ecosystem/glow.md
+++ b/_ecosystem/glow.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: Glow
 summary: Glow is a ML compiler that accelerates the performance of deep learning frameworks on different hardware platforms.
-external: true
 link: https://github.com/pytorch/glow
 order: 3
 summary-home: Glow is a ML compiler that accelerates the performance of deep learning frameworks on different hardware platforms.

--- a/_ecosystem/gpytorch.md
+++ b/_ecosystem/gpytorch.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: GPyTorch
 summary: GPyTorch is a Gaussian process library implemented using PyTorch, designed for creating scalable, flexible Gaussian process models.
-external: true
 link: https://cornellius-gp.github.io/
 order: 4
 

--- a/_ecosystem/horovod
+++ b/_ecosystem/horovod
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: Horovod
 summary: Horovod is a distributed training library for deep learning frameworks. Horovod aims to make distributed DL fast and easy to use.
-external: true
 link: http://horovod.ai
 order: 9
 summary-home: Horovod is a distributed training library for deep learning frameworks. Horovod aims to make distributed DL fast and easy to use.

--- a/_ecosystem/parlai
+++ b/_ecosystem/parlai
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: ParlAI
 summary: ParlAI is a unified platform for sharing, training, and evaluating dialog models across many tasks.
-external: true
 link: http://parl.ai/
 order: 10
 summary-home: ParlAI is a unified platform for sharing, training, and evaluating dialog models across many tasks.

--- a/_ecosystem/pyro.md
+++ b/_ecosystem/pyro.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: Pyro
 summary: Pyro is a universal probabilistic programming language (PPL) written in Python and supported by PyTorch on the backend.
-external: true
 link: http://pyro.ai/
 order: 5
 ---

--- a/_ecosystem/tensorly.md
+++ b/_ecosystem/tensorly.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: TensorLy
 summary: TensorLy is a high level API for tensor methods and deep tensorized neural networks in Python that aims to make tensor learning simple.
-external: true
 link: http://tensorly.org/stable/home.html
 order: 6
 ---

--- a/_ecosystem/translate.md
+++ b/_ecosystem/translate.md
@@ -2,7 +2,6 @@
 layout: ecosystem_detail
 title: Translate
 summary: Translate is an open source project based on Facebook's machine translation systems.
-external: true
 link: https://github.com/pytorch/translate
 order: 6
 logo-class: language

--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -474,12 +474,6 @@ a, .btn {
   background-repeat: no-repeat;
   padding: rem(25px) rem(30px);
 
-  &.external {
-    h4 {
-      @include external_link_icon
-    }
-  }
-
   &.reasoning {
     background-image: url($baseurl + "/assets/images/logo-elf.svg");
     background-size: 29px 25px;

--- a/_sass/ecosystem.scss
+++ b/_sass/ecosystem.scss
@@ -319,3 +319,23 @@
     }
   }
 }
+
+.ecosystem .experimental {
+  .ecosystem-card-title-container {
+    display: inline-flex;
+      .experimental-badge {
+        text-transform: uppercase;
+        margin-left: 15px;
+        background-color: #e4e4e4;
+        color: $not_quite_black;
+        opacity: 0.75;
+        font-size: rem(10px);
+        letter-spacing: 1px;
+        line-height: rem(22px);
+        height: rem(20px);
+        width: rem(96px);
+        text-align: center;
+        margin-top: rem(4px);
+    }
+  }
+}

--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -63,13 +63,16 @@ body-class: ecosystem
         {% for item in site.ecosystem %}
           <div class="col-md-6 ecosystem-card-wrapper" data-categories="{{ item.category | join: "," }}">
             <div class="card ecosystem-card">
-              {% if item.external %}
-                <a href="{{ item.link }}" target="_blank">
-              {% else %}
-                <a href="{{ site.baseurl }}{{ item.url }}">
-              {% endif %}
-                <div class="card-body {{ item.logo-class }} {% if item.external %}external{% endif %}">
-                  <h4>{{ item.title }}</h4>
+              <a href="{{ item.link }}" target="_blank">
+                <div class="card-body {{ item.logo-class }} {% if item.experimental %}experimental{% endif %}">
+                  <div class="ecosystem-card-title-container">
+                    <h4>{{ item.title }}</h4>
+                      {% if item.experimental %}
+                        <div class="experimental-badge">
+                          Experimental
+                        </div>
+                      {% endif %}
+                  </div>
                   <p class="card-summary">{{ item.summary }}</p>
                 </div>
               </a>


### PR DESCRIPTION
This PR: 

- Adds an "experimental" badge to ecosystem cards that have the `experimental` front matter variable
- Removes the `external` front matter variable from ecosystem card markdown files
- Removes the link icon from ecosystem cards

I've added the `experimental` variable to two ecosystem cards--TensorLy and Glow--so that you can preview the badge design.