### PR TITLE
Add GA tracking for Get Started Module Cloud options

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -5,6 +5,7 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-90545585-1', 'auto');
+  ga('create', 'UA-117752657-2', 'auto', 'newCampaignTracker');
   ga('send', 'pageview');
 
 </script>

--- a/assets/track-events.js
+++ b/assets/track-events.js
@@ -1,11 +1,17 @@
 var trackEvents = {
   recordClick: function(eventCategory, eventLabel) {
     if (typeof ga == "function") {
-      ga('send', 'event', {
+      var gaEventObject = {
         eventCategory: eventCategory,
         eventAction: "click",
         eventLabel: eventLabel
-      });
+      };
+
+      ga('send', 'event', gaEventObject);
+
+      if (eventCategory == "Quick Start Module - Cloud Platforms") {
+        ga('newCampaignTracker.send', 'event', gaEventObject);
+      }
     }
 
     if (typeof fbq === "function") {


### PR DESCRIPTION
This PR adds additional Google Analytics event tracking for the Get Started Module Cloud options on the homepage. 