### PR TITLE
Fix mobile page tab navigation

### DIFF
--- a/_mobile/android.md
+++ b/_mobile/android.md
@@ -323,3 +323,6 @@ Explicitly destructs native (C++) part of the Module, `torch::jit::script::Modul
 
 As fbjni library destructs native part automatically when current `org.pytorch.Module` instance will be collected by Java GC, the instance will not leak if this method is not called, but timing of deletion and the thread will be at the whim of the Java GC. If you want to control the thread and timing of the destructor, you should call this method explicitly.
 
+<!-- Do not remove the below script -->
+
+<script page-id="android" src="{{ site.baseurl }}/assets/menu-tab-selection.js"></script>

--- a/_mobile/home.md
+++ b/_mobile/home.md
@@ -27,4 +27,6 @@ Learn more or get started on [Android](http://pytorch.org/mobile/android) or [iO
   <img src="{{ site.url }}/assets/images/pytorchmobile.png" width="100%">
 </div>
 
+<!-- Do not remove the below script -->
+
 <script page-id="home" src="{{ site.baseurl }}/assets/menu-tab-selection.js"></script>

--- a/_mobile/ios.md
+++ b/_mobile/ios.md
@@ -164,7 +164,6 @@ Currently, the iOS framework uses the raw Pytorch C++ APIs directly. The C++ doc
 
 If you have any questions or want to contribute to PyTorch, please feel free to drop issues or open pull request to get in touch.
 
+<!-- Do not remove the below script -->
 
-
-
-
+<script page-id="ios" src="{{ site.baseurl }}/assets/menu-tab-selection.js"></script>


### PR DESCRIPTION
This PR updates the mobile page tab navigation. Clicking on an option will correctly highlight the selected tab.