### PR TITLE
Add search to hub pages

### DIFF
--- a/_includes/hub_model_tags.html
+++ b/_includes/hub_model_tags.html
@@ -1,10 +1,12 @@
-<div id="dropdownFilterTags">
-  {% assign all_tags = site.hub | where: "category", include.category | map: "tags" | join: ',' | split: ',' | uniq | sort %}
+<div class="hub-tags-container">
+  <div id="dropdown-filter-tags">
+    {% assign all_tags = site.hub | where: "category", include.category | map: "tags" | join: ',' | split: ',' | uniq | sort %}
 
-  <div class="hub-filter-menu">
-    <div class="hub-filter filter-btn all-tag-selected" data-tag="all">All</div>
-    {% for tag in all_tags %}
-      <div class="hub-filter filter-btn filter" data-tag="{{ tag }}">{{ tag | capitalize }}</div>
-    {% endfor %}
+    <div class="hub-filter-menu">
+      <div class="hub-filter filter-btn all-tag-selected" data-tag="all">All</div>
+      {% for tag in all_tags %}
+        <div class="hub-filter filter-btn filter" data-tag="{{ tag }}">{{ tag | capitalize }}</div>
+      {% endfor %}
+    </div>
   </div>
 </div>

--- a/_includes/hub_researcher_tags_and_cards.html
+++ b/_includes/hub_researcher_tags_and_cards.html
@@ -1,7 +1,8 @@
 <nav class="navbar navbar-expand-lg navbar-light research-menu">
   {% include hub_model_tags.html category="researchers" %}
+  {% include hub_search.html %}
 </nav>
 
-<hr>
+<hr class="hub-divider">
 
 {% include hub_cards.html category="researchers" %}

--- a/_includes/hub_search.html
+++ b/_includes/hub_search.html
@@ -1,0 +1,11 @@
+<div class="hub-search-wrapper" key="search">
+  <div class="hub-search-border">
+    <div id="hub-search-icon"></div>
+    <div id="hub-close-search">X</div>
+    <input
+      id="hub-search-input"
+      type="text"
+      title="Search"
+    />
+  </div>
+</div>

--- a/_layouts/hub_detail.html
+++ b/_layouts/hub_detail.html
@@ -8,16 +8,14 @@
 
     <div class="jumbotron jumbotron-fluid">
       <div class="container">
-        <img src="{{ site.baseurl }}/assets/images/pytorch-hub-arrow.svg"></img>
+        <span class="detail-arrow">
+          {% if page.category == 'researchers' %}
+            <a href="{{ site.baseurl }}/hub/research-models"><</a>
+          {% else %}
+            <a href="{{ site.baseurl }}/hub/developer-models"><</a>
+          {% endif %}
+        </span>
         <h1>
-          <span class="detail-arrow">
-            {% if page.category == 'researchers' %}
-              <a href="{{ site.baseurl }}/hub/research-models"><</a>
-            {% else %}
-              <a href="{{ site.baseurl }}/hub/developer-models"><</a>
-            {% endif %}
-          </span>
-          <br>
           {{ page.title }}
         </h1>
 

--- a/_layouts/hub_index.html
+++ b/_layouts/hub_index.html
@@ -36,3 +36,4 @@
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
 <script list-id="hub-cards" display-count="12" pagination="true" src="{{ site.baseurl }}/assets/filter-hub-tags.js"></script>
+<script src="{{ site.baseurl }}/assets/hub-search-bar.js"></script>

