### PR TITLE
Update hub page layout

### DIFF
--- a/hub/hub.html
+++ b/hub/hub.html
@@ -13,8 +13,8 @@ body-class: hub
       <span id="hub-sub-header"></span>Hub</span>
     </h1>
 
-    <p class="lead">Discover and publish models to a pre-trained model repository designed for both research exploration and development needs.
-      Check out the models for <a href="#model-row">Researchers</a> and <a href="#model-row">Developers</a>, or learn <a href="https://pytorch.org/docs/stable/hub.html">How It Works</a>.</p>
+    <p class="lead">Discover and publish models to a pre-trained model repository designed for research exploration. <br>
+      Check out the models for <a href="#model-row">Researchers</a>, or learn <a href="https://pytorch.org/docs/stable/hub.html">How It Works</a>.</p>
     <p><a href="{{ site.external_urls.hub_template }}">Contribute Models</a></p>
     <p class="hub-release-message">*This is a beta release - we will be collecting feedback and improving the PyTorch Hub over the coming months.</p>
 
@@ -26,7 +26,7 @@ body-class: hub
     <div class="container">
       <!-- START CONTENT -->
       <div class="row" id="model-row">
-        <div class="col-md-6 hub-column">
+        <div class="col-md-12 hub-column">
           <h3 class="research-hub-title">For Researchers —</h3>
           <h3 class="research-hub-sub-title">Explore and extend models<br> from the latest <br>cutting edge research</h3>
 
@@ -61,7 +61,7 @@ body-class: hub
               {% assign hub = site.hub | where: "category", "researchers" | sort: "order" %}
 
               {% for item in hub %}
-                <div class="col-md-12 research-hub-card-wrapper" data-item-count="{{ forloop.index }}" data-tags="{{ item.tags | join: ',' }}">
+                <div class="col-md-6 research-hub-card-wrapper" data-item-count="{{ forloop.index }}" data-tags="{{ item.tags | join: ',' }}">
                   <div class="card hub-card">
                     <a href="{{ site.baseurl }}{{ item.url }}">
                       <div class="card-body">
@@ -88,7 +88,7 @@ body-class: hub
           </div>
         </div>
 
-        <div class="col-md-6 hub-column">
+        <!-- <div class="col-md-6 hub-column">
           <h3 class="research-hub-title">For Developers —</h3>
           <h3 class="research-hub-sub-title">Get plug & play models<br> to accelerate <br> ML development</h3>
 
@@ -115,7 +115,7 @@ body-class: hub
                 </ul>
               </div>
             </div>
-            <!--             
+
             <a id="dropdownSort" data-toggle="dropdown" data-target="#dropdownSortMenu" >
               Sort <img src="{{ site.baseurl }}/assets/images/filter-arrow.svg">
             </a>
@@ -166,8 +166,7 @@ body-class: hub
               <a class="all-models-button" id="development-models" href="{{ site.baseurl }}/hub/developer-models">All Developer Models ({{ hub | size}})</a>
             </div>
           </div>
-          -->
-        </div>
+        </div> -->
       </div>
 
       <div class="row how-it-works">
@@ -206,5 +205,5 @@ body-class: hub
 </div>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-<script list-id="hub-index-cards" display-count="3" pagination="false" src="{{ site.baseurl }}/assets/filter-hub-tags.js"></script>
+<script list-id="hub-index-cards" display-count="6" pagination="false" src="{{ site.baseurl }}/assets/filter-hub-tags.js"></script>
 <script src="{{ site.baseurl }}/assets/hub-search-bar.js"></script>

--- a/hub/research_models_compact_index.html
+++ b/hub/research_models_compact_index.html
@@ -6,6 +6,7 @@ background-class: hub-background
 body-class: hub
 summary: Explore and extend models from the latest cutting edge research.
 compact: true
+redirect_from: "/hub/developer-models/compact"
 ---
 
 {% include hub_researcher_tags_and_cards.html %}

--- a/hub/research_models_index.html
+++ b/hub/research_models_index.html
@@ -5,6 +5,7 @@ permalink: hub/research-models
 background-class: hub-background
 body-class: hub
 summary: Explore and extend models from the latest cutting edge research.
+redirect_from: "/hub/developer-models"
 ---
 
 {% include hub_researcher_tags_and_cards.html %}


### PR DESCRIPTION
This PR removes the "For Developers" section from the hub page.