### PR TITLE
Missing package - error on colab

### DIFF
--- a/assets/hub/huggingface_pytorch-transformers.ipynb
+++ b/assets/hub/huggingface_pytorch-transformers.ipynb
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "pip install tqdm boto3 requests regex sentencepiece sacremoses"
+    "pip install tqdm boto3 requests regex sentencepiece sacremoses transformers"
    ]
   },
   {


### PR DESCRIPTION
I got the following error:  ModuleNotFoundError: No module named 'tokenizers'
error reproduction: Open on colab and execute this line after the command pip
`tokenizer = torch.hub.load('huggingface/pytorch-transformers', 'tokenizer', 'bert-base-cased')`
The problem is found in every line containing torch.hub.load(huggingface ...)
Fix: add the transformers dependecy