### PR TITLE
Fix duplicate word in torchvision 0.3 post

### DIFF
--- a/_posts/2019-5-22-torchvision03.md
+++ b/_posts/2019-5-22-torchvision03.md
@@ -5,7 +5,7 @@ author: Francisco Massa
 redirect_from: /2019/05/23/torchvision03.html
 ---
 
-PyTorch domain libraries like torchvision enable provide convenient access to common datasets and models that can be used to quickly create a state-of-the-art baseline. Moreover, they also provide common abstractions to reduce boilerplate code that users might have to otherwise repeatedly write. The torchvision 0.3 release brings several new features including models for semantic segmentation, object detection, instance segmentation, and person keypoint detection, as well as custom C++ / CUDA ops specific to computer vision.
+PyTorch domain libraries like torchvision provide convenient access to common datasets and models that can be used to quickly create a state-of-the-art baseline. Moreover, they also provide common abstractions to reduce boilerplate code that users might have to otherwise repeatedly write. The torchvision 0.3 release brings several new features including models for semantic segmentation, object detection, instance segmentation, and person keypoint detection, as well as custom C++ / CUDA ops specific to computer vision.
 
 <div class="text-center">
   <img src="{{ site.url }}/assets/images/torchvision_0.3_headline.png" width="100%">


### PR DESCRIPTION
Remove `enable`, keeping only `provide`

Before
> libraries like torchvision enable provide convenient

After
> libraries like torchvision provide convenient