### PR TITLE
Fix redirects on mobile and get started pages

### DIFF
--- a/_get_started/get-started-locally.md
+++ b/_get_started/get-started-locally.md
@@ -7,6 +7,7 @@ body-class: get-started
 order: 1
 published: true
 get-started-locally: true
+redirect_from: "/get-started/"
 ---
 
 ## Start Locally

--- a/_mobile/home.md
+++ b/_mobile/home.md
@@ -6,6 +6,7 @@ background-class: mobile-background
 body-class: mobile
 order: 1
 published: true
+redirect_from: "/mobile/"
 ---
 
 # PyTorch Mobile


### PR DESCRIPTION
Visiting [pytorch.org/mobile](pytorch.org/mobil) works, but visiting [pytorch.org/mobile/](pytorch.org/mobile/) does not. This PR fixes the issue so that both links will work correctly. The same bug was present for the Get Started page, so that was adjusted as well. Preview link:

- https://5dd6ed8929a03065d6b26ac4--shiftlab-pytorch-github-io.netlify.com/mobile/