### PR TITLE
Update trackingID for Deep Learning download tracking

### DIFF
--- a/assets/track-events.js
+++ b/assets/track-events.js
@@ -12,6 +12,10 @@ var trackEvents = {
       if (eventCategory == "Quick Start Module - Cloud Platforms") {
         ga('newCampaignTracker.send', 'event', gaEventObject);
       }
+
+      if (eventLabel == "Download") {
+        ga('newCampaignTracker.send', 'event', gaEventObject);
+      }
     }
 
     if (typeof fbq === "function" && eventLabel !== "Download") {


### PR DESCRIPTION
This PR updates the GA `trackingID` that the Deep Learning download event uses. It will now use UA-117752657-2.