### PR TITLE
Fix 404 on pages with trailing slashes

### DIFF
--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Ecosystem
-permalink: ecosystem.html
+permalink: ecosystem/
 background-class: ecosystem-background
 body-class: ecosystem
 ---

--- a/features.html
+++ b/features.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Features
-permalink: features.html
+permalink: features/
 background-class: features-background
 body-class: features
 ---

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: PyTorch Hub
-permalink: hub.html
+permalink: hub/
 background-class: hub-background
 body-class: hub
 ---

--- a/resources.html
+++ b/resources.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Resources
-permalink: resources.html
+permalink: resources/
 body-class: resources
 redirect_from: /support/
 ---


### PR DESCRIPTION
As mentioned on [Jekyll 2->3 migration guide](https://jekyllrb.com/docs/upgrading/2-to-3/#permalinks-no-longer-automatically-add-a-trailing-slash), certain URLs with trailing slashes return 404.

For example,
https://pytorch.org/hub works, but https://pytorch.org/hub/ doesn't

I think that one of the solution is add trailing slashes in the `permalink`, the other is to rename files to `index.html` e.g. in `hub/` folder rename `hub.html` to `index.html`.

This PR adds trailing slashes, but doing so will break the link https://pytorch.org/hub.html. I don't think it'll cause any problem as all the URLs in this repo use `/hub`.