### PR TITLE
Ensure that card text doesn't overflow

### DIFF
--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -442,13 +442,16 @@ a, .btn {
   height: 110px;
   margin-bottom: rem(20px);
   margin-bottom: rem(30px);
+  overflow: scroll;
 
   @include max-width-desktop {
     height: 150px;
+    overflow: inherit;
   }
 
   @include small-desktop {
     height: 170px;
+    overflow: inherit;
   }
 
   p.card-summary {

--- a/_sass/ecosystem.scss
+++ b/_sass/ecosystem.scss
@@ -59,6 +59,17 @@
 .ecosystem-cards-wrapper {
   margin-bottom: rem(18px);
   padding-top: rem(20px);
+  .col-md-6 {
+    @media (min-width: 768px) {
+      flex: 0 0 100%;
+      max-width: 100%;
+    }
+
+    @include max-width-desktop {
+      flex: 0 0 50%;
+      max-width: 50%;
+    }
+  }
 }
 
 .ecosystem .main-content-menu {

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -423,19 +423,6 @@
   }
 }
 
-.hub .hub-card {
-  overflow: scroll;
-  @include max-width-desktop {
-    height: 150px;
-    overflow: inherit;
-  }
-
-  @include small-desktop {
-    height: 170px;
-    overflow: inherit;
-  }
-}
-
 .hub #development-models-hide, #research-models-hide {
   display: none;
 }


### PR DESCRIPTION
This PR ensures that the text in the ecosystem and resource cards does not overflow. I'm using the same approach as the Hub cards: a scroll bar will appear if the card text overflows. I also updated the width of the ecosystem cards for the tablet view:

<img width="760" alt="ecosystem cards" src="https://user-images.githubusercontent.com/16585245/67707831-9660a100-f991-11e9-80c9-f54bd341cdf8.png">

The ecosystem cards will now take up the entire width of the screen when viewed on a tablet.
