### PR TITLE
fix pip command for torch 1.2.0 CUDA 10.0

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -53,7 +53,7 @@ pip install torch==1.2.0 torchvision==0.4.0
 
 ```
 # CUDA 10.0
-pip install torch===1.2.0 torchvision===0.4.0 -f https://download.pytorch.org/whl/torch_stable.html
+pip install torch==1.2.0 torchvision===0.4.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 9.2
 pip install torch==1.2.0+cu92 torchvision==0.4.0+cu92 -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
Replace `===` to `==` in the pip install command for torch 1.2.0 CUDA 10.0