### PR TITLE
Add new pixel for GitHub link

### DIFF
--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -58,7 +58,7 @@
       </div>
     </li>
 
-    <li class="main-menu-item">
+    <li class="main-menu-item" id="github-main-menu-link">
       <a href="{{ site.external_urls.github }}">GitHub</a>
     </li>
 

--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -59,7 +59,7 @@
           <a href="{{ site.baseurl }}/resources">Resources</a>
         </li>
 
-        <li>
+        <li id="github-mobile-menu-link">
           <a href="{{ site.external_urls.github }}">GitHub</a>
         </li>
       </ul>

--- a/assets/track-events.js
+++ b/assets/track-events.js
@@ -28,6 +28,15 @@ var trackEvents = {
       return true;
     });
 
+    // Clicks on GitHub link in main or mobile menu
+    $("#github-main-menu-link, #github-mobile-menu-link").on(
+      "click",
+      function() {
+        trackEvents.recordClick("Link", $(this).text());
+        return true;
+      }
+    );
+
     // Clicks on Resource cards
     $(".resource-card a").on("click", function() {
       trackEvents.recordClick("Resource Card", $(this).find("h4").text());


### PR DESCRIPTION
This PR adds a new pixel to track when a user clicks on the GitHub link in the main or mobile menu: `ga("send", "event", {eventCategory: "Link", eventAction: "click", eventLabel: "GitHub"})`.