### PR TITLE
Fix typo

### DIFF
--- a/_get_started/installation/windows.md
+++ b/_get_started/installation/windows.md
@@ -256,7 +256,8 @@ conda install numpy pyyaml mkl mkl-include setuptools cmake cffi typing
 
 ```bash
 git clone --recursive https://github.com/pytorch/pytorch
-cd pytorchset "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build"
+cd pytorch
+set "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build"
 set CMAKE_GENERATOR=Visual Studio 15 2017 Win64
 set DISTUTILS_USE_SDK=1
 REM The following two lines are needed for Python 2.7, but the support for it is very experimental.


### PR DESCRIPTION
There is no directory named `pytorchset`. This should be a typo caused by a missing line break.