### PR TITLE
Adjust features page for mobile view

### DIFF
--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -155,6 +155,12 @@ a, .btn {
 
   &.features-background {
     background-image: url($baseurl + "/assets/images/features-background.jpg");
+    @include desktop {
+      height: 300px;
+    }
+    @media (max-width: 320px) {
+      height: 350px;
+    }
   }
 
   &.blog-background {

--- a/_sass/features.scss
+++ b/_sass/features.scss
@@ -17,6 +17,14 @@
   }
 }
 
+.features {
+  .main-content-wrapper {
+    @media (max-width: 320px) {
+      margin-top: 340px;
+    }
+  }
+}
+
 .features-row {
   padding-bottom: rem(60px);
   align-items: center;
@@ -152,7 +160,13 @@
 }
 
 .features .jumbotron {
-  height: 195px;
+  height: 200px;
+  @include desktop {
+    height: 195px;
+  }
+  @media (max-width: 320px) {
+    height: 250px;
+  }
   h1 {
     padding-top: rem(30px);
   }


### PR DESCRIPTION
This PR updates the features page jumbotron area so that the text isn't cut off on mobile views. The preview can be viewed here: https://5de6cc2d5408fc01808637e6--shiftlab-pytorch-github-io.netlify.com.