### PR TITLE
Add redirect_to urls to ecosystem markdown files

### DIFF
--- a/_ecosystem/Ignite
+++ b/_ecosystem/Ignite
@@ -4,5 +4,5 @@ title: Ignite
 summary: Ignite is a high-level library for training neural networks in PyTorch. It helps with writing compact, but full-featured training loops.
 link: https://github.com/pytorch/ignite
 order: 11
-
+redirect_to: https://github.com/pytorch/ignite
 ---

--- a/_ecosystem/allennlp.md
+++ b/_ecosystem/allennlp.md
@@ -6,5 +6,6 @@ link: https://allennlp.org/
 order: 1
 summary-home: AllenNLP is an open-source research library built on PyTorch for designing and evaluating deep learning models for NLP.
 featured-home: true
+redirect_to: https://allennlp.org/
 ---
 

--- a/_ecosystem/elf.md
+++ b/_ecosystem/elf.md
@@ -7,5 +7,5 @@ logo-class: reasoning
 order: 2
 summary-home: ELF is a platform for game research that allows developers to train and test their algorithms in various game environments.
 featured-home: true
-
+redirect_to: https://github.com/pytorch/elf
 ---

--- a/_ecosystem/fastai
+++ b/_ecosystem/fastai
@@ -6,5 +6,6 @@ link: https://docs.fast.ai
 order: 10
 summary-home: fastai is a library that simplifies training fast and accurate neural nets using modern best practices.
 featured-home: false
+redirect_to: https://docs.fast.ai
 ---
 

--- a/_ecosystem/glow.md
+++ b/_ecosystem/glow.md
@@ -7,5 +7,5 @@ order: 3
 summary-home: Glow is a ML compiler that accelerates the performance of deep learning frameworks on different hardware platforms.
 featured-home: true
 logo-class: tool
-
+redirect_to: https://github.com/pytorch/glow
 ---

--- a/_ecosystem/gpytorch.md
+++ b/_ecosystem/gpytorch.md
@@ -4,5 +4,5 @@ title: GPyTorch
 summary: GPyTorch is a Gaussian process library implemented using PyTorch, designed for creating scalable, flexible Gaussian process models.
 link: https://cornellius-gp.github.io/
 order: 4
-
+redirect_to: https://cornellius-gp.github.io/
 ---

--- a/_ecosystem/horovod
+++ b/_ecosystem/horovod
@@ -6,5 +6,6 @@ link: http://horovod.ai
 order: 9
 summary-home: Horovod is a distributed training library for deep learning frameworks. Horovod aims to make distributed DL fast and easy to use.
 featured-home: false
+redirect_to: http://horovod.ai
 ---
 

--- a/_ecosystem/parlai
+++ b/_ecosystem/parlai
@@ -6,4 +6,5 @@ link: http://parl.ai/
 order: 10
 summary-home: ParlAI is a unified platform for sharing, training, and evaluating dialog models across many tasks.
 featured-home: false
+redirect_to: http://parl.ai/
 ---

--- a/_ecosystem/pyro.md
+++ b/_ecosystem/pyro.md
@@ -4,4 +4,5 @@ title: Pyro
 summary: Pyro is a universal probabilistic programming language (PPL) written in Python and supported by PyTorch on the backend.
 link: http://pyro.ai/
 order: 5
+redirect_to: http://pyro.ai/
 ---

--- a/_ecosystem/tensorly.md
+++ b/_ecosystem/tensorly.md
@@ -4,4 +4,5 @@ title: TensorLy
 summary: TensorLy is a high level API for tensor methods and deep tensorized neural networks in Python that aims to make tensor learning simple.
 link: http://tensorly.org/stable/home.html
 order: 6
+redirect_to: http://tensorly.org/stable/home.html
 ---

--- a/_ecosystem/translate.md
+++ b/_ecosystem/translate.md
@@ -5,7 +5,7 @@ summary: Translate is an open source project based on Facebook's machine transla
 link: https://github.com/pytorch/translate
 order: 6
 logo-class: language
-
+redirect_to: https://github.com/pytorch/translate
 ---
 
 ## Get Started


### PR DESCRIPTION
This PR resolves issue #155. Since the ecosystem cards only feature external links now, the site no longer needs links like https://pytorch.org/ecosystem/elf/. With this fix if a user visits that link, they will be redirected to https://github.com/pytorch/elf.