### PR TITLE
Update 1.3.0 and stable Persons of Interest and correct sidebar

### DIFF
--- a/docs/1.3.0/community/persons_of_interest.html
+++ b/docs/1.3.0/community/persons_of_interest.html
@@ -6,26 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
   <title>PyTorch Governance | Persons of Interest &mdash; PyTorch master documentation</title>
-  
 
-  
-  
-  
-  
+
+
+
+
+
     <link rel="canonical" href="https://pytorch.org/docs/stable/community/persons_of_interest.html"/>
-  
 
-  
 
-  
-  
-    
 
-  
+
+
+
+
+
+
 
   <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
@@ -35,9 +35,9 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="torch" href="../torch.html" />
-    <link rel="prev" title="PyTorch Governance" href="governance.html" /> 
+    <link rel="prev" title="PyTorch Governance" href="governance.html" />
 
-  
+
   <script src="../_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
@@ -111,9 +111,9 @@
 
 <body class="pytorch-body">
 
-   
 
-    
+
+
 
     <div class="table-of-contents-link-wrapper">
       <span>Table of Contents</span>
@@ -124,21 +124,21 @@
       <div class="pytorch-side-scroll">
         <div class="pytorch-menu pytorch-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           <div class="pytorch-left-menu-search">
-            
 
-            
-              
-              
+
+
+
+
                 <div class="version">
                   <a href='http://pytorch.org/docs/versions.html'>1.3.0 &#x25BC</a>
                 </div>
-              
-            
-
-            
 
 
-  
+
+
+
+
+
 
 
 <div role="search">
@@ -149,15 +149,15 @@
   </form>
 </div>
 
-            
+
           </div>
 
-          
-            
-            
-              
-            
-            
+
+
+
+
+
+
               <p class="caption"><span class="caption-text">Notes</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
@@ -171,7 +171,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-<li class="toctree-l1"><a class="reference external" href="* `PyTorch on XLA Devices &lt;http://pytorch.org/xla/&gt;`_">* `PyTorch on XLA Devices &lt;http://pytorch.org/xla/&gt;`_</a></li>
+<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul class="current">
@@ -213,20 +213,20 @@
 </ul>
 <p class="caption"><span class="caption-text">torchaudio Reference</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="* `torchaudio &lt;https://pytorch.org/audio&gt;`_">* `torchaudio &lt;https://pytorch.org/audio&gt;`_</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
 </ul>
 <p class="caption"><span class="caption-text">torchtext Reference</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="* `torchtext &lt;https://pytorch.org/text&gt;`_">* `torchtext &lt;https://pytorch.org/text&gt;`_</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Other Languages</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="* `C++ API &lt;https://pytorch.org/cppdocs/&gt;`_">* `C++ API &lt;https://pytorch.org/cppdocs/&gt;`_</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/cppdocs/">C++ API</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../packages.html">Javadoc</a></li>
 </ul>
 
-            
-          
+
+
         </div>
       </div>
     </nav>
@@ -234,7 +234,7 @@
     <div class="pytorch-container">
       <div class="pytorch-page-level-bar" id="pytorch-page-level-bar">
         <div class="pytorch-breadcrumbs-wrapper">
-          
+
 
 
 
@@ -253,30 +253,30 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="pytorch-breadcrumbs">
-    
+
       <li>
         <a href="../index.html">
-          
+
             Docs
-          
+
         </a> &gt;
       </li>
 
-        
+
       <li>PyTorch Governance | Persons of Interest</li>
-    
-    
+
+
       <li class="pytorch-breadcrumbs-aside">
-        
-            
+
+
             <a href="../_sources/community/persons_of_interest.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
-          
-        
+
+
       </li>
-    
+
   </ul>
 
-  
+
 </div>
         </div>
 
@@ -288,13 +288,13 @@
       <section data-toggle="wy-nav-shift" id="pytorch-content-wrap" class="pytorch-content-wrap">
         <div class="pytorch-content-left">
 
-        
-          
+
+
           <div class="rst-content">
-          
+
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
-              
+
   <div class="section" id="pytorch-governance-persons-of-interest">
 <h1>PyTorch Governance | Persons of Interest<a class="headerlink" href="#pytorch-governance-persons-of-interest" title="Permalink to this headline">¶</a></h1>
 <div class="section" id="general-maintainers">
@@ -311,12 +311,86 @@
 </div>
 <div class="section" id="module-level-maintainers">
 <h2>Module-level maintainers<a class="headerlink" href="#module-level-maintainers" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="torch">
