### PR TITLE
Changed incorrect function name in doc

### DIFF
--- a/docs/master/torch.html
+++ b/docs/master/torch.html
@@ -5402,7 +5402,7 @@ via the biased estimator. Otherwise, Bessel’s correction will be used.</p>
 </div>
 <dl class="function">
 <dt>
-<code class="sig-prename descclassname">torch.</code><code class="sig-name descname">std</code><span class="sig-paren">(</span><em class="sig-param">input</em>, <em class="sig-param">dim</em>, <em class="sig-param">keepdim=False</em>, <em class="sig-param">unbiased=True) -&gt; (Tensor</em>, <em class="sig-param">Tensor</em><span class="sig-paren">)</span></dt>
+<code class="sig-prename descclassname">torch.</code><code class="sig-name descname">std_mean</code><span class="sig-paren">(</span><em class="sig-param">input</em>, <em class="sig-param">dim</em>, <em class="sig-param">keepdim=False</em>, <em class="sig-param">unbiased=True) -&gt; (Tensor</em>, <em class="sig-param">Tensor</em><span class="sig-paren">)</span></dt>
 <dd></dd></dl>
 
 <p>Returns the standard-deviation and mean of each row of the <code class="xref py py-attr docutils literal notranslate"><span class="pre">input</span></code> tensor in the


### PR DESCRIPTION
std_mean is incorrectly called std in the docs:

 torch.std(input, dim, keepdim=False, unbiased=True) -> (Tensor, Tensor)

Should be:

 torch.std_mean(input, dim, keepdim=False, unbiased=True) -> (Tensor, Tensor)