### PR TITLE
Fix search input in mobile menu

### DIFF
--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -199,6 +199,21 @@
   height: 100%;
   min-height: 100%;
   margin-top: -$mobile_header_height;
+  padding-top: 25%;
+  @media only screen and (max-width: 320px) {
+    padding-top: 50%;
+    overflow-y: scroll;
+  }
+
+  @include small-desktop {
+    padding-top: 0;
+  }
+
+  .navSearchWrapper {
+    @media only screen and (max-width: 320px) {
+      width: 75%;
+    }
+  }
 }
 
 .blog-header,

--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -24,7 +24,12 @@ input[type='search'] {
 }
 
 .tabletSearchWrapper {
-  top: -55px;
+  top: 0px;
+
+  @include small-desktop {
+    top: -55px;
+  }
+
   @include small-desktop {
     padding-bottom: 20px;
     position: relative;


### PR DESCRIPTION
This PR adjusts the position of the search input within the mobile menu. On some viewports, the search input was hidden or obscured under the PyTorch logo, but now it should always be visible.