### PR TITLE
Clear cloud instructions when alibaba option is selected

### DIFF
--- a/assets/quick-start-module.js
+++ b/assets/quick-start-module.js
@@ -14,6 +14,7 @@ var opts = {
 };
 
 var supportedCloudPlatforms = [
+  'alibaba',
   'aws',
   'google-cloud',
   'microsoft-azure',


### PR DESCRIPTION
This PR ensures that the cloud instructions on the Get Started page are cleared when Alibaba is selected.