### PR TITLE
Add ability to specify which case studies appear on homepage

### DIFF
--- a/_case_studies/salesforce.md
+++ b/_case_studies/salesforce.md
@@ -2,6 +2,8 @@
 layout: blog_detail
 title: Salesforce
 logo: assets/images/salesforce.png
+featured-home: true
+order: 1
 ---
 
 Pushing the state of the art in NLP and Multi-task learning.

--- a/_case_studies/stanford-university.md
+++ b/_case_studies/stanford-university.md
@@ -2,6 +2,8 @@
 layout: blog_detail
 title: Stanford University
 logo: assets/images/stanford-university.png
+featured-home: true
+order: 2
 ---
 
 Using PyTorch's flexibility to efficiently research new algorithmic approaches.

--- a/_case_studies/udacity.md
+++ b/_case_studies/udacity.md
@@ -2,6 +2,8 @@
 layout: blog_detail
 title: Udacity
 logo: assets/images/udacity.png
+featured-home: true
+order: 3
 ---
 
 Educating the next wave of AI Innovators using PyTorch.

--- a/index.html
+++ b/index.html
@@ -143,10 +143,12 @@ body-class: homepage
         </a> -->
 
         <div class="row university-testimonials-content">
-          {% for item in site.case_studies limit:3 %}
+          {% assign case_studies = site.case_studies | where: "featured-home", true | sort: "order" %}
+
+          {% for case_study in case_studies %}
             <div class="col-md-4">
-              <img src="{{ site.baseurl }}/{{ item.logo }}" class="img-fluid" width="140">
-              <p>{{ item.excerpt }}</p>
+              <img src="{{ site.baseurl }}/{{ case_study.logo }}" class="img-fluid" width="140">
+              <p>{{ case_study.excerpt }}</p>
               <!-- Temporarily hiding link out to case studies for time being -->
 <!--               <a href="{{ site.baseurl }}{{ item.url }}" class="btn btn-lg with-right-arrow">
                 Read More


### PR DESCRIPTION
This PR adds the variables `featured-home` and `order` to the case studies front matter block. With this update, a case study will only appear on the homepage if `featured-home` is set to `true`. Also, if you want more than 3 case studies to appear on the homepage, you can set the additional cards' `featured-home` variables to `true`.