### PR TITLE
Cloud Partner Left Nav

### DIFF
--- a/_get_started/get-started-via-cloud-partners.md
+++ b/_get_started/get-started-via-cloud-partners.md
@@ -6,6 +6,7 @@ background-class: get-started-background
 body-class: get-started
 order: 2
 published: true
+get-started-via-cloud: true
 ---
 
 ## Start via Cloud Partners
@@ -20,26 +21,14 @@ published: true
 ---
 
 {% capture aws %}
-<nav class="inline_toc" markdown="1">
-* TOC
-{:toc}
-</nav>
 {% include_relative installation/aws.md %}
 {% endcapture %}
 
 {% capture azure %}
-<nav class="inline_toc" markdown="1">
-* TOC
-{:toc}
-</nav>
 {% include_relative installation/azure.md %}
 {% endcapture %}
 
 {% capture google-cloud %}
-<nav class="inline_toc" markdown="1">
-* TOC
-{:toc}
-</nav>
 {% include_relative installation/google-cloud.md %}
 {% endcapture %}
 

--- a/_get_started/installation/google-cloud.md
+++ b/_get_started/installation/google-cloud.md
@@ -20,6 +20,7 @@ Once you are logged in, you will be brought to your [Google Cloud console](https
 Google Cloud provides no setup required, pre-configured virtual machines to help you build your deep learning projects. [Cloud Deep Learning VM Image](https://cloud.google.com/deep-learning-vm-image/){:target="_blank"} is a set of Debian-based virtual machines that allow you to [build and run](https://cloud.google.com/deep-learning-vm/docs/) machine PyTorch learning based applications.
 
 ### GPU-based Virtual Machines
+{: #google-cloud-gpu-based-virtual-machines}
 
 For custom virtual machines, generally you will want to use [Compute Engine Virtual Machine instances](https://cloud.google.com/compute/){:target="_blank"}), with GPU enabled, to build with PyTorch. Google has [various virtual machine types](https://console.cloud.google.com/compute/instances) and pricing options, with both [Linux](https://cloud.google.com/compute/docs/quickstart-linux){:target="_blank"} and [Windows](https://cloud.google.com/compute/docs/quickstart-windows){:target="_blank"}, all of which can be configured for specific use cases. For PyTorch, it is highly recommended that you use a [GPU-enabled](https://cloud.google.com/compute/docs/gpus/add-gpus){:target="_blank"} virtual machines. They are tailored for the high compute needs of machine learning.
 

--- a/_includes/get_started_via_cloud.html
+++ b/_includes/get_started_via_cloud.html
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-md-3 cloud-nav">
+    {% include get_started_via_cloud_side_nav.html %}
+  </div>
+  <div class="col-md-12">
+    <div class="article-wrapper" data-id="{{ item.slug }}">
+      <article class="pytorch-article">
+        {{ content }}
+      </article>
+    </div>
+  </div>
+</div>

--- a/_includes/get_started_via_cloud_side_nav.html
+++ b/_includes/get_started_via_cloud_side_nav.html
@@ -1,0 +1,3 @@
+<div class="sticky-top get-started-cloud-sidebar">
+  <ul id="get-started-cloud-sidebar-list"></ul>
+</div>

--- a/_includes/quick_start_cloud_options.html
+++ b/_includes/quick_start_cloud_options.html
@@ -1,7 +1,7 @@
 <div class="quick-start-guides">
   <div class="cloud-option-row">
     <div class="cloud-option" data-toggle="cloud-dropdown">
-      <div class="cloud-option-body alibaba">
+      <div class="cloud-option-body alibaba" id="alibaba">
         Alibaba Cloud
       </div>
       <ul>
@@ -12,7 +12,7 @@
   
   <div class="cloud-option-row">
     <div class="cloud-option" data-toggle="cloud-dropdown">
-      <div class="cloud-option-body aws">
+      <div class="cloud-option-body aws" id="aws">
         Amazon Web Services
       </div>
 
@@ -25,7 +25,7 @@
 
   <div class="cloud-option-row">
     <div class="cloud-option" data-toggle="cloud-dropdown">
-      <div class="cloud-option-body google-cloud">
+      <div class="cloud-option-body google-cloud" id="google-cloud">
         Google Cloud Platform
       </div>
 
@@ -42,7 +42,7 @@
 
   <div class="cloud-option-row">
     <div class="cloud-option" data-toggle="cloud-dropdown">
-      <div class="cloud-option-body microsoft-azure">
+      <div class="cloud-option-body microsoft-azure" id="microsoft-azure">
         Microsoft Azure
       </div>
 

--- a/_layouts/get_started.html
+++ b/_layouts/get_started.html
@@ -37,6 +37,10 @@
 
             {% include get_started_locally.html %}
 
+          {% elsif page.get-started-via-cloud == true %}
+
+            {% include get_started_via_cloud.html %}
+
           {% else %}
 
             <div class="article-wrapper" data-id="{{ item.slug }}">
@@ -54,6 +58,4 @@
   </body>
 </html>
 
-{% if page.get-started-locally == true %}
-  <script src="{{ site.baseurl }}/assets/get-started-sidebar.js"></script>
-{% endif %}
+<script src="{{ site.baseurl }}/assets/get-started-sidebar.js"></script>

--- a/_sass/get-started.scss
+++ b/_sass/get-started.scss
@@ -238,3 +238,38 @@
     padding-left: rem(20px);
   }
 }
+
+.cloud-nav {
+  display: none;
+}
+
+.get-started .get-started-cloud-sidebar {
+  padding-top: rem(50px);
+  padding-bottom: rem(40px);
+  top: 15%;
+
+  ul {
+    padding-left: 0;
+  }
+
+  li {
+    list-style-type: none;
+    line-height: 36px;
+
+    a {
+      color: #8c8c8c;
+      &.active,
+      &:hover {
+        color: $orange;
+      }
+    }
+
+    .subitem {
+      padding-left: rem(20px);
+    }
+  }
+
+  li.subitem {
+    padding-left: rem(20px);
+  }
+}

--- a/assets/get-started-sidebar.js
+++ b/assets/get-started-sidebar.js
@@ -1,36 +1,53 @@
-// Create the sidebar menus for each OS
+// Create the sidebar menus for each OS and Cloud Partner
 
 $([".macos", ".linux", ".windows"]).each(function(index, osClass) {
-  buildSidebarMenu(osClass);
+  buildSidebarMenu(osClass, "#get-started-locally-sidebar-list");
 });
 
-// On page load initially show the Mac OS menu
-
-showSidebar("macos");
-
-$("#macos").on("click", function() {
-  showSidebar("macos");
+$([".alibaba", ".aws", ".microsoft-azure", ".google-cloud"]).each(function(index, cloudPartner) {
+  buildSidebarMenu(cloudPartner, "#get-started-cloud-sidebar-list");
 });
 
-$("#linux").on("click", function() {
-  showSidebar("linux");
+// On start locally page load initially show the Mac OS menu
+showSidebar("macos", ".get-started-locally-sidebar li");
+
+$(["macos", "linux", "windows"]).each(function(index, osClass) {
+  $("#" + osClass).click(function() {
+    showSidebar(osClass, ".get-started-locally-sidebar li");
+  })
 });
 
-$("#windows").on("click", function() {
-  showSidebar("windows");
+// Show cloud partner side nav on click or hide side nav if already open 
+$(["alibaba", "aws", "microsoft-azure", "google-cloud"]).each(function(index, sidebarClass) {
+  $("#" + sidebarClass).click(function() {
+    showSidebar(sidebarClass, ".get-started-cloud-sidebar li");
+    // alibaba filter for centering cloud module
+    if (sidebarClass == "alibaba") {
+      $(".article-wrapper").parent().removeClass("col-md-8 offset-md-1").addClass("col-md-12");
+      $(".cloud-nav").hide();
+    } else {
+      $(".article-wrapper").parent().removeClass("col-md-12").addClass("col-md-8 offset-md-1");
+      $(".cloud-nav").show();
+    }
+    if ($("#" + sidebarClass).parent().hasClass("open")) {
+      $(".get-started-cloud-sidebar li").hide();
+      $(".cloud-nav").hide();
+      $(".article-wrapper").parent().removeClass("col-md-8 offset-md-1").addClass("col-md-12");
+    }
+  })
 });
 
-function buildSidebarMenu(osClass) {
-  $(osClass + " > h2," + osClass + " > h3").each(function(index, element) {
-    osClass = osClass.replace(".", "");
+function buildSidebarMenu(menuClass, menuItem) {
+  $(menuClass + " > h2," + menuClass + " > h3").each(function(index, element) {
+    menuClass = menuClass.replace(".", "");
 
     // If the menu item is an H3 tag then it should be indented
     var indentMenuItem = $(element).get(0).tagName == "H3" ? "subitem" : "";
 
     // Combine the menu item classes
-    var menuItemClasses = [osClass, indentMenuItem].join(" ");
+    var menuItemClasses = [menuClass, indentMenuItem].join(" ");
 
-    $("#get-started-locally-sidebar-list").append(
+    $(menuItem).append(
       "<li class='" +
         menuItemClasses +
         "' style='display:none'><a href=#" +
@@ -42,16 +59,15 @@ function buildSidebarMenu(osClass) {
   });
 }
 
-function showSidebar(osClass) {
+function showSidebar(selectedClass, menuItem) {
   // Hide all of the menu items at first
-  // Then filter for the selected OS
-
-  $(".get-started-locally-sidebar li")
+  // Then filter for the selected OS/cloud partner
+  $(menuItem)
     .hide()
     .filter(function() {
       return $(this)
         .attr("class")
-        .includes(osClass);
+        .includes(selectedClass);
     })
     .show();
 }


### PR DESCRIPTION
* Moved right nav to the left side for cloud partners
  * Nav was previously tucked on the right side in-line with drop-down content
  * Functions similar to Get Started Locally left nav
* Created new id for Google Cloud GPU to avoid confusion with Microsoft GPU
  * Google Cloud GPU and Microsoft Azure both shared the same id which broke the Azure link.
* Centered Cloud Module when no cloud partner is selected