--- a/_sass/hub-search.scss
+++ b/_sass/hub-search.scss
@@ -1,0 +1,99 @@
+.hub .hub-search-wrapper {
+  @include desktop {
+    top: 8px;
+  }
+  .algolia-autocomplete .ds-dropdown-menu {
+    min-width: 100%;
+    max-width: 100% !important;
+  }
+  .algolia-autocomplete {
+    width: 100%;
+  }
+  &.active {
+    width: 100%;
+  }
+  span {
+    font-size: 1.125rem;
+    text-align: center;
+  }
+}
+
+#hub-search-icon {
+  background-image: url($baseurl + "/assets/images/search-icon.svg");
+  color: transparent;
+  opacity: 0.4;
+  width: 25px;
+  height: 25px;
+  margin-left: 3rem;
+  background-size: 15px 20px;
+  background-repeat: no-repeat;
+  right: 10px;
+  position: absolute;
+  cursor: pointer;
+  &:hover {
+    background-image: url($baseurl + "/assets/images/search-icon-orange.svg");
+    opacity: 1;
+  }
+}
+
+#hub-search-input {
+  background-color: $very_dark_grey;
+  border: none;
+  color: $black;
+  font-size: rem(18px);
+  font-weight: 300;
+  line-height: 20px;
+  outline: none;
+  position: relative;
+  display: none;
+  width: 100%;
+  border-radius: 5px;
+  padding: rem(14px) 0 rem(14px) rem(5px);
+}
+
+#hub-close-search {
+  display: none;
+  margin-left: 20px;
+  opacity: 0.4;
+  right: 10px;
+  position: absolute;
+  z-index: 1;
+  cursor: pointer;
+  font-size: rem(18px);
+  @include desktop {
+   top: rem(18px);
+  }
+  &:hover {
+    color: $orange;
+    opacity: 1;
+  }
+}
+
+.hub .hub-divider {
+  margin-bottom: 2.2rem;
+  margin-top: 1.5rem;
+}
+
+.hub .active-hub-divider{
+  border-color: $orange;
+}
+
+.hub .hub-search-border {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  border: none;
+  background-color: transparent;
+  border-radius: 20px;
+  width: 100%;
+}
+
+.hub .hub-cards-wrapper {
+  z-index: 1000;
+}
+
+.hub .nav-container {
+  display: flex;
+  width: 100%;
+  position: absolute;
+}

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -1,11 +1,10 @@
 .hub .jumbotron {
-  height: 280px;
+  height: 375px;
   @include desktop {
-    height: 300px;
+    height: 420px;
   }
 
   h1 {
-    padding-top: rem(120px);
     #hub-header, #hub-sub-header {
       color: $orange;
       font-weight: lighter;
@@ -46,26 +45,50 @@
   }
 }
 
