### PR TITLE
PR for issue #31678

### DIFF
--- a/docs/master/onnx.html
+++ b/docs/master/onnx.html
@@ -1104,12 +1104,11 @@ which are defined in torch/onnx/symbolic_helper.py</p></li>
 optimization is applied to the model during export. Constant-folding
 optimization will replace some of the ops that have all constant
 inputs, with pre-computed constant nodes.</p></li>
-<li><p><strong>example_outputs</strong> (<em>tuple of Tensors</em><em>, </em><em>default None</em>) – example_outputs must be provided
+<li><p><strong>example_outputs</strong> (<em>tuple of Tensors</em><em>, </em><em>default None</em>) –Example outputs of the model that is being exported. example_outputs must be provided
 when exporting a ScriptModule or TorchScript Function.</p></li>
 <li><p><strong>strip_doc_string</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>default True</em>) – if True, strips the field
 “doc_string” from the exported model, which information about the stack
 trace.</p></li>
-<li><p><strong>example_outputs</strong> – example outputs of the model that is being exported.</p></li>
 <li><p><strong>dynamic_axes</strong> (<em>dict&lt;string</em><em>, </em><em>dict&lt;python:int</em><em>, </em><em>string&gt;&gt;</em><em> or </em><em>dict&lt;string</em><em>, </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>(</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>)</em><em>&gt;</em><em>, </em><em>default empty dict</em>) – <p>a dictionary to specify dynamic axes of input/output, such that:
 - KEY:  input and/or output names
 - VALUE: index of dynamic axes for given key and potentially the name to be used for


### PR DESCRIPTION
[docs] torch.onnx.export docs contains two descriptions for example_outputs arg #31678
So combined the information for it with the description with the parameters. 
This is my first PR so please tell me if I have done something wrong.
Thank you.
Fixes https://github.com/pytorch/pytorch/issues/31678