-<h3>torch.*<a class="headerlink" href="#torch" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="jit">
+<h3>JIT<a class="headerlink" href="#jit" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Greg Chanan (<a class="reference external" href="https://github.com/gchanan">gchanan</a>)</p></li>
+<li><p>Zach Devito (<a class="reference external" href="https://github.com/zdevito">zdevito</a>)</p></li>
+<li><p>Michael Suo (<a class="reference external" href="https://github.com/suo">suo</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="distributed">
+<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Pieter Noordhuis (<a class="reference external" href="https://github.com/pietern">pietern</a>)</p></li>
+<li><p>Shen Li (<a class="reference external" href="https://github.com/mrshenli">mrshenli</a>)</p></li>
+<li><p>(sunsetting) Teng Li (<a class="reference external" href="https://github.com/teng-li">teng-li</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="autograd-engine">
+<h3>Autograd Engine<a class="headerlink" href="#autograd-engine" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
+<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="multiprocessing-and-dataloaders">
+<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Simon Wang (<a class="reference external" href="https://github.com/SsnL">SsnL</a>)</p></li>
+<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
+<li><p>(proposed) Vitaly Fedyunin
+(<a class="reference external" href="https://github.com/proposed">VitalyFedyunin</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="cuda">
+<h3>CUDA<a class="headerlink" href="#cuda" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+<li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="c">
+<h3>C++<a class="headerlink" href="#c" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
+<li><p>(sunsetting) Peter Goldsborough
+(<a class="reference external" href="https://github.com/goldsborough">goldsborough</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="build-ci">
+<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+<li><p>Jesse Hellemn (<a class="reference external" href="https://github.com/pjh5">pjh5</a>)</p></li>
 <li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>[linear algebra] Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+<li><p>(sunsetting) Orion Reblitz-Richardson
+(<a class="reference external" href="https://github.com/orionr">orionr</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="distributions-rng">
+<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Fritz Obermeyer (<a class="reference external" href="https://github.com/fritzo">fritzo</a>)</p></li>
+<li><p>Neeraj Pradhan (<a class="reference external" href="https://github.com/neerajprad">neerajprad</a>)</p></li>
+<li><p>Alican Bozkurt (<a class="reference external" href="https://github.com/alicanb">alicanb</a>)</p></li>
+<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="c10">
+<h3>C10<a class="headerlink" href="#c10" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Sebastian Messmer (<a class="reference external" href="https://github.com/smessmer">smessmer</a>)</p></li>
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="onnx-pytorch">
+<h3>ONNX &lt;-&gt; PyTorch<a class="headerlink" href="#onnx-pytorch" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Lu Fang (<a class="reference external" href="https://github.com/houseroad">houseroad</a>)</p></li>
+<li><p>Lara Haidar (<a class="reference external" href="https://github.com/houseroad">lara-hdr</a>)</p></li>
+<li><p>Spandan Tiwari (<a class="reference external" href="https://github.com/houseroad">spandantiwari</a>)</p></li>
+<li><p>Bowen Bao (<a class="reference external" href="https://github.com/houseroad">BowenBao</a>)</p></li>
 </ul>
 </div>
 <div class="section" id="torch-nn">
@@ -329,74 +403,30 @@
 <li><p>Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="torch-optim">
-<h3>torch.optim<a class="headerlink" href="#torch-optim" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Vincent Quenneville-Belair (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
-<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="autograd-engine">
-<h3>Autograd Engine<a class="headerlink" href="#autograd-engine" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
-<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="jit">
-<h3>JIT<a class="headerlink" href="#jit" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Zach Devito (<a class="reference external" href="https://github.com/zdevito">zdevito</a>)</p></li>
-<li><p>Michael Suo (<a class="reference external" href="https://github.com/suo">suo</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="distributions-rng">
-<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Fritz Obermeyer (<a class="reference external" href="https://github.com/fritzo">fritzo</a>)</p></li>
-<li><p>Neeraj Pradhan (<a class="reference external" href="https://github.com/neerajprad">neerajprad</a>)</p></li>
-<li><p>Alican Bozkurt (<a class="reference external" href="https://github.com/alicanb">alicanb</a>)</p></li>
-<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="distributed">
-<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Pieter Noordhuis (<a class="reference external" href="https://github.com/pietern">pietern</a>)</p></li>
-<li><p>Shen Li (<a class="reference external" href="https://github.com/mrshenli">mrshenli</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="multiprocessing-and-dataloaders">
-<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
-<li><p>Simon Wang (<a class="reference external" href="https://github.com/SsnL">SsnL</a>)</p></li>
-<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
-</ul>
-</div>
 <div class="section" id="cpu-performance-simd">
 <h3>CPU Performance / SIMD<a class="headerlink" href="#cpu-performance-simd" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
-<li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
+<li><p>Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
 <li><p>Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
-<li><p>(sunsetting) Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
-<li><p>[threading] Ilia Cherniavskii (<a class="reference external" href="https://github.com/ilia-cher">ilia-cher</a>)</p></li>
+<li><p>Richard Zou (<a class="reference external" href="https://github.com/zou3519">zou3519</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="cuda">
-<h3>CUDA<a class="headerlink" href="#cuda" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="amd-rocm-hip">
+<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
+<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
+<li><p>Johannes M. Dieterich (<a class="reference external" href="https://github.com/iotamudelta">iotamudelta</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="windows">
+<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
 </ul>
 </div>
 <div class="section" id="mkldnn">
 <h3>MKLDNN<a class="headerlink" href="#mkldnn" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
 <li><p>Yinghai Lu (<a class="reference external" href="https://github.com/yinghai">yinghai</a>)</p></li>
 </ul>
 </div>
@@ -409,58 +439,28 @@
 <li><p>Alex Suhan (<a class="reference external" href="https://github.com/asuhan">asuhan</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="amd-rocm-hip">
-<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
-<li><p>Johannes M. Dieterich (<a class="reference external" href="https://github.com/iotamudelta">iotamudelta</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="build-ci">
-<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>Karl Ostmo (<a class="reference external" href="https://github.com/kostmo">kostmo</a>)</p></li>
-<li><p>Hong Xu (<a class="reference external" href="https://github.com/xuhdev">xuhdev</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="benchmarks">
-<h3>Benchmarks<a class="headerlink" href="#benchmarks" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Mingzhe Li (<a class="reference external" href="https://github.com/mingzhe09088">mingzhe09088</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="c-api">
-<h3>C++ API<a class="headerlink" href="#c-api" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="c10-utils-and-operator-dispatch">
-<h3>C10 utils and operator dispatch<a class="headerlink" href="#c10-utils-and-operator-dispatch" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Sebastian Messmer (<a class="reference external" href="https://github.com/smessmer">smessmer</a>)</p></li>
-<li><p>Dmytro Dzhulgakov (<a class="reference external" href="https://github.com/dzhulgakov">dzhulgakov</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="onnx-pytorch">
-<h3>ONNX &lt;-&gt; PyTorch<a class="headerlink" href="#onnx-pytorch" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Lu Fang (<a class="reference external" href="https://github.com/houseroad">houseroad</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="windows">
-<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="powerpc">
-<h3>PowerPC<a class="headerlink" href="#powerpc" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="ppc">
+<h3>PPC<a class="headerlink" href="#ppc" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Alfredo Mendoza (<a class="reference external" href="https://github.com/avmgithub">avmgithub</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchvision">
+<h3>torchvision<a class="headerlink" href="#torchvision" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Francisco Massa (<a class="reference external" href="https://github.com/fmassa">fmassa</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchtext">
+<h3>torchtext<a class="headerlink" href="#torchtext" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Guanheng George Zhang (<a class="reference external" href="https://github.com/zhangguanheng66">zhangguanheng66</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchaudio">
+<h3>torchaudio<a class="headerlink" href="#torchaudio" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Vincent Quenneville-Belair (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
 </ul>
 </div>
 </div>
@@ -468,25 +468,25 @@
 
 
              </article>
-             
+
             </div>
             <footer>
-  
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
-        <a href="../torch.html" class="btn btn-neutral float-right" title="torch" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
-      
-      
-        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
-      
-    </div>
-  
 
-  
+    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+
+        <a href="../torch.html" class="btn btn-neutral float-right" title="torch" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+
+
+        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+
+    </div>
+
+
+
 
     <hr>
 
-  
+
 
   <div role="contentinfo">
     <p>
@@ -494,11 +494,11 @@
 
     </p>
   </div>
-    
+
       <div>
         Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
       </div>
-     
+
 
 </footer>
 
@@ -544,20 +544,20 @@
       </section>
     </div>
 
-  
 
 
-  
 
-     
+
+
+
        <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
          <script type="text/javascript" src="../_static/jquery.js"></script>
          <script type="text/javascript" src="../_static/underscore.js"></script>
          <script type="text/javascript" src="../_static/doctools.js"></script>
          <script type="text/javascript" src="../_static/language_data.js"></script>
-     
 
-  
+
+
 
   <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
   <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
@@ -567,7 +567,7 @@
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script> 
+  </script>
 
   <!-- Begin Footer -->
 

--- a/docs/1.3.0/community/persons_of_interest.html
+++ b/docs/1.3.0/community/persons_of_interest.html
@@ -6,7 +6,6 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>PyTorch Governance | Persons of Interest &mdash; PyTorch master documentation</title>

--- a/docs/1.3.0/index.html
+++ b/docs/1.3.0/index.html
@@ -6,26 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
   <title>PyTorch documentation &mdash; PyTorch master documentation</title>
-  
 
-  
-  
-  
-  
+
+
+
+
+
     <link rel="canonical" href="https://pytorch.org/docs/stable/index.html"/>
-  
 
-  
 
-  
-  
-    
 
-  
+
+
+
+
+
+
 
   <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
   <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
@@ -34,9 +34,9 @@
   <link rel="stylesheet" href="_static/katex-math.css" type="text/css" />
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
-    <link rel="next" title="Autograd mechanics" href="notes/autograd.html" /> 
+    <link rel="next" title="Autograd mechanics" href="notes/autograd.html" />
 
-  
+
   <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
@@ -110,9 +110,9 @@
 
 <body class="pytorch-body">
 
-   
 
-    
+
+
 
     <div class="table-of-contents-link-wrapper">
       <span>Table of Contents</span>
@@ -123,21 +123,21 @@
       <div class="pytorch-side-scroll">
         <div class="pytorch-menu pytorch-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           <div class="pytorch-left-menu-search">
-            
 
-            
-              
-              
+
+
+
+
                 <div class="version">
                   <a href='http://pytorch.org/docs/versions.html'>1.3.0 &#x25BC</a>
                 </div>
-              
-            
-
-            
 
 
-  
+
+
+
+
+
 
 
 <div role="search">
@@ -148,74 +148,84 @@
   </form>
 </div>
 
-            
+
           </div>
 
-          
-            
-            
-              
-            
-            
+
+
+
+
+
+
               <p class="caption"><span class="caption-text">Notes</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="notes/windows.html">Windows FAQ</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
+<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance | Persons of Interest</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Python API</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="__config__.html">torch.__config__</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
 </ul>
-<p class="caption"><span class="caption-text">torchvision Reference</span></p>
+<p class="caption"><span class="caption-text">torchaudio Reference</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="torchvision/index.html">torchvision</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
+</ul>
+<p class="caption"><span class="caption-text">torchtext Reference</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
+</ul>
+<p class="caption"><span class="caption-text">Other Languages</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/cppdocs/">C++ API</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../packages.html">Javadoc</a></li>
 </ul>
 
-            
-          
+
+
         </div>
       </div>
     </nav>
@@ -223,7 +233,7 @@
     <div class="pytorch-container">
       <div class="pytorch-page-level-bar" id="pytorch-page-level-bar">
         <div class="pytorch-breadcrumbs-wrapper">
-          
+
 
 
 
@@ -244,33 +254,33 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="pytorch-breadcrumbs">
-    
+
       <li>
         <a href="#">
-          
+
             Docs
-          
+
         </a> &gt;
       </li>
 
-        
+
       <li>PyTorch documentation</li>
-    
-    
+
+
       <li class="pytorch-breadcrumbs-aside">
-        
-            
-            
+
+
+
               <!-- User defined GitHub URL -->
               <a href="https://github.com/pytorch/pytorch" class="fa fa-github"> Edit on GitHub</a>
-            
-          
-        
+
+
+
       </li>
-    
+
   </ul>
 
-  
+
 </div>
         </div>
 
@@ -282,13 +292,13 @@
       <section data-toggle="wy-nav-shift" id="pytorch-content-wrap" class="pytorch-content-wrap">
         <div class="pytorch-content-left">
 
-        
-          
+
+
           <div class="rst-content">
-          
+
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
-              
+
   <div class="section" id="pytorch-documentation">
 <h1>PyTorch documentation<a class="headerlink" href="#pytorch-documentation" title="Permalink to this headline">¶</a></h1>
 <p>PyTorch is an optimized tensor library for deep learning using GPUs and CPUs.</p>
@@ -397,23 +407,23 @@
 
 
              </article>
-             
+
             </div>
             <footer>
-  
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
-        <a href="notes/autograd.html" class="btn btn-neutral float-right" title="Autograd mechanics" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
-      
-      
-    </div>
-  
 
-  
+    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+
+        <a href="notes/autograd.html" class="btn btn-neutral float-right" title="Autograd mechanics" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
+
+
+    </div>
+
+
+
 
     <hr>
 
-  
+
 
   <div role="contentinfo">
     <p>
@@ -421,11 +431,11 @@
 
     </p>
   </div>
-    
+
       <div>
         Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
       </div>
-     
+
 
 </footer>
 
@@ -448,20 +458,20 @@
       </section>
     </div>
 
-  
 
 
-  
 
-     
+
+
+
        <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
          <script type="text/javascript" src="_static/jquery.js"></script>
          <script type="text/javascript" src="_static/underscore.js"></script>
          <script type="text/javascript" src="_static/doctools.js"></script>
          <script type="text/javascript" src="_static/language_data.js"></script>
-     
 
-  
+
+
 
   <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
   <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
@@ -471,7 +481,7 @@
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script> 
+  </script>
 
   <!-- Begin Footer -->
 

--- a/docs/stable/community/persons_of_interest.html
+++ b/docs/stable/community/persons_of_interest.html
@@ -6,26 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
   <title>PyTorch Governance | Persons of Interest &mdash; PyTorch master documentation</title>
-  
 
-  
-  
-  
-  
+
+
+
+
+
     <link rel="canonical" href="https://pytorch.org/docs/stable/community/persons_of_interest.html"/>
-  
 
-  
 
-  
-  
-    
 
-  
+
+
+
+
+
+
 
   <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
@@ -35,9 +35,9 @@
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="torch" href="../torch.html" />
-    <link rel="prev" title="PyTorch Governance" href="governance.html" /> 
+    <link rel="prev" title="PyTorch Governance" href="governance.html" />
 
-  
+
   <script src="../_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
@@ -73,25 +73,11 @@
           </li>
 
           <li>
-            <div class="ecosystem-dropdown">
-              <a id="dropdownMenuButton" data-toggle="ecosystem-dropdown">
-                Ecosystem
-              </a>
-              <div class="ecosystem-dropdown-menu">
-                <a class="nav-dropdown-item" href="https://pytorch.org/hub"">
-                  <span class=dropdown-title>Models (Beta)</span>
-                  <p>Discover, publish, and reuse pre-trained models</p>
-                </a>
-                <a class="nav-dropdown-item" href="https://pytorch.org/ecosystem">
-                  <span class=dropdown-title>Tools & Libraries</span>
-                  <p>Explore the ecosystem of tools and libraries</p>
-                </a>
-              </div>
-            </div>
+            <a href="https://pytorch.org/features">Features</a>
           </li>
 
           <li>
-            <a href="https://pytorch.org/mobile">Mobile</a>
+            <a href="https://pytorch.org/ecosystem">Ecosystem</a>
           </li>
 
           <li>
@@ -107,21 +93,7 @@
           </li>
 
           <li>
-            <div class="resources-dropdown">
-              <a id="resourcesDropdownButton" data-toggle="resources-dropdown">
-                Resources
-              </a>
-              <div class="resources-dropdown-menu">
-                <a class="nav-dropdown-item" href="https://pytorch.org/resources"">
-                  <span class=dropdown-title>Developer Resources</span>
-                  <p>Find resources and get questions answered</p>
-                </a>
-                <a class="nav-dropdown-item" href="https://pytorch.org/features">
-                  <span class=dropdown-title>About</span>
-                  <p>Learn about PyTorch’s features and capabilities</p>
-                </a>
-              </div>
-            </div>
+            <a href="https://pytorch.org/resources">Resources</a>
           </li>
 
           <li>
@@ -139,9 +111,9 @@
 
 <body class="pytorch-body">
 
-   
 
-    
+
+
 
     <div class="table-of-contents-link-wrapper">
       <span>Table of Contents</span>
@@ -152,21 +124,21 @@
       <div class="pytorch-side-scroll">
         <div class="pytorch-menu pytorch-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
           <div class="pytorch-left-menu-search">
-            
 
-            
-              
-              
+
+
+
+
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.3.1 &#x25BC</a>
+                  <a href='http://pytorch.org/docs/versions.html'>1.3.0 &#x25BC</a>
                 </div>
-              
-            
-
-            
 
 
-  
+
+
+
+
+
 
 
 <div role="search">
@@ -177,15 +149,15 @@
   </form>
 </div>
 
-            
+
           </div>
 
-          
-            
-            
-              
-            
-            
+
+
+
+
+
+
               <p class="caption"><span class="caption-text">Notes</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
@@ -239,10 +211,6 @@
 <li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
 </ul>
-<p class="caption"><span class="caption-text">torchvision Reference</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torchvision/index.html">torchvision</a></li>
-</ul>
 <p class="caption"><span class="caption-text">torchaudio Reference</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
@@ -257,8 +225,8 @@
 <li class="toctree-l1"><a class="reference internal" href="../packages.html">Javadoc</a></li>
 </ul>
 
-            
-          
+
+
         </div>
       </div>
     </nav>
@@ -266,7 +234,7 @@
     <div class="pytorch-container">
       <div class="pytorch-page-level-bar" id="pytorch-page-level-bar">
         <div class="pytorch-breadcrumbs-wrapper">
-          
+
 
 
 
@@ -285,30 +253,30 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="pytorch-breadcrumbs">
-    
+
       <li>
         <a href="../index.html">
-          
+
             Docs
-          
+
         </a> &gt;
       </li>
 
-        
+
       <li>PyTorch Governance | Persons of Interest</li>
-    
-    
+
+
       <li class="pytorch-breadcrumbs-aside">
-        
-            
+
+
             <a href="../_sources/community/persons_of_interest.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
-          
-        
+
+
       </li>
-    
+
   </ul>
 
-  
+
 </div>
         </div>
 
@@ -320,13 +288,13 @@
       <section data-toggle="wy-nav-shift" id="pytorch-content-wrap" class="pytorch-content-wrap">
         <div class="pytorch-content-left">
 
-        
-          
+
+
           <div class="rst-content">
-          
+
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
-              
+
   <div class="section" id="pytorch-governance-persons-of-interest">
 <h1>PyTorch Governance | Persons of Interest<a class="headerlink" href="#pytorch-governance-persons-of-interest" title="Permalink to this headline">¶</a></h1>
 <div class="section" id="general-maintainers">
@@ -343,12 +311,86 @@
 </div>
 <div class="section" id="module-level-maintainers">
 <h2>Module-level maintainers<a class="headerlink" href="#module-level-maintainers" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="torch">
-<h3>torch.*<a class="headerlink" href="#torch" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="jit">
+<h3>JIT<a class="headerlink" href="#jit" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Greg Chanan (<a class="reference external" href="https://github.com/gchanan">gchanan</a>)</p></li>
+<li><p>Zach Devito (<a class="reference external" href="https://github.com/zdevito">zdevito</a>)</p></li>
+<li><p>Michael Suo (<a class="reference external" href="https://github.com/suo">suo</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="distributed">
+<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Pieter Noordhuis (<a class="reference external" href="https://github.com/pietern">pietern</a>)</p></li>
+<li><p>Shen Li (<a class="reference external" href="https://github.com/mrshenli">mrshenli</a>)</p></li>
+<li><p>(sunsetting) Teng Li (<a class="reference external" href="https://github.com/teng-li">teng-li</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="autograd-engine">
+<h3>Autograd Engine<a class="headerlink" href="#autograd-engine" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
+<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="multiprocessing-and-dataloaders">
+<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Simon Wang (<a class="reference external" href="https://github.com/SsnL">SsnL</a>)</p></li>
+<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
+<li><p>(proposed) Vitaly Fedyunin
+(<a class="reference external" href="https://github.com/proposed">VitalyFedyunin</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="cuda">
+<h3>CUDA<a class="headerlink" href="#cuda" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+<li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="c">
+<h3>C++<a class="headerlink" href="#c" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
+<li><p>(sunsetting) Peter Goldsborough
+(<a class="reference external" href="https://github.com/goldsborough">goldsborough</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="build-ci">
+<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+<li><p>Jesse Hellemn (<a class="reference external" href="https://github.com/pjh5">pjh5</a>)</p></li>
 <li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>[linear algebra] Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+<li><p>(sunsetting) Orion Reblitz-Richardson
+(<a class="reference external" href="https://github.com/orionr">orionr</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="distributions-rng">
+<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Fritz Obermeyer (<a class="reference external" href="https://github.com/fritzo">fritzo</a>)</p></li>
+<li><p>Neeraj Pradhan (<a class="reference external" href="https://github.com/neerajprad">neerajprad</a>)</p></li>
+<li><p>Alican Bozkurt (<a class="reference external" href="https://github.com/alicanb">alicanb</a>)</p></li>
+<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="c10">
+<h3>C10<a class="headerlink" href="#c10" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Sebastian Messmer (<a class="reference external" href="https://github.com/smessmer">smessmer</a>)</p></li>
+<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="onnx-pytorch">
+<h3>ONNX &lt;-&gt; PyTorch<a class="headerlink" href="#onnx-pytorch" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Lu Fang (<a class="reference external" href="https://github.com/houseroad">houseroad</a>)</p></li>
+<li><p>Lara Haidar (<a class="reference external" href="https://github.com/houseroad">lara-hdr</a>)</p></li>
+<li><p>Spandan Tiwari (<a class="reference external" href="https://github.com/houseroad">spandantiwari</a>)</p></li>
+<li><p>Bowen Bao (<a class="reference external" href="https://github.com/houseroad">BowenBao</a>)</p></li>
 </ul>
 </div>
 <div class="section" id="torch-nn">
@@ -361,74 +403,30 @@
 <li><p>Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="torch-optim">
-<h3>torch.optim<a class="headerlink" href="#torch-optim" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Vincent Quenneville-Belair (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
-<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="autograd-engine">
-<h3>Autograd Engine<a class="headerlink" href="#autograd-engine" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
-<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="jit">
-<h3>JIT<a class="headerlink" href="#jit" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Zach Devito (<a class="reference external" href="https://github.com/zdevito">zdevito</a>)</p></li>
-<li><p>Michael Suo (<a class="reference external" href="https://github.com/suo">suo</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="distributions-rng">
-<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Fritz Obermeyer (<a class="reference external" href="https://github.com/fritzo">fritzo</a>)</p></li>
-<li><p>Neeraj Pradhan (<a class="reference external" href="https://github.com/neerajprad">neerajprad</a>)</p></li>
-<li><p>Alican Bozkurt (<a class="reference external" href="https://github.com/alicanb">alicanb</a>)</p></li>
-<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="distributed">
-<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Pieter Noordhuis (<a class="reference external" href="https://github.com/pietern">pietern</a>)</p></li>
-<li><p>Shen Li (<a class="reference external" href="https://github.com/mrshenli">mrshenli</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="multiprocessing-and-dataloaders">
-<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
-<li><p>Simon Wang (<a class="reference external" href="https://github.com/SsnL">SsnL</a>)</p></li>
-<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
-</ul>
-</div>
 <div class="section" id="cpu-performance-simd">
 <h3>CPU Performance / SIMD<a class="headerlink" href="#cpu-performance-simd" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
-<li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
+<li><p>Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
 <li><p>Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
-<li><p>(sunsetting) Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
-<li><p>[threading] Ilia Cherniavskii (<a class="reference external" href="https://github.com/ilia-cher">ilia-cher</a>)</p></li>
+<li><p>Richard Zou (<a class="reference external" href="https://github.com/zou3519">zou3519</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="cuda">
-<h3>CUDA<a class="headerlink" href="#cuda" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="amd-rocm-hip">
+<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
+<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
+<li><p>Johannes M. Dieterich (<a class="reference external" href="https://github.com/iotamudelta">iotamudelta</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="windows">
+<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
 </ul>
 </div>
 <div class="section" id="mkldnn">
 <h3>MKLDNN<a class="headerlink" href="#mkldnn" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
 <li><p>Yinghai Lu (<a class="reference external" href="https://github.com/yinghai">yinghai</a>)</p></li>
 </ul>
 </div>
@@ -441,58 +439,28 @@
 <li><p>Alex Suhan (<a class="reference external" href="https://github.com/asuhan">asuhan</a>)</p></li>
 </ul>
 </div>
-<div class="section" id="amd-rocm-hip">
-<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
-<li><p>Johannes M. Dieterich (<a class="reference external" href="https://github.com/iotamudelta">iotamudelta</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="build-ci">
-<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>Karl Ostmo (<a class="reference external" href="https://github.com/kostmo">kostmo</a>)</p></li>
-<li><p>Hong Xu (<a class="reference external" href="https://github.com/xuhdev">xuhdev</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="benchmarks">
-<h3>Benchmarks<a class="headerlink" href="#benchmarks" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Mingzhe Li (<a class="reference external" href="https://github.com/mingzhe09088">mingzhe09088</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="c-api">
-<h3>C++ API<a class="headerlink" href="#c-api" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="c10-utils-and-operator-dispatch">
-<h3>C10 utils and operator dispatch<a class="headerlink" href="#c10-utils-and-operator-dispatch" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Sebastian Messmer (<a class="reference external" href="https://github.com/smessmer">smessmer</a>)</p></li>
-<li><p>Dmytro Dzhulgakov (<a class="reference external" href="https://github.com/dzhulgakov">dzhulgakov</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="onnx-pytorch">
-<h3>ONNX &lt;-&gt; PyTorch<a class="headerlink" href="#onnx-pytorch" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Lu Fang (<a class="reference external" href="https://github.com/houseroad">houseroad</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="windows">
-<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this headline">¶</a></h3>
-<ul class="simple">
-<li><p>Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="powerpc">
-<h3>PowerPC<a class="headerlink" href="#powerpc" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="ppc">
+<h3>PPC<a class="headerlink" href="#ppc" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Alfredo Mendoza (<a class="reference external" href="https://github.com/avmgithub">avmgithub</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchvision">
+<h3>torchvision<a class="headerlink" href="#torchvision" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Francisco Massa (<a class="reference external" href="https://github.com/fmassa">fmassa</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchtext">
+<h3>torchtext<a class="headerlink" href="#torchtext" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Guanheng George Zhang (<a class="reference external" href="https://github.com/zhangguanheng66">zhangguanheng66</a>)</p></li>
+</ul>
+</div>
+<div class="section" id="torchaudio">
+<h3>torchaudio<a class="headerlink" href="#torchaudio" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Vincent Quenneville-Belair (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
 </ul>
 </div>
 </div>
@@ -500,25 +468,25 @@
 
 
              </article>
-             
+
             </div>
             <footer>
-  
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
-        <a href="../torch.html" class="btn btn-neutral float-right" title="torch" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
-      
-      
-        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
-      
-    </div>
-  
 
-  
+    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+
+        <a href="../torch.html" class="btn btn-neutral float-right" title="torch" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+
+
+        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+
+    </div>
+
+
+
 
     <hr>
 
-  
+
 
   <div role="contentinfo">
     <p>
@@ -526,11 +494,11 @@
 
     </p>
   </div>
-    
+
       <div>
         Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
       </div>
-     
+
 
 </footer>
 
@@ -576,20 +544,20 @@
       </section>
     </div>
 
-  
 
 
-  
 
-     
+
+
+
        <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
          <script type="text/javascript" src="../_static/jquery.js"></script>
          <script type="text/javascript" src="../_static/underscore.js"></script>
          <script type="text/javascript" src="../_static/doctools.js"></script>
          <script type="text/javascript" src="../_static/language_data.js"></script>
-     
 
-  
+
+
 
   <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
   <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
@@ -599,7 +567,7 @@
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script> 
+  </script>
 
   <!-- Begin Footer -->
 
@@ -727,23 +695,15 @@
       <div class="main-menu">
         <ul>
           <li>
-            <a href="https://pytorch.org/get-started">Get Started</a>
+            <a href="#">Get Started</a>
           </li>
 
           <li>
-            <a href="https://pytorch.org/features">Features</a>
+            <a href="#">Features</a>
           </li>
 
           <li>
-            <a href="https://pytorch.org/ecosystem">Ecosystem</a>
-          </li>
-
-          <li>
-            <a href="https://pytorch.org/mobile">Mobile</a>
-          </li>
-
-          <li>
-            <a href="https://pytorch.org/hub">PyTorch Hub</a>
+            <a href="#">Ecosystem</a>
           </li>
 
           <li>
@@ -782,7 +742,6 @@
       sideMenus.bind();
       scrollToAnchor.bind();
       highlightNavigation.bind();
-      mainMenuDropdown.bind();
 
       // Add class to links that have code blocks, since we cannot create links in code blocks
       $("article.pytorch-article a span.pre").each(function(e) {


### PR DESCRIPTION
Update Persons of Interest in v1.3.0 and stable to match that of v1.2.0
v1.2.0: https://pytorch.org/docs/1.2.0/community/persons_of_interest.html

Correct the incorrectly hyperlinked sidebars from the Persons of Interest page and the index.html

Below is a local build via `make serve` of the v1.3.0 Persons of Interest docs page: 

<img width="1124" alt="Screen Shot 2019-11-30 at 3 37 18 PM" src="https://user-images.githubusercontent.com/8042156/69905851-e8795580-1387-11ea-8c1b-29f20a48af42.png">

