### PR TITLE
Update tracking pixels for Deep Learning pages

### DIFF
--- a/_layouts/deep_learning.html
+++ b/_layouts/deep_learning.html
@@ -21,12 +21,12 @@
               <p class="lead deep-learning-landing-text">Download a free copy of the book and learn how to get started with AI / ML development using PyTorch</p>
             {% else %}
               <p class="lead deep-learning-thank-you-text">Thanks for requesting a copy of the Deep Learning with PyTorch book!
-                <span class="download-book-link"><a href="/assets/deep-learning/Deep-Learning-with-PyTorch.pdf" target="_blank">Click here</a> to download the book.</span>
+                <span class="download-book-link"><a id="download-pdf" href="{{ site.baseurl }}/assets/deep-learning/Deep-Learning-with-PyTorch.pdf" target="_blank">Click here</a> to download the book.</span>
               </p>
             {% endif %}
           </div>
           <div class="col-md-5 deep-learning-book-container {% if page.deep-learning-landing == false %}thank-you-book-container{% endif %}">
-            <img class="deep-learning-book" src="/assets/images/deep-learning-thumbnail.png">
+            <img class="deep-learning-book" src="{{ site.baseurl }}/assets/images/deep-learning-thumbnail.png">
           </div>
         </div>
       </div>

--- a/assets/track-events.js
+++ b/assets/track-events.js
@@ -1,6 +1,6 @@
 var trackEvents = {
   recordClick: function(eventCategory, eventLabel) {
-    if (typeof ga == "function") {
+    if (typeof ga == "function" && eventLabel !== "Lead") {
       var gaEventObject = {
         eventCategory: eventCategory,
         eventAction: "click",
@@ -14,7 +14,7 @@ var trackEvents = {
       }
     }
 
-    if (typeof fbq === "function" && eventLabel !== "Download") {
+    if (typeof fbq === "function" && eventLabel !== "Lead") {
       fbq("trackCustom", eventCategory, {
         target: eventLabel
       });
@@ -100,11 +100,22 @@ var trackEvents = {
       )
     })
 
-    // Clicks on Deep Learning Download button
-    $("#deep-learning-button").on(
+    // Clicks on link to download Deep Learning book
+    // on Thank You page
+    $("#download-pdf").on(
       "click",
       function() {
         trackEvents.recordClick("Link", "Download");
+        return true;
+      }
+    );
+
+    // Enters email and clicks download book button
+    // on Deep Learning landing page
+    $("#deep-learning-button").on(
+      "click",
+      function() {
+        trackEvents.recordClick("Link", "Lead");
         return true;
       }
     );


### PR DESCRIPTION
This PR adjusts the tracking pixels on the Deep Learning pages. Now the GA Download pixel fires when a user downloads the PDF on the Thank You page instead of when they enter their email address on the Landing page. Preview links:

- https://5dd54e39587f6d021357df25--shiftlab-pytorch-github-io.netlify.com/deep-learning-with-pytorch
- https://5dd54e39587f6d021357df25--shiftlab-pytorch-github-io.netlify.com/deep-learning-with-pytorch-thank-you