### PR TITLE
Conditionally hide shortcuts menu title

### DIFF
--- a/_includes/mobile_page_side_nav.html
+++ b/_includes/mobile_page_side_nav.html
@@ -1,5 +1,5 @@
 <div class="sticky-top mobile-page-sidebar">
-  <p>Shortcuts</p>
+  <p id="shortcuts-menu">Shortcuts</p>
   <ul id="mobile-page-sidebar-list"></ul>
 </div>
 

--- a/assets/mobile-page-sidebar.js
+++ b/assets/mobile-page-sidebar.js
@@ -9,7 +9,6 @@ $(".mobile-page-sidebar li").on("click", function() {
   addActiveClass(this);
 });
 
-
 function removeActiveClass() {
   $(".mobile-page-sidebar li a").each(function() {
     $(this).removeClass("active");
@@ -20,4 +19,8 @@ function addActiveClass(element) {
   $(element)
     .find("a")
     .addClass("active");
+}
+
+if ($("#mobile-page-sidebar-list").text() == "") {
+  $("#shortcuts-menu").hide();
 }


### PR DESCRIPTION
This PR adjusts the Shortcuts menu title on the mobile page. If there aren't any menu items then the Shorcuts title will be hidden.