### PR TITLE
Ecosystem Dropdown Changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ external_urls:
   github: https://github.com/pytorch/pytorch
   github_issues: https://github.com/pytorch/pytorch/issues
   contributing: https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md
+  hub_template: https://github.com/pytorch/hub/blob/master/docs/template.md
   twitter: https://twitter.com/pytorch
   facebook: https://www.facebook.com/pytorch
   slack: https://goo.gl/forms/PP1AGvNHpSaJP8to1

--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -23,10 +23,6 @@
             <span class=dropdown-title>Tools & Libraries</span>
             <p>Explore the ecosystem of tools and libraries</p>
           </a>
-          <a class="ecosystem-dropdown-item" href="{{ site.baseurl }}/ecosystem/join">
-            <span class=dropdown-title>Join</span>
-            <p>Submit your project and join the community</p>
-          </a>
         </div>
       </div>
     </li>

--- a/_sass/ecosystem.scss
+++ b/_sass/ecosystem.scss
@@ -20,6 +20,10 @@
     color: $dark_grey;
   }
 
+  .ecosystem-join {
+    margin-bottom: rem(48px);
+  }
+
   svg {
     margin-bottom: rem(20px);
   }

--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -14,7 +14,8 @@ body-class: ecosystem
     </h1>
 
     <p class="lead">Tap into a rich ecosystem of tools, libraries, and more to support, accelerate, and explore AI development.</p>
-
+    <p class="ecosystem-join"><a href="{{ site.baseurl }}/ecosystem/join">Join the Ecosystem</a></p>
+    
   </div>
 </div>
 

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -15,7 +15,9 @@ body-class: hub
 
     <p class="lead">Discover and publish models to a pre-trained model repository designed for both research exploration and development needs.
       Check out the models for <a href="#model-row">Researchers</a> and <a href="#model-row">Developers</a>, or learn <a href="https://pytorch.org/docs/stable/hub.html">How It Works</a>.</p>
+    <p><a href="{{ site.external_urls.hub_template }}">Contribute Models</a></p>
     <p class="hub-release-message">*This is a beta release - we will be collecting feedback and improving the PyTorch Hub over the coming months.</p>
+   
   </div>
 </div>
 


### PR DESCRIPTION
This PR:
 - Removes "Join" from global nav
 - Adds link to "Join" on Ecosystem page
 - Adds link to "Contribute Models" on Hub page