### PR TITLE
Add excerpt variable to front matter block

### DIFF
--- a/_posts/2019-12-06-openmined-and-pytorch-launch-fellowship-funding-for-privacy-preserving-ml.md
+++ b/_posts/2019-12-06-openmined-and-pytorch-launch-fellowship-funding-for-privacy-preserving-ml.md
@@ -2,6 +2,7 @@
 layout: blog_detail
 title: 'OpenMined and PyTorch partner to launch fellowship funding for privacy-preserving ML community'
 author: Andrew Trask (OpenMined/U.Oxford), Shubho Sengupta, Laurens van der Maaten, Joe Spisak
+excerpt: Many applications of machine learning (ML) pose a range of security and privacy challenges.
 ---
 
 <div class="text-center">


### PR DESCRIPTION
This PR resolves the formatting issue that occurs when the "OpenMined and PyTorch partner..." blog post is a featured post. Since the post begins with an image instead of text, the featured post excerpt is thrown off. By adding an excerpt variable to the post, the issue is resolved.