### PR TITLE
Add header for torchaudio, torchtext, and other languages

### DIFF
--- a/docs/stable/index.html
+++ b/docs/stable/index.html
@@ -368,16 +368,19 @@
 </ul>
 </div>
 <div class="toctree-wrapper compound">
+<p class="caption"><span class="caption-text">torchaudio Reference</span></p>
 </div>
 <ul class="simple">
 <li><p><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></p></li>
 </ul>
 <div class="toctree-wrapper compound">
+<p class="caption"><span class="caption-text">torchtext Reference</span></p>
 </div>
 <ul class="simple">
 <li><p><a class="reference external" href="https://pytorch.org/text">torchtext</a></p></li>
 </ul>
 <div class="toctree-wrapper compound">
+<p class="caption"><span class="caption-text">Other Languages</span></p>
 </div>
 <ul class="simple">
 <li><p><a class="reference external" href="https://pytorch.org/cppdocs/">C++ API</a></p></li>


### PR DESCRIPTION
Headers aren't generating when going from rst to html. Manually added them here