### PR TITLE
Change torchvision model href so it gets you to the code instead of paper

### DIFF
--- a/docs/master/torchvision/models.html
+++ b/docs/master/torchvision/models.html
@@ -349,18 +349,18 @@ keypoint detection and video classification.</p>
 <p>The models subpackage contains definitions for the following model
 architectures for image classification:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://arxiv.org/abs/1404.5997">AlexNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1409.1556">VGG</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1512.03385">ResNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1602.07360">SqueezeNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1608.06993">DenseNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1512.00567">Inception</a> v3</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1409.4842">GoogLeNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1807.11164">ShuffleNet</a> v2</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1801.04381">MobileNet</a> v2</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1611.05431">ResNeXt</a></p></li>
+<li><p><a class="reference internal" href="#torchvision.models.alexnet">AlexNet</a></p></li>
+<li><p><a class="reference internal" href="#id2">VGG</a></p></li>
+<li><p><a class="reference internal" href="#id10">ResNet</a></p></li>
+<li><p><a class="reference internal" href="#id15">SqueezeNet</a></p></li>
+<li><p><a class="reference internal" href="#id16">DenseNet</a></p></li>
+<li><p><a class="reference internal" href="#inception-v3">Inception</a> v3</p></li>
+<li><p><a class="reference internal" href="#id23">GoogLeNet</a></p></li>
+<li><p><a class="reference internal" href="#shufflenet-v2">ShuffleNet</a> v2</p></li>
+<li><p><a class="reference internal" href="#mobilenet-v2">MobileNet</a> v2</p></li>
+<li><p><a class="reference internal" href="#id27">ResNeXt</a></p></li>
 <li><p><a class="reference internal" href="#wide-resnet">Wide ResNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1807.11626">MNASNet</a></p></li>
+<li><p><a class="reference external" href="#id30">MNASNet</a></p></li>
 </ul>
 <p>You can construct a model with random weights by calling its constructor:</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.models</span> <span class="k">as</span> <span class="nn">models</span>


### PR DESCRIPTION
I feel the torchvision model links on the first page on https://pytorch.org/docs/stable/torchvision/models.html should scroll you down to the code and the link to the paper is there anyways. It would save some time for readers I think and make reading the docs easier. 

I'm not comfortable coding in html but these changes seemed very easy to do and locally they seemed to work. But you may want to check it extra so I didn't mess anything up.