### PR TITLE
pushd not available in sh

### DIFF
--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ideas used from https://gist.github.com/motemen/8595451
 
 # Based on https://github.com/eldarlabs/ghpages-deploy-script/blob/master/scripts/deploy-ghpages.sh


### PR DESCRIPTION
sh on osx knows about pushd but it doesn't on Linux sh. https://stackoverflow.com/questions/5193048/bin-sh-pushd-not-found
Try changing the script to run bash, unless we had a particular reason to use sh. At least it runs fine on my mac. 