### PR TITLE
update commands for v1.0.1

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -128,7 +128,7 @@ conda install pytorch-cpu torchvision-cpu -c pytorch
 To install PyTorch via Anaconda, and you are using CUDA 9.0, use the following `conda` command:
 
 ```bash
-conda install pytorch torchvision -c pytorch
+conda install pytorch torchvision cudatoolkit=9.0 -c pytorch
 ```
 
 <div>
@@ -142,13 +142,13 @@ conda install pytorch torchvision -c pytorch
 #### CUDA 8.x
 
 ```bash
-conda install pytorch torchvision cuda80 -c pytorch
+conda install pytorch torchvision cudatoolkit=8.0 -c pytorch
 ```
 
 #### CUDA 10.0
 
 ```bash
-conda install pytorch torchvision cuda100 -c pytorch
+conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
 ```
 
 ### pip
@@ -159,28 +159,28 @@ To install PyTorch via pip, and do not have a [CUDA-capable](https://developer.n
 
 ```bash
 # Python 2.7
-pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl
 pip install torchvision
 
 # if the above command does not work, then you have python 2.7 UCS2, use this command
-pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27m-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27m-linux_x86_64.whl
 ```
 
 ```bash
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp35-cp35m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp36-cp36m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0.post2-cp37-cp37m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
@@ -203,28 +203,28 @@ pip install torch torchvision
 
 ```bash
 # Python 2.7
-pip install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl
 pip install torchvision
 
 # if the above command does not work, then you have python 2.7 UCS2, use this command
-pip install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp27-cp27m-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp27-cp27m-linux_x86_64.whl
 ```
 
 ```bash
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp35-cp35m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp35-cp35m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp36-cp36m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0.post2-cp37-cp37m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
@@ -232,28 +232,28 @@ pip3 install torchvision
 
 ```bash
 # Python 2.7
-pip install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl
 pip install torchvision
 
 # if the above command does not work, then you have python 2.7 UCS2, use this command
-pip install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp27-cp27m-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp27-cp27m-linux_x86_64.whl
 ```
 
 ```bash
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp35-cp35m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp35-cp35m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp36-cp36m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp36-cp36m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0.post2-cp37-cp37m-linux_x86_64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1.post2-cp37-cp37m-linux_x86_64.whl
 pip3 install torchvision
 ```
 
@@ -313,7 +313,6 @@ export CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" # [anaconda root direct
 
 # Install basic dependencies
 conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
-conda install -c mingfeima mkldnn
 
 # Add LAPACK support for the GPU
 conda install -c pytorch magma-cuda80 # or magma-cuda90 if CUDA 9

--- a/_get_started/installation/windows.md
+++ b/_get_started/installation/windows.md
@@ -76,19 +76,19 @@ conda install pytorch-cpu torchvision-cpu -c pytorch
 To install PyTorch via Anaconda, and you are using CUDA 9.0, use the following `conda` command:
 
 ```bash
-conda install pytorch torchvision -c pytorch
+conda install pytorch torchvision cudatoolkit=9.0 -c pytorch
 ```
 
 #### CUDA 8.x
 
 ```bash
-conda install pytorch torchvision cuda80 -c pytorch
+conda install pytorch torchvision cudatoolkit=8.0 -c pytorch
 ```
 
 #### CUDA 10.0
 
 ```bash
-conda install pytorch torchvision cuda100 -c pytorch
+conda install pytorch torchvision cudatoolkit=10.0 -c pytorch
 ```
 
 ### pip
@@ -99,28 +99,28 @@ To install PyTorch via pip, and do not have a [CUDA-capable](https://developer.n
 
 ```bash
 # Python 2.7
-pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl
 pip install torchvision
 
 # if the above command does not work, then you have python 2.7 UCS2, use this command
-pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27m-linux_x86_64.whl
+pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27m-linux_x86_64.whl
 ```
 
 ```bash
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp35-cp35m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp36-cp36m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```bash
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp37-cp37m-win_amd64.whl
 pip3 install torchvision
 ```
 
@@ -132,19 +132,19 @@ To install PyTorch via pip, and you are using CUDA 9.0, use the following comman
 
 ```
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp35-cp35m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp35-cp35m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp36-cp36m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp37-cp37m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp37-cp37m-win_amd64.whl
 pip3 install torchvision
 ```
 
@@ -162,19 +162,19 @@ _CUDA 8.x_
 
 ```
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp35-cp35m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp35-cp35m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp36-cp36m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp36-cp36m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp37-cp37m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp37-cp37m-win_amd64.whl
 pip3 install torchvision
 ```
 
@@ -183,19 +183,19 @@ _CUDA 10.0_
 
 ```
 # Python 3.5
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp35-cp35m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp35-cp35m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.6
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp36-cp36m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp36-cp36m-win_amd64.whl
 pip3 install torchvision
 ```
 
 ```
 # Python 3.7
-pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp37-cp37m-win_amd64.whl
+pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp37-cp37m-win_amd64.whl
 pip3 install torchvision
 ```
 

--- a/assets/quick-start-module.js
+++ b/assets/quick-start-module.js
@@ -172,49 +172,49 @@ $("[data-toggle='cloud-dropdown']").on("click", function(e) {
 function commandMessage(key) {
   var object = {
     "stable,conda,linux,cuda8,python2.7":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,linux,cuda9.0,python2.7":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,linux,cuda10.0,python2.7":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,linux,cudanone,python2.7":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
 
     "stable,conda,linux,cuda8,python3.5":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,linux,cuda9.0,python3.5":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,linux,cuda10.0,python3.5":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,linux,cudanone,python3.5":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
 
     "stable,conda,linux,cuda8,python3.6":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,linux,cuda9.0,python3.6":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,linux,cuda10.0,python3.6":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,linux,cudanone,python3.6":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
 
     "stable,conda,linux,cuda8,python3.7":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,linux,cuda9.0,python3.7":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,linux,cuda10.0,python3.7":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,linux,cudanone,python3.7":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
@@ -280,37 +280,37 @@ function commandMessage(key) {
       "# PyTorch does not support Python 2.7 on Windows. Please install with Python 3.",
 
     "stable,conda,windows,cuda8,python3.5":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,windows,cuda9.0,python3.5":
-      "conda install pytorch torchvision -c pytorch ",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch ",
 
     "stable,conda,windows,cuda10.0,python3.5":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,windows,cudanone,python3.5":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
 
     "stable,conda,windows,cuda8,python3.6":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,windows,cuda9.0,python3.6":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,windows,cuda10.0,python3.6":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,windows,cudanone,python3.6":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
 
     "stable,conda,windows,cuda8,python3.7":
-      "conda install pytorch torchvision cuda80 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=8.0 -c pytorch",
 
     "stable,conda,windows,cuda9.0,python3.7":
-      "conda install pytorch torchvision -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=9.0 -c pytorch",
 
     "stable,conda,windows,cuda10.0,python3.7":
-      "conda install pytorch torchvision cuda100 -c pytorch",
+      "conda install pytorch torchvision cudatoolkit=10.0 -c pytorch",
 
     "stable,conda,windows,cudanone,python3.7":
       "conda install pytorch-cpu torchvision-cpu -c pytorch",
@@ -360,48 +360,48 @@ function commandMessage(key) {
     "stable,pip,macos,cudanone,python3.7": "pip3 install torch torchvision",
 
     "stable,pip,linux,cudanone,python2.7":
-      "pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision <br/><br/> # if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp27-cp27m-linux_x86_64.whl",
+      "pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision <br/><br/> # if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp27-cp27m-linux_x86_64.whl",
 
     "stable,pip,linux,cuda8,python2.7":
-      "pip install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision<br/><br/># if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp27-cp27m-linux_x86_64.whl",
+      "pip install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision<br/><br/># if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp27-cp27m-linux_x86_64.whl",
 
     "stable,pip,linux,cuda9.0,python2.7": "pip install torch torchvision",
 
     "stable,pip,linux,cuda10.0,python2.7":
-      "pip install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision<br/><br/># if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp27-cp27m-linux_x86_64.whl",
+      "pip install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp27-cp27mu-linux_x86_64.whl<br/>pip install torchvision<br/><br/># if the above command does not work, then you have python 2.7 UCS2, use this command<br/>pip install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp27-cp27m-linux_x86_64.whl",
 
     "stable,pip,linux,cudanone,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda8,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda9.0,python3.5": "pip3 install torch torchvision",
 
     "stable,pip,linux,cuda10.0,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp35-cp35m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cudanone,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda8,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda9.0,python3.6": "pip3 install torch torchvision",
 
     "stable,pip,linux,cuda10.0,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp36-cp36m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cudanone,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda8,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,linux,cuda9.0,python3.7": "pip3 install torch torchvision",
 
     "stable,pip,linux,cuda10.0,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp37-cp37m-linux_x86_64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cudanone,python2.7":
       "# PyTorch does not support Python 2.7 on Windows. Please install with Python 3.",
@@ -416,40 +416,40 @@ function commandMessage(key) {
       "# PyTorch does not support Python 2.7 on Windows. Please install with Python 3.",
 
     "stable,pip,windows,cudanone,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda8,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda9.0,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda10.0,python3.5":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp35-cp35m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cudanone,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda8,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda9.0,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda10.0,python3.6":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp36-cp36m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cudanone,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.0-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cpu/torch-1.0.1-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda8,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.0-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu80/torch-1.0.1-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda9.0,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu90/torch-1.0.1-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,pip,windows,cuda10.0,python3.7":
-      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.0-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
+      "pip3 install https://download.pytorch.org/whl/cu100/torch-1.0.1-cp37-cp37m-win_amd64.whl<br/>pip3 install torchvision",
 
     "stable,libtorch,linux,cudanone,cplusplus":
       "Download here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-latest.zip</a>",
@@ -467,13 +467,13 @@ function commandMessage(key) {
       "Download here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-latest.zip </a>",
 
     "stable,libtorch,macos,cuda8,cplusplus":
-      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip </a>",
+      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip </a>",
 
     "stable,libtorch,macos,cuda9.0,cplusplus":
-      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip </a>",
+      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip </a>",
 
     "stable,libtorch,macos,cuda10.0,cplusplus":
-      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.0.zip </a>",
+      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip </a>",
 
     "stable,libtorch,windows,cudanone,cplusplus":
       "Download here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-latest.zip</a>",
@@ -488,49 +488,49 @@ function commandMessage(key) {
       "Download here: <br/><a href='https://download.pytorch.org/libtorch/cu100/libtorch-win-shared-with-deps-latest.zip'>https://download.pytorch.org/libtorch/cu100/libtorch-win-shared-with-deps-latest.zip</a>",
 
     "preview,conda,linux,cuda8,python2.7":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,linux,cuda9.0,python2.7":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,linux,cuda10.0,python2.7":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,linux,cudanone,python2.7":
       "conda install pytorch-nightly-cpu -c pytorch",
 
     "preview,conda,linux,cuda8,python3.5":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,linux,cuda9.0,python3.5":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,linux,cuda10.0,python3.5":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,linux,cudanone,python3.5":
       "conda install pytorch-nightly-cpu -c pytorch",
 
     "preview,conda,linux,cuda8,python3.6":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,linux,cuda9.0,python3.6":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,linux,cuda10.0,python3.6":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,linux,cudanone,python3.6":
       "conda install pytorch-nightly-cpu -c pytorch",
 
     "preview,conda,linux,cuda8,python3.7":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,linux,cuda9.0,python3.7":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,linux,cuda10.0,python3.7":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,linux,cudanone,python3.7":
       "conda install pytorch-nightly-cpu -c pytorch",
@@ -596,37 +596,37 @@ function commandMessage(key) {
       "# Preview Build With Python 2.7 On Windows Not Supported.",
 
     "preview,conda,windows,cuda8,python3.5":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,windows,cuda9.0,python3.5":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,windows,cuda10.0,python3.5":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,windows,cudanone,python3.5":
       "conda install pytorch-nightly-cpu -c pytorch",
 
     "preview,conda,windows,cuda8,python3.6":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,windows,cuda9.0,python3.6":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,windows,cuda10.0,python3.6":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,windows,cudanone,python3.6":
       "conda install pytorch-nightly-cpu -c pytorch",
 
     "preview,conda,windows,cuda8,python3.7":
-      "conda install pytorch-nightly cuda80 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=8.0 -c pytorch",
 
     "preview,conda,windows,cuda9.0,python3.7":
       "conda install pytorch-nightly -c pytorch",
 
     "preview,conda,windows,cuda10.0,python3.7":
-      "conda install pytorch-nightly cuda100 -c pytorch",
+      "conda install pytorch-nightly cudatoolkit=10.0 -c pytorch",
 
     "preview,conda,windows,cudanone,python3.7":
       "conda install pytorch-nightly-cpu -c pytorch",


### PR DESCRIPTION
- update cuda80 -> cudatoolkit=8.0
- update cuda100 -> cudatoolkit=10.0
- update default conda install command on linux and windows to use `cudatoolkit=9.0` explicitly

- update 1.0.0 to 1.0.1 everywhere else relevant.

cc: @pjh5 @peterjc123 