-.hub .detail-github-link {
-  margin-top: rem(45px);
-  background: $orange;
-  a {
-    color: $white;
-    padding-right: rem(50px);
+.hub.hub-index .jumbotron {
+  height: 280px;
+  @include desktop {
+    height: 325px;
   }
 }
 
+.hub .detail-github-link {
+  background: $orange;
+  color: $white;
+}
+
 .hub .detail-colab-link {
-  margin-top: rem(45px);
   background: $yellow;
-  a {
-    color: $black;
+  color: $black;
+}
+
+.hub {
+  .detail-colab-link, .detail-github-link {
+    margin-top: rem(45px);
+    @include small-desktop {
+      margin-top: rem(20px);
+    }
+    @media (max-width: 320px) {
+      margin-top: rem(20px);
+    }
+    @media (max-width: 360px) {
+      margin-top: rem(20px);
+    }
+  }
+}
+
+.hub a {
+  .detail-colab-link, .detail-github-link {
     padding-right: rem(50px);
   }
 }
 
 .hub .detail-arrow {
   color: $orange;
+  @include desktop {
+    font-size: 4.5rem;
+  }
+  font-size: 2.5rem;
 }
 
 .hub .with-right-white-arrow {
@@ -87,6 +110,9 @@
   @include desktop {
     padding-top: rem(135px);
   }
+  @media (max-width: 320px) {
+    padding-top: rem(160px);
+  }
 }
 
 .hub.hub-detail  .main-content {
@@ -97,9 +123,9 @@
 }
 
 .hub.hub-detail .jumbotron {
-  height: 100px;
+  height: 350px;
   @include desktop {
-    height: 100px;
+    height: 400px;
   }
 }
 
@@ -109,7 +135,7 @@
   @include desktop {
     margin-top: 305px + $desktop_header_height;
   }
-  margin-top: 275px;
+  margin-top: 300px;
 }
 
 .hub-feedback-button {
@@ -134,6 +160,12 @@
 .hub.hub-detail .main-content-wrapper {
   @include desktop {
     margin-top: 270px + $desktop_header_height;
+  }
+  @include small-desktop {
+    margin-top: 330px + $desktop_header_height;
+  }
+  @media (max-width: 320px) {
+    margin-top: 300px;
   }
   margin-top: 275px;
 }
@@ -247,6 +279,8 @@
 .hub #dropdownFilter, #dropdownSort, #dropdownSortLeft {
   color: $mid_gray;
   cursor: pointer;
+  z-index: 1;
+  position: absolute;
 }
 
 .hub #dropdownSort, #dropdownSortLeft {
@@ -478,6 +512,7 @@
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
   line-height: 1.5;
+  margin-bottom: 5px;
   &:hover {
     border: 1px solid $orange;
     color: $orange;
@@ -510,5 +545,13 @@
 
   .active .page {
     background-color: #dee2e6;
+  }
+}
+
+.hub .hub-tags-container {
+  width: 40%;
+
+  &.active {
+    width: 0;
   }
 }

--- a/assets/hub-search-bar.js
+++ b/assets/hub-search-bar.js
@@ -1,0 +1,46 @@
+docsearch({
+  apiKey: "e3b73ac141dff0b0fd27bdae9055bc73",
+  indexName: "pytorch",
+  inputSelector: "#hub-search-input",
+  algoliaOptions: { facetFilters: ["tags:hub"] },
+  debug: false // Set debug to true if you want to inspect the dropdown
+});
+
+$("#hub-search-icon").on("click", function() {
+  $(this).hide();
+  $("#hub-close-search").fadeIn("slow");
+  $(".hub-divider").addClass("active-hub-divider");
+  $("#hub-search-input")
+    .show()
+    .css("background-color", "#CCCDD1")
+    .focus();
+  $(".hub-search-wrapper, .hub-tags-container").addClass("active");
+  $("#dropdown-filter-tags").hide();
+});
+
+function hideHubSearch(searchIcon) {
+  $(searchIcon).hide();
+  $("#hub-search-icon, #dropdown-filter-tags").fadeIn("slow");
+  $("#hub-search-input")
+    .fadeOut("slow")
+    .css("background-color", "#f3f4f7");
+  $(".hub-divider").removeClass("active-hub-divider");
+  $("#hub-search-input")
+    .removeClass("active-search-icon")
+    .val("");
+  $(".hub-search-wrapper, .hub-tags-container").removeClass("active");
+}
+
+$("#hub-close-search").on("click", function() {
+  hideHubSearch(this);
+});
+
+$(document).click(function(event) {
+  $target = $(event.target);
+  if (
+    !$target.closest(".hub-search-wrapper").length &&
+    $(".hub-search-wrapper").is(":visible")
+  ) {
+    hideHubSearch("#hub-close-search");
+  }
+});

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -28,3 +28,4 @@ $baseurl:"{{ site.baseurl }}";
 @import "search";
 @import "cookie-banner";
 @import "hub";
+@import "hub-search";

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -32,7 +32,7 @@ body-class: hub
 
           <nav class="navbar navbar-expand-lg navbar-light research-menu">
             {% include hub_model_tags.html category="researchers" %}
-
+            {% include hub_search.html %}
             <!--
             <a id="dropdownSortLeft" data-toggle="dropdown" data-target="#dropdownSortMenuLeft" >
               Sort <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
@@ -54,7 +54,7 @@ body-class: hub
           -->
           </nav>
 
-          <hr>
+          <hr class="hub-divider">
 
           <div id="hub-index-cards">
             <div class="list row hub-cards-wrapper cards-left">
@@ -207,3 +207,4 @@ body-class: hub
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
 <script list-id="hub-index-cards" display-count="3" pagination="false" src="{{ site.baseurl }}/assets/filter-hub-tags.js"></script>
+<script src="{{ site.baseurl }}/assets/hub-search-bar.js"></script>


### PR DESCRIPTION
This PR adds Algolia search to the hub pages. It also:

- Moves the "<" character out of the H1 tag on the Hub detail pages, so Algolia will properly display the card titles in the search results
- Addresses some mobile view jumbotron padding issues on the hub index and hub detail pages
- Fixes the font color of the GitHub and Colab buttons on the Hub detail pages