### PR TITLE
Add PyTorch hub

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ collections:
   ecosystem:
     output: true
     permalink: /ecosystem/:path/
+  hub:
+    output: true
+    permalink: /pytorch-hub/:title/
   case_studies:
     output: true
     permalink: /case-studies/:path/

--- a/_includes/footer_scripts.html
+++ b/_includes/footer_scripts.html
@@ -15,7 +15,7 @@
 
   scrollToAnchor.bind();
 
-  var hasStaticHeader = $(".blog-header, .blog-detail-header, .resources-header, .get-started-header, .features-header, .ecosystem-header").length > 0;
+  var hasStaticHeader = $(".blog-header, .blog-detail-header, .resources-header, .get-started-header, .features-header, .ecosystem-header, .pytorch-hub-header").length > 0;
 
   if (!hasStaticHeader) {
     $(window).on("scroll", function() {

--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -8,8 +8,27 @@
       <a href="{{ site.baseurl }}/features">Features</a>
     </li>
 
-    <li class="main-menu-item {% if current[1] == 'ecosystem' %}active{% endif %}">
-      <a href="{{ site.baseurl }}/ecosystem">Ecosystem</a>
+    <li class="main-menu-item {% if current[1] == 'ecosystem' or current[1] == 'pytorch-hub' %}active{% endif %}">
+
+      <div class="ecosystem-dropdown">
+        <a id="dropdownMenuButton" data-toggle="ecosystem-dropdown">
+          Ecosystem
+        </a>
+        <div class="ecosystem-dropdown-menu">
+          <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/pytorch-hub">
+            <span class=dropdown-title>Models (Beta)</span>
+            <p>Discover, publish, and reuse pre-trained models</p>
+          </a>
+          <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/ecosystem">
+            <span class=dropdown-title>Tools & Libraries</span>
+            <p>Explore the ecosystem of tools and libraries</p>
+          </a>
+          <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/ecosystem/join">
+            <span class=dropdown-title>Join</span>
+            <p>Submit your project and join the community</p>
+          </a>
+        </div>
+      </div>
     </li>
 
     <li class="main-menu-item {% if current[1] == 'blog' %}active{% endif %}">
@@ -45,3 +64,17 @@
     </li>
   </ul>
 </div>
+
+<script>
+  var menu = ".ecosystem-dropdown-menu";
+  var showMenuClass = "show-menu";
+
+$("[data-toggle='ecosystem-dropdown']").on("click", function(e) {
+  if ($(menu).hasClass(showMenuClass)) {
+    $(menu).removeClass(showMenuClass);
+  } else {
+    $("[data-toggle='ecosystem-dropdown'].show-menu").removeClass(showMenuClass);
+    $(menu).addClass(showMenuClass);
+  }
+});
+</script>

--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -35,6 +35,10 @@
           <a href="{{ site.baseurl }}/ecosystem">Ecosystem</a>
         </li>
 
+        <li class="{% if current[1] == 'pytorch-hub' %}active{% endif %}">
+          <a href="{{ site.baseurl }}/pytorch-hub">PyTorch Hub</a>
+        </li>
+
         <li class="{% if current[1] == 'blog' %}active{% endif %}">
           <a href="{{ site.baseurl }}/blog">Blog</a>
         </li>

--- a/_layouts/pytorch_hub_detail.html
+++ b/_layouts/pytorch_hub_detail.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include head.html %}
+  <body class="{{ page.body-class }} hub-detail">
+    {% include header.html %}
+
+    <div class="main-background {{ page.background-class }} hub-detail-background"></div>
+
+    <div class="jumbotron jumbotron-fluid">
+      <div class="container">
+        <img src="{{ site.baseurl }}/assets/images/pytorch-hub-arrow.svg"></img>
+        <h1>
+          <span class="detail-arrow"><a href="{{ site.baseurl }}/pytorch-hub"><</a></span> <br>
+          {{ page.title }}
+        </h1>
+
+        <div class="row">
+          <div class="col-md-6">
+            <p class="detail-lead">By {{ page.author }} </p>
+          </div>
+
+          <div class="col-md-6">
+            <p class="detail-lead lead-summary">{{ page.summary }}</p>
+            <button class="btn btn-lg with-right-white-arrow detail-github-link"><a href="{{ page.github-link }}">View on Github</a></button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="main-content-wrapper">
+      <div class="main-content">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-6">
+              <img src="{{ site.baseurl }}/assets/images/{{ page.featured_image_1 }}" data-image-name="{{ page.featured_image_1 }}" class="featured-image img-fluid">
+              <img src="{{ site.baseurl }}/assets/images/{{ page.featured_image_2 }}" data-image-name="{{ page.featured_image_2 }}" class="featured-image img-fluid">
+            </div>
+            <div class="col-md-6">
+              <article class="pytorch-article">
+                {{ content }}
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {% include footer.html %}
+  </body>
+</html>
+
+<script>
+  $('.featured-image').each(function() {
+    if ($(this).data("image-name") == "no-image") {
+      $(this).hide();
+    }
+  });
+</script>

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -18,6 +18,8 @@ $smoky_grey: #CCCDD1;
 $medium_smoky_grey: #CCCDD1;
 $code_link_color: #4974D1;
 $purple: #812CE5;
+$light_white: #e2e2e2;
+$mid_gray: #979797;
 
 $desktop_header_height: 90px;
 $mobile_header_height: 68px;

--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -128,8 +128,16 @@ a, .btn {
     background-image: url($baseurl + "/assets/images/home-background.jpg");
   }
 
+  &.pytorch-hub-background {
+    background-color: $light_grey;
+  }
+
    &.ecosystem-background {
-    background-image: url($baseurl + "/assets/images/ecosystem-background.jpg");
+    background-color: $light_grey;
+  }
+
+  &.ecosystem-join-background {
+    background-color: $light_grey;
   }
 
    &.ecosystem-detail-background {
@@ -422,7 +430,8 @@ a, .btn {
 }
 
 .ecosystem-card,
-.resource-card {
+.resource-card,
+.hub-card {
   border-radius: 0;
   border: none;
   height: 110px;

--- a/_sass/ecosystem.scss
+++ b/_sass/ecosystem.scss
@@ -1,15 +1,23 @@
 .ecosystem .jumbotron {
   height: 170px;
   @include desktop {
-    height: 239px;
+    height: 300px;
   }
 
   h1 {
-    padding-top: rem(35px);
+    padding-top: rem(125px);
+    #ecosystem-header {
+      color: #CC2FAA;
+    }
+    #ecosystem-header-tools {
+      color: not_quite_black;
+    }
   }
 
   p.lead {
     margin-bottom: rem(25px);
+    padding-top: rem(50px);
+    color: $dark_grey;
   }
 
   svg {
@@ -21,7 +29,7 @@
   height: 275px;
 
   @include desktop {
-    height: 349px;
+    height: 395px;
   }
 }
 
@@ -35,7 +43,7 @@
   background-color: $light_grey;
 
   @include desktop {
-    margin-top: 260px + $desktop_header_height;
+    margin-top: 305px + $desktop_header_height;
   }
   margin-top: 275px;
 }
@@ -172,17 +180,17 @@
       color: $black;
       span {
         font-weight: 300;
-        color: #812CE5;
+        color: $purple;
       }
     }
   }
 
   .join-wrapper {
-    background-color: $white;
+    background-color: $light_grey;
 
     .main-content {
       @include desktop {
-        padding-top: 4.4rem;
+        padding-top: 1.5rem;
       }
     }
 
@@ -258,7 +266,6 @@
 
     input, textarea {
       width: 100%;
-      background-color: #F1F2F6;
       border: none;
       border-bottom: 2px solid $purple;
       height: rem(44px);

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -21,7 +21,8 @@
   &.resources-header,
   &.get-started-header,
   &.features-header,
-  &.ecosystem-header {
+  &.ecosystem-header,
+  &.pytorch-hub-header {
     background-color: $white;
     border-bottom: 1px solid #e2e2e2;
   }
@@ -204,7 +205,8 @@
 .resources-header,
 .get-started-header,
 .features-header,
-.ecosystem-header {
+.ecosystem-header,
+.pytorch-hub-header {
   .header-logo {
     background-image: url($baseurl + "/assets/images/logo-dark.svg");
   }
@@ -216,4 +218,109 @@
   .main-menu-open-button {
     background-image: url($baseurl + "/assets/images/icon-menu-dots-dark.svg");
   }
+}
+
+.main-menu ul li {
+  .ecosystem-dropdown a {
+    cursor: pointer;
+  }
+
+  .dropdown-menu {
+    border-radius: 0;
+    padding: 0;
+
+    .dropdown-item {
+      color: $dark_grey;
+      border-bottom: 1px solid #e2e2e2;
+      &:last-of-type {
+        border-bottom-color: transparent;
+      }
+
+      &:hover {
+        background-color: $orange;
+      }
+
+      p {
+        font-size: rem(16px);
+        color: #979797;
+      }
+    }
+
+    a.dropdown-item {
+      &:hover {
+        color: $white;
+        p {
+          color: $white;
+        }
+      }
+    }
+  }
+}
+
+.ecosystem-dropdown-menu {
+  left: -75px;
+  width: 226px;
+  display: none;
+  position: absolute;
+  top: rem(50px);
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 10rem;
+  padding: 0.5rem 0;
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  color: #212529;
+  text-align: left;
+  list-style: none;
+  background-color: $white;
+  background-clip: padding-box;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.25rem;
+}
+
+.ecosystem-dropdown-menu.show-menu {
+  display: block;
+}
+
+.main-menu ul li .ecosystem-dropdown-menu {
+  border-radius: 0;
+  padding: 0;
+}
+
+.main-menu ul li .ecosystem-dropdown-menuu .ecosystem-dropdown-item {
+  color: #6c6c6d;
+  border-bottom: 1px solid #e2e2e2;
+}
+
+.header-holder .main-menu ul li a.ecosystem-dropdown-item {
+  display: block;
+  font-size: rem(16px);
+  line-height: rem(21px);
+  width: 100%;
+  padding: 0.25rem 1.5rem;
+  clear: both;
+  font-weight: 400;
+  color: #979797;
+  text-align: center;
+  background-color: transparent;
+  border-bottom: 1px solid #e2e2e2;
+  &:last-of-type {
+    border-bottom-color: transparent;
+  }
+  &:hover {
+    background-color: $orange;
+    color: white;
+  }
+  .dropdown-title {
+    font-size: rem(18px);
+    color: $dark_grey;
+    letter-spacing: 0;
+    line-height: 34px;
+  }
+}
+
+.header-holder .main-menu ul li a.ecosystem-dropdown-item:hover .dropdown-title {
+  background-color: $orange;
+  color: white;
 }

--- a/_sass/pytorch-hub.scss
+++ b/_sass/pytorch-hub.scss
@@ -1,0 +1,389 @@
+.pytorch-hub .jumbotron {
+  height: 280px;
+  @include desktop {
+    height: 300px;
+  }
+
+  h1 {
+    padding-top: rem(120px);
+    #pytorch-hub-header, #pytorch-hub-sub-header {
+      color: $orange;
+      font-weight: lighter;
+    }
+    #pytorch-hub-sub-header {
+      color: not_quite_black;
+    }
+  }
+
+  p.lead, p.hub-release-message {
+    margin-bottom: rem(25px);
+    padding-top: rem(35px);
+    color: $dark_grey;
+
+    @include desktop {
+      width: 77%;
+    }
+  }
+
+  p.hub-release-message {
+    padding-top: 0;
+    font-style: italic;
+  }
+
+  svg {
+    margin-bottom: rem(20px);
+  }
+
+  p.detail-lead {
+    padding-top: rem(50px);
+    color: $mid_gray;
+    width: 100%;
+    margin-bottom: 0px;
+  }
+
+  p.lead-summary {
+    color: $dark_grey;
+  }
+}
+
+.pytorch-hub .detail-github-link {
+  margin-top: rem(45px);
+  background: $orange;
+  a {
+    color: $white;
+    padding-right: rem(50px);
+  }
+}
+
+.pytorch-hub .detail-arrow {
+  color: $orange;
+}
+
+.pytorch-hub .with-right-white-arrow {
+  padding-right: rem(32px);
+  position: relative;
+  background-image: url($baseurl + "/assets/images/chevron-right-white.svg");
+  background-size: 6px 13px;
+  background-position: top 10px right 11px;
+  background-repeat: no-repeat;
+  @include desktop {
+    background-size: 8px 14px;
+    background-position: top 15px right 12px;
+    padding-right: rem(32px);
+  }
+}
+
+.pytorch-hub .main-content {
+  padding-top: rem(140px);
+  @include desktop {
+    padding-top: rem(135px);
+  }
+}
+
+.pytorch-hub.hub-detail  .main-content {
+  padding-top: rem(200px);
+  @include desktop {
+    padding-top: rem(150px);
+  }
+}
+
+.pytorch-hub.hub-detail .jumbotron {
+  height: 100px;
+  @include desktop {
+    height: 100px;
+  }
+}
+
+.pytorch-hub .main-content-wrapper {
+  background-color: $light_grey;
+
+  @include desktop {
+    margin-top: 305px + $desktop_header_height;
+  }
+  margin-top: 275px;
+}
+
+.pytorch-hub.hub-detail .main-content-wrapper {
+  @include desktop {
+    margin-top: 270px + $desktop_header_height;
+  }
+  margin-top: 275px;
+}
+
+.pytorch-hub .hub-cards-wrapper, .hub-cards-wrapper-right {
+  margin-bottom: rem(18px);
+  padding-top: rem(20px);
+
+  .card-body {
+    .card-summary {
+      width: 75%;
+    }
+    .hub-image {
+      position: absolute;
+      top: 0px;
+      right: 0px;
+      height: 100%;
+      width: 25%;
+      img {
+        height: 100%;
+        width: 100%;
+      }
+      &:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        z-index: 1;
+        background: #000000;
+        opacity: .075;
+      }
+    }
+  }
+}
+
+.pytorch-hub .github-stars-image {
+  height: 8px;
+  width: 8px;
+  margin-left: rem(15px);
+  position: relative;
+  top: rem(2px);
+  @include desktop {
+    height: 9px;
+    width: 9px;
+  }
+}
+
+.pytorch-hub .github-stars-count {
+  margin-left: rem(5px);
+  color: $mid_gray;
+  position: relative;
+  top: rem(3px);
+}
+
+.pytorch-hub .detail-count {
+  font-size: rem(20px);
+}
+
+.pytorch-hub .detail-stars-container {
+  display: inline-flex;
+  .github-stars-image {
+    margin-left: 0;
+  }
+}
+
+.pytorch-hub .card-body {
+  .hub-card-title-container {
+    display: inline-flex;
+      .experimental-badge {
+        text-transform: uppercase;
+        margin-left: rem(15px);
+        background-color: #e4e4e4;
+        color: $not_quite_black;
+        opacity: 0.75;
+        font-size: rem(10px);
+        letter-spacing: 1px;
+        line-height: rem(22px);
+        height: rem(20px);
+        width: rem(96px);
+        text-align: center;
+        margin-top: rem(4px);
+    }
+  }
+}
+
+.pytorch-hub .pytorch-hub-filter-menu {
+  ul {
+    list-style-type: none;
+    padding-left: rem(20px);
+    li {
+      padding-right: rem(20px);
+      word-break: break-all;
+
+      a {
+      color: $mid_gray;
+      &:hover {
+        color: $orange;
+        }
+      }
+    }
+  }
+}
+
+.pytorch-hub .hub-filter {
+  cursor: pointer;
+}
+
+.pytorch-hub #dropdownFilter, #dropdownSort, #dropdownSortLeft {
+  color: $mid_gray;
+  cursor: pointer;
+}
+
+.pytorch-hub #dropdownSort, #dropdownSortLeft {
+  margin-left: rem(100px);
+}
+
+.pytorch-hub .sort-menu {
+  left: 63%;
+  @include desktop {
+    left: 25%;
+  }
+}
+
+.pytorch-hub .research-hub-title,
+.research-hub-sub-title {
+  text-transform: uppercase;
+  letter-spacing: 1.78px;
+  line-height: rem(32px);
+}
+
+.research-hub-sub-title {
+  padding-bottom: rem(20px);
+}
+
+.pytorch-hub .research-hub-title {
+  color: $orange;
+}
+
+.pytorch-hub .all-models-button, .full-docs-button {
+  font-size: 1.125rem;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+  padding: rem(10px) rem(30px) rem(10px) rem(20px);
+  background-color: $white;
+  margin-bottom: 0.125rem;
+  border: 2px solid $light_grey;
+  letter-spacing: -0.25px;
+  line-height: rem(28px);
+  color: $dark_grey;
+  background-image: url($baseurl + "/assets/images/chevron-right-orange.svg");
+  background-size: 6px 13px;
+  background-position: center right 10px;
+  background-repeat: no-repeat;
+  a {
+    color: $dark_grey;
+  }
+
+  @include animated_border_hover_state;
+}
+
+.pytorch-hub .hub-column {
+  padding-bottom: rem(75px);
+}
+
+.pytorch-hub .how-it-works {
+  padding-top: rem(50px);
+  padding-bottom: rem(45px);
+  .how-it-works-text {
+    color: $dark_grey;
+    font-size: rem(20px);
+    letter-spacing: 0;
+    line-height: rem(30px);
+  }
+  .how-it-works-title-col {
+    padding-bottom: rem(55px);
+  }
+  .full-docs-button {
+    margin-top: rem(30px);
+  }
+}
+
+.pytorch-hub .hub-code-text {
+  font-size: 80%;
+  color: $not_quite_black;
+  background-color: $light_white;
+  padding: 2px;
+}
+
+.pytorch-hub .hub-code-block {
+  display: block;
+  border-left: 3px solid $orange;
+  padding: rem(20px) rem(25px) rem(20px) rem(25px);
+  margin-bottom: rem(60px);
+}
+
+.pytorch-hub pre.highlight {
+    background-color: $light_white;
+    border-left: 2px solid $orange;
+}
+
+.pytorch-hub code.highlighter-rouge {
+  background-color: $light_white;
+}
+
+.pytorch-hub article {
+  padding-top: rem(20px);
+  @include desktop {
+    padding-top: 0;
+  }
+  p {
+    color: $slate;
+  }
+}
+
+.pytorch-hub .hub-detail-background {
+  @include desktop {
+    height: 515px;
+  }
+}
+
+.pytorch-hub .dropdown-menu {
+  border-radius: 0;
+}
+
+.pytorch-hub .card {
+  &:hover {
+    .hub-image:before {
+      bottom: 100%;
+    }
+  }
+}
+
+.pytorch-hub.pytorch-hub.hub-detail {
+  .github-stars-image {
+    img {
+      @include desktop {
+        height: 10px
+      }
+      height: 9px
+    }
+  }
+}
+
+.pytorch-hub .hub-card {
+  height: auto;
+  @include max-width-desktop {
+    height: 150px;
+  }
+
+  @include small-desktop {
+    height: 170px;
+  }
+}
+
+.pytorch-hub #development-models-hide, #research-models-hide {
+  display: none;
+}
+
+.pytorch-hub .col-md-6.hub-column {
+  @media (min-width: 768px) {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  @include max-width-desktop {
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+}
+
+.pytorch-hub .featured-image {
+  padding-bottom: rem(20px);
+}
+
+.pytorch-hub .coming-soon {
+  font-weight: 300;
+  font-style: italic;
+}

--- a/assets/images/filter-arrow.svg
+++ b/assets/images/filter-arrow.svg
@@ -1,0 +1,13 @@
+<svg width="9px" height="6px" viewBox="0 0 9 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Desktop" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Eco_Landing-Option2" transform="translate(-788.000000, -806.000000)" fill="#979797" fill-rule="nonzero">
+            <g id="RESEARCH" transform="translate(98.000000, 609.000000)">
+                <g id="Group-4" transform="translate(640.000000, 0.000000)">
+                    <g id="Filterted-By" transform="translate(2.000000, 186.000000)">
+                        <polygon id="Triangle" transform="translate(52.500000, 14.000000) scale(1, -1) translate(-52.500000, -14.000000) " points="52.5 11 57 17 48 17"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/images/github-star.svg
+++ b/assets/images/github-star.svg
@@ -1,0 +1,17 @@
+
+<svg width="10px" height="9px" viewBox="0 0 10 9" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Desktop" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Eco_Landing_FilterSort" transform="translate(-195.000000, -1441.000000)">
+            <rect fill="transparent" x="0" y="0" width="1440" height="4736"></rect>
+            <g id="RESEARCH" transform="translate(99.000000, 735.000000)" fill="#979797">
+                <g id="Card-5" transform="translate(1.000000, 671.000000)">
+                    <g id="GitHub" transform="translate(94.000000, 26.000000)">
+                        <g id="Star" transform="translate(0.000000, 8.000000)">
+                            <polygon id="Fill-1" points="5.99955952 1 4.53183169 4.06323077 1 4.43776923 3.62476875 6.70542308 2.90959366 10 5.99955952 8.33823077 9.08940634 10 8.37435029 6.70542308 10.999 4.43776923 7.46728735 4.06323077"></polygon>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/images/pytorch-hub-arrow.svg
+++ b/assets/images/pytorch-hub-arrow.svg
@@ -1,0 +1,12 @@
+
+<svg width="365px" height="196px" viewBox="0 0 365 196" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Desktop" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" font-family="Avenir-Book, Avenir" font-size="72" font-weight="normal" letter-spacing="2" line-spacing="77">
+        <g id="Eco_SubPage" transform="translate(-98.000000, -249.000000)">
+            <g id="Header" transform="translate(95.000000, 229.000000)">
+                <text id="&lt;-Sollicitudin-Matti">
+                    <tspan x="0" y="72" fill="#EE4C2C">&lt;</tspan>
+                </text>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -27,3 +27,4 @@ $baseurl:"{{ site.baseurl }}";
 @import "similar-posts-module";
 @import "search";
 @import "cookie-banner";
+@import "pytorch-hub";

--- a/assets/pytorch-hub-buttons.js
+++ b/assets/pytorch-hub-buttons.js
@@ -1,0 +1,40 @@
+var numberOfCardsToShow = 3;
+
+$(".cards-left > .col-md-12, .cards-right > .col-md-12")
+  .filter(function() {
+    return $(this).attr("data-item-count") > numberOfCardsToShow.toString();
+  })
+  .hide();
+
+$("#development-models").on("click", function() {
+  showCards(this, "#development-models-hide", ".cards-right > .col-md-12");
+});
+
+$("#development-models-hide").on("click", function() {
+  hideCards(this, "#development-models", ".cards-right > .col-md-12");
+});
+
+$("#research-models").on("click", function() {
+  showCards(this, "#research-models-hide", ".cards-left > .col-md-12");
+});
+
+$("#research-models-hide").on("click", function() {
+  hideCards(this, "#research-models", ".cards-left > .col-md-12");
+});
+
+function showCards(buttonToHide, buttonToShow, cardsWrapper) {
+  $(buttonToHide).hide();
+  $(buttonToShow)
+    .add(cardsWrapper)
+    .show();
+}
+
+function hideCards(buttonToHide, buttonToShow, cardsWrapper) {
+  $(buttonToHide).hide();
+  $(buttonToShow).show();
+  $(cardsWrapper)
+    .filter(function() {
+      return $(this).attr("data-item-count") !== numberOfCardsToShow.toString();
+    })
+    .hide();
+}

--- a/assets/pytorch-hub-filter.js
+++ b/assets/pytorch-hub-filter.js
@@ -1,0 +1,52 @@
+$(".hub-filter[data-tag]").on("click", function(e) {
+  e.preventDefault();
+  var tag = $(this).data("tag");
+
+  if (tag) {
+    showCardsByTag(tag, ".research-hub-card-wrapper", "tags");
+  } else {
+    $(".hub-filter").show();
+  }
+
+  updateMenuSelection(tag, ".research-menu .hub-filter", "data-tag");
+});
+
+$(".right-hub-filter[data-right-tag]").on("click", function(e) {
+  e.preventDefault();
+  var rightTag = $(this).data("right-tag");
+
+  if (rightTag) {
+    showCardsByTag(rightTag, ".hub-card-wrapper", "right-tags");
+  } else {
+    $(".hub-filter").show();
+  }
+
+  updateMenuSelection(
+    rightTag,
+    ".development-menu .right-hub-filter",
+    "data-right-tag"
+  );
+});
+
+function showCardsByTag(tag, wrapper, dataTags) {
+  if (tag === "all") {
+    $(wrapper).show();
+    return;
+  }
+
+  $(wrapper).each(function(i, el) {
+    var targets = $(el)
+      .data(dataTags)
+      .split(",");
+    if (targets.indexOf(tag) > -1) {
+      $(el).show();
+    } else {
+      $(el).hide();
+    }
+  });
+}
+
+function updateMenuSelection(tag, menu, dataTags) {
+  $(menu).removeClass("selected");
+  $(menu + "[" + dataTags + "=" + tag + "]").addClass("selected");
+}

--- a/assets/pytorch-hub-sort.js
+++ b/assets/pytorch-hub-sort.js
@@ -1,0 +1,31 @@
+var $wrapper = $(".cards-right");
+var $leftWrapper = $(".cards-left");
+
+$("#sortLow").on("click", function() {
+  sorter("low", $wrapper);
+});
+
+$("#sortHigh").on("click", function() {
+  sorter("high", $wrapper);
+});
+
+$("#sortLowLeft").on("click", function() {
+  sorter("low", $leftWrapper);
+});
+
+$("#sortHighLeft").on("click", function() {
+  sorter("high", $leftWrapper);
+});
+
+function sorter(type, wrapper) {
+  wrapper
+    .find(".col-md-12")
+    .sort(function(a, b) {
+      if (type == "high") {
+        return b.dataset.count - a.dataset.count;
+      } else {
+        return a.dataset.count - b.dataset.count;
+      }
+    })
+    .appendTo(wrapper);
+}

--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -6,13 +6,15 @@ background-class: ecosystem-background
 body-class: ecosystem
 ---
 
-<div class="jumbotron jumbotron-fluid on-dark-background">
+<div class="jumbotron jumbotron-fluid">
   <div class="container">
-    <h1>Ecosystem</h1>
+    <h1>
+      <span id="ecosystem-header">Ecosystem</span> <br>
+      <span id="ecosystem-header-tools">Tools</span>
+    </h1>
 
     <p class="lead">Tap into a rich ecosystem of tools, libraries, and more to support, accelerate, and explore AI development.</p>
 
-    <p><a class="join-link" href="{{ site.baseurl }}/ecosystem/join">Join the PyTorch ecosystem</a></p>
   </div>
 </div>
 

--- a/ecosystem/join.html
+++ b/ecosystem/join.html
@@ -3,11 +3,12 @@ layout: default
 title: Join
 permalink: ecosystem/join.html
 body-class: ecosystem
+background-class: ecosystem-join-background
 ---
 
 <div class="jumbotron jumbotron-fluid join-jumbotron">
   <div class="container">
-    <h1>Join The<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span>Pytorch Ecosystem</span></h1>
+    <h1><span>Join The</span> <br>Ecosystem</h1>
 
   </div>
 </div>

--- a/pytorch-hub.html
+++ b/pytorch-hub.html
@@ -1,0 +1,224 @@
+---
+layout: default
+title: PyTorch Hub
+permalink: pytorch-hub.html
+background-class: pytorch-hub-background
+body-class: pytorch-hub
+---
+
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h1>
+      <span id="pytorch-hub-header">PyTorch</span> <br>
+      <span id="pytorch-hub-sub-header"></span>Hub</span>
+    </h1>
+
+    <p class="lead">Discover and publish models to a pre-trained model repository designed for both research exploration and development needs.
+      Check out the models for <a href="#model-row">Researchers</a> and <a href="#model-row">Developers</a>, or learn <a href="https://pytorch.org/docs/stable/hub.html">How It Works</a>.</p>
+    <p class="hub-release-message">*This is a beta release - we will be collecting feedback and improving the PyTorch Hub over the coming months.</p>
+  </div>
+</div>
+
+<div class="main-content-wrapper">
+  <div class="main-content">
+    <div class="container">
+      <!-- START CONTENT -->
+      <div class="row" id="model-row">
+        <div class="col-md-6 hub-column">
+          <h3 class="research-hub-title">For Researchers —</h3>
+          <h3 class="research-hub-sub-title">Explore and extend models<br> from the latest <br>cutting edge research</h3>
+
+          <nav class="navbar navbar-expand-lg navbar-light research-menu">
+            <a id="dropdownFilter" data-toggle="dropdown" data-target="#dropdownFilterLeft">
+              Filter <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
+            </a>
+
+            <div class="dropdown-menu" id="dropdownFilterLeft">
+              {% assign all_tags = site.hub | where: "category", "researchers" | map: "tags" | join: ',' | split: ',' | uniq | sort %}
+
+              <div class="pytorch-hub-filter-menu">
+                <ul>
+                  <li>
+                    <a class="hub-filter" data-tag="all" href="#">All</a>
+                  </li>
+                  {% for tag in all_tags %}
+                    <li>
+                      <a class="hub-filter" data-tag="{{ tag }}" href="#{{ tag }}">{{ tag | capitalize }}</a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+            <!--
+            <a id="dropdownSortLeft" data-toggle="dropdown" data-target="#dropdownSortMenuLeft" >
+              Sort <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
+            </a>
+
+            <div class="dropdown-menu sort-menu" id="dropdownSortMenuLeft">
+              <div class="pytorch-hub-filter-menu">
+                <ul>
+                  <li>
+                    <a class= "hub-filter" id="sortLowLeft">Lowest</a>
+                  </li>
+
+                  <li>
+                    <a class= "hub-filter" id="sortHighLeft">Highest</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          -->
+          </nav>
+
+          <hr>
+
+          <div class="row hub-cards-wrapper">
+            {% assign hub = site.hub | where: "category", "researchers" | sort: "order" %}
+
+            <div class="cards-left">
+              {% for item in hub %}
+                <div class="col-md-12 research-hub-card-wrapper" data-item-count="{{ forloop.index }}" data-tags="{{ item.tags | join: ',' }}">
+                  <div class="card hub-card">
+                    <a href="{{ site.baseurl }}{{ item.url }}">
+                      <div class="card-body">
+                        <div class="hub-card-title-container">
+                          <h4>{{ item.title }}</h4>
+                        </div>
+                        <p class="card-summary">{{ item.summary }}</p>
+                        <div class="hub-image">
+                          <img src="{{ site.baseurl }}/assets/images/{{ item.image }}">
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+
+            <div class="col-md-12">
+              <button class="all-models-button" id="research-models">All Research Models ({{ hub | size}})</button>
+              <button class="all-models-button" id="research-models-hide">Fewer Research Models</button>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="col-md-6 hub-column">
+          <h3 class="research-hub-title">For Developers —</h3>
+          <h3 class="research-hub-sub-title">Get plug & play models<br> to accelerate <br> ML development</h3>
+
+          <h5 class="coming-soon">Coming Soon</h5>
+          <!--
+          <nav class="navbar navbar-expand-lg navbar-light development-menu">
+            <a id="dropdownFilter" data-toggle="dropdown" data-target="#dropdownFilterRight" >
+              Filter <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
+            </a>
+
+            <div class="dropdown-menu" id="dropdownFilterRight">
+              {% assign all_tags = site.hub | where: "category", "developers" | map: "tags" | join: ',' | split: ',' | uniq | sort %}
+
+              <div class="pytorch-hub-filter-menu">
+                <ul>
+                  <li>
+                    <a class="right-hub-filter" data-right-tag="all" href="#">All</a>
+                  </li>
+                  {% for tag in all_tags %}
+                    <li>
+                      <a class="right-hub-filter" data-right-tag="{{ tag }}" href="#{{ tag }}">{{ tag | capitalize }}</a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+            <!--
+            <a id="dropdownSort" data-toggle="dropdown" data-target="#dropdownSortMenu" >
+              Sort <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
+            </a>
+
+            <div class="dropdown-menu sort-menu" id="dropdownSortMenu">
+              <div class="pytorch-hub-filter-menu">
+                <ul>
+                  <li>
+                    <a class= "hub-filter" id="sortLow">Lowest</a>
+                  </li>
+
+                  <li>
+                    <a class= "hub-filter" id="sortHigh">Highest</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+          </nav>
+
+          <hr>
+
+          <div class="row hub-cards-wrapper">
+            {% assign hub = site.hub | where: "category", "developers" | sort: "order" %}
+
+            <div class="cards-right">
+              {% for item in hub %}
+                <div class="col-md-12 hub-card-wrapper" data-item-count="{{ forloop.index }}" data-right-tags="{{ item.tags | join: ',' }}">
+                  <div class="card hub-card">
+                    <a href="{{ site.baseurl }}{{ item.url }}">
+                      <div class="card-body">
+                        <div class="hub-card-title-container">
+                          <h4>{{ item.title }} </h4>
+                        </div>
+                        <p class="card-summary">{{ item.summary }}</p>
+                        <div class="hub-image">
+                          <img src="{{ site.baseurl }}/assets/images/{{ item.image }}">
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+
+            <div class="col-md-12">
+              <button class="all-models-button" id="development-models">All Development Models ({{ hub | size}})</button>
+              <button class="all-models-button" id="development-models-hide">Fewer Development Models</button>
+            </div>
+          </div>
+          -->
+        </div>
+      </div>
+
+      <div class="row how-it-works">
+        <div class="col-md-12 how-it-works-title-col">
+          <h3 class="research-hub-title">How it works —</h3>
+        </div>
+        <div class="col-md-6">
+          <h3 class="research-hub-sub-title">Publishing Models</h3>
+
+          <div class="row">
+            <div class="col-md-12">
+              <div class="how-it-works-text">
+                PyTorch Hub supports publishing pre-trained models (model definitions and pre-trained weights) to a GitHub repository by adding a simple <code class="hub-code-text">hubconf.py</code> file.
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <h3 class="research-hub-sub-title">Loading models</h3>
+
+          <div class="row">
+            <div class="col-md-12">
+              <div class="how-it-works-text">
+                Users can load pre-trained models using <code class="hub-code-text">torch.hub.load()</code> API.
+              </div>
+              <p class="how-it-works-text">Here’s an example showing how to load the <code class="hub-code-text">resnet18</code> entrypoint from the <code class="hub-code-text">pytorch/vision</code> repo.</p>
+              <p class="how-it-works-text"><code class="hub-code-text hub-code-block">model = torch.hub.load('pytorch/vision', 'resnet18', pretrained=True)</code></p>
+              <button class="full-docs-button"><a href="https://pytorch.org/docs/stable/hub.html">See Full Documentation</a></button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="{{ site.baseurl }}/assets/pytorch-hub-filter.js"></script>
+<script src="{{ site.baseurl }}/assets/pytorch-hub-buttons.js"></script>


### PR DESCRIPTION
This PR:

- Adds the PyTorch Hub page
- Adds the PyTorch Hub detail page for each hub "card"
- Updates the design of the ecosystem page
- Updates the design of the ecosystem join page
- Adds an ecosystem dropdown menu to the main nav

This PR does not include the "_hub" collection folder since it will be added to the repo as a submodule. Here is a preview that includes hub card examples: https://5cd48e0007ee45dcf5569b96--shiftlab-pytorch-github-io.netlify.com/pytorch-hub.