### PR TITLE
Ensure that ecosystem cards display in proper order

### DIFF
--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -60,7 +60,9 @@ body-class: ecosystem
       <!-- START CONTENT -->
 
       <div class="row ecosystem-cards-wrapper">
-        {% for item in site.ecosystem %}
+        {% assign ecosystem = site.ecosystem  | sort: 'order' %}
+
+        {% for item in ecosystem %}
           <div class="col-md-6 ecosystem-card-wrapper" data-categories="{{ item.category | join: "," }}">
             <div class="card ecosystem-card">
               <a href="{{ item.link }}" target="_blank">


### PR DESCRIPTION
This PR ensures that the Ecosystem cards display according to the order they are assigned in each markdown file.