### PR TITLE
change html header title to 'Pytorch 1.5.0 documentation' 

### DIFF
--- a/docs/stable/__config__.html
+++ b/docs/stable/__config__.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.__config__ &mdash; PyTorch master documentation</title>
+  <title>torch.__config__ &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/index.html
+++ b/docs/stable/_modules/index.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Overview: module code &mdash; PyTorch master documentation</title>
+  <title>Overview: module code &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch.html
+++ b/docs/stable/_modules/torch.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch &mdash; PyTorch master documentation</title>
+  <title>torch &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/__config__.html
+++ b/docs/stable/_modules/torch/__config__.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.__config__ &mdash; PyTorch master documentation</title>
+  <title>torch.__config__ &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/_jit_internal.html
+++ b/docs/stable/_modules/torch/_jit_internal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch._jit_internal &mdash; PyTorch master documentation</title>
+  <title>torch._jit_internal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/_lobpcg.html
+++ b/docs/stable/_modules/torch/_lobpcg.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch._lobpcg &mdash; PyTorch master documentation</title>
+  <title>torch._lobpcg &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/_lowrank.html
+++ b/docs/stable/_modules/torch/_lowrank.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch._lowrank &mdash; PyTorch master documentation</title>
+  <title>torch._lowrank &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/_tensor_str.html
+++ b/docs/stable/_modules/torch/_tensor_str.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch._tensor_str &mdash; PyTorch master documentation</title>
+  <title>torch._tensor_str &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/_utils.html
+++ b/docs/stable/_modules/torch/_utils.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch._utils &mdash; PyTorch master documentation</title>
+  <title>torch._utils &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd.html
+++ b/docs/stable/_modules/torch/autograd.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd &mdash; PyTorch master documentation</title>
+  <title>torch.autograd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/anomaly_mode.html
+++ b/docs/stable/_modules/torch/autograd/anomaly_mode.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.anomaly_mode &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.anomaly_mode &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/function.html
+++ b/docs/stable/_modules/torch/autograd/function.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.function &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.function &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/functional.html
+++ b/docs/stable/_modules/torch/autograd/functional.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.functional &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/grad_mode.html
+++ b/docs/stable/_modules/torch/autograd/grad_mode.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.grad_mode &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.grad_mode &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/gradcheck.html
+++ b/docs/stable/_modules/torch/autograd/gradcheck.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.gradcheck &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.gradcheck &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/autograd/profiler.html
+++ b/docs/stable/_modules/torch/autograd/profiler.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.autograd.profiler &mdash; PyTorch master documentation</title>
+  <title>torch.autograd.profiler &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda.html
+++ b/docs/stable/_modules/torch/cuda.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda &mdash; PyTorch master documentation</title>
+  <title>torch.cuda &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/amp/grad_scaler.html
+++ b/docs/stable/_modules/torch/cuda/amp/grad_scaler.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.amp.grad_scaler &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.amp.grad_scaler &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/comm.html
+++ b/docs/stable/_modules/torch/cuda/comm.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.comm &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.comm &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/memory.html
+++ b/docs/stable/_modules/torch/cuda/memory.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.memory &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.memory &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/nvtx.html
+++ b/docs/stable/_modules/torch/cuda/nvtx.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.nvtx &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.nvtx &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/random.html
+++ b/docs/stable/_modules/torch/cuda/random.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.random &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.random &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/cuda/streams.html
+++ b/docs/stable/_modules/torch/cuda/streams.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda.streams &mdash; PyTorch master documentation</title>
+  <title>torch.cuda.streams &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed.html
+++ b/docs/stable/_modules/torch/distributed.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed &mdash; PyTorch master documentation</title>
+  <title>torch.distributed &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed/autograd.html
+++ b/docs/stable/_modules/torch/distributed/autograd.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed.autograd &mdash; PyTorch master documentation</title>
+  <title>torch.distributed.autograd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed/distributed_c10d.html
+++ b/docs/stable/_modules/torch/distributed/distributed_c10d.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed.distributed_c10d &mdash; PyTorch master documentation</title>
+  <title>torch.distributed.distributed_c10d &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed/optim/optimizer.html
+++ b/docs/stable/_modules/torch/distributed/optim/optimizer.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed.optim.optimizer &mdash; PyTorch master documentation</title>
+  <title>torch.distributed.optim.optimizer &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed/rpc.html
+++ b/docs/stable/_modules/torch/distributed/rpc.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed.rpc &mdash; PyTorch master documentation</title>
+  <title>torch.distributed.rpc &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributed/rpc/api.html
+++ b/docs/stable/_modules/torch/distributed/rpc/api.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributed.rpc.api &mdash; PyTorch master documentation</title>
+  <title>torch.distributed.rpc.api &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/bernoulli.html
+++ b/docs/stable/_modules/torch/distributions/bernoulli.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.bernoulli &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.bernoulli &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/beta.html
+++ b/docs/stable/_modules/torch/distributions/beta.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.beta &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.beta &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/binomial.html
+++ b/docs/stable/_modules/torch/distributions/binomial.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.binomial &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.binomial &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/categorical.html
+++ b/docs/stable/_modules/torch/distributions/categorical.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.categorical &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.categorical &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/cauchy.html
+++ b/docs/stable/_modules/torch/distributions/cauchy.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.cauchy &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.cauchy &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/chi2.html
+++ b/docs/stable/_modules/torch/distributions/chi2.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.chi2 &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.chi2 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/constraint_registry.html
+++ b/docs/stable/_modules/torch/distributions/constraint_registry.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.constraint_registry &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.constraint_registry &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/constraints.html
+++ b/docs/stable/_modules/torch/distributions/constraints.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.constraints &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.constraints &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/continuous_bernoulli.html
+++ b/docs/stable/_modules/torch/distributions/continuous_bernoulli.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.continuous_bernoulli &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.continuous_bernoulli &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/dirichlet.html
+++ b/docs/stable/_modules/torch/distributions/dirichlet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.dirichlet &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.dirichlet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/distribution.html
+++ b/docs/stable/_modules/torch/distributions/distribution.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.distribution &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.distribution &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/exp_family.html
+++ b/docs/stable/_modules/torch/distributions/exp_family.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.exp_family &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.exp_family &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/exponential.html
+++ b/docs/stable/_modules/torch/distributions/exponential.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.exponential &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.exponential &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/stable/_modules/torch/distributions/fishersnedecor.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.fishersnedecor &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.fishersnedecor &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/gamma.html
+++ b/docs/stable/_modules/torch/distributions/gamma.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.gamma &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.gamma &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/geometric.html
+++ b/docs/stable/_modules/torch/distributions/geometric.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.geometric &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.geometric &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/gumbel.html
+++ b/docs/stable/_modules/torch/distributions/gumbel.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.gumbel &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.gumbel &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/half_cauchy.html
+++ b/docs/stable/_modules/torch/distributions/half_cauchy.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.half_cauchy &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.half_cauchy &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/half_normal.html
+++ b/docs/stable/_modules/torch/distributions/half_normal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.half_normal &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.half_normal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/independent.html
+++ b/docs/stable/_modules/torch/distributions/independent.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.independent &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.independent &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/kl.html
+++ b/docs/stable/_modules/torch/distributions/kl.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.kl &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.kl &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/laplace.html
+++ b/docs/stable/_modules/torch/distributions/laplace.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.laplace &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.laplace &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/log_normal.html
+++ b/docs/stable/_modules/torch/distributions/log_normal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.log_normal &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.log_normal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/lowrank_multivariate_normal.html
+++ b/docs/stable/_modules/torch/distributions/lowrank_multivariate_normal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.lowrank_multivariate_normal &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.lowrank_multivariate_normal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/mixture_same_family.html
+++ b/docs/stable/_modules/torch/distributions/mixture_same_family.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.mixture_same_family &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.mixture_same_family &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/multinomial.html
+++ b/docs/stable/_modules/torch/distributions/multinomial.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.multinomial &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.multinomial &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/stable/_modules/torch/distributions/multivariate_normal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.multivariate_normal &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.multivariate_normal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/negative_binomial.html
+++ b/docs/stable/_modules/torch/distributions/negative_binomial.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.negative_binomial &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.negative_binomial &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/normal.html
+++ b/docs/stable/_modules/torch/distributions/normal.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.normal &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.normal &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/stable/_modules/torch/distributions/one_hot_categorical.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.one_hot_categorical &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.one_hot_categorical &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/pareto.html
+++ b/docs/stable/_modules/torch/distributions/pareto.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.pareto &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.pareto &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/poisson.html
+++ b/docs/stable/_modules/torch/distributions/poisson.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.poisson &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.poisson &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/stable/_modules/torch/distributions/relaxed_bernoulli.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.relaxed_bernoulli &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.relaxed_bernoulli &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/stable/_modules/torch/distributions/relaxed_categorical.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.relaxed_categorical &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.relaxed_categorical &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/studentT.html
+++ b/docs/stable/_modules/torch/distributions/studentT.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.studentT &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.studentT &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/stable/_modules/torch/distributions/transformed_distribution.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.transformed_distribution &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.transformed_distribution &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/transforms.html
+++ b/docs/stable/_modules/torch/distributions/transforms.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.transforms &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.transforms &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/uniform.html
+++ b/docs/stable/_modules/torch/distributions/uniform.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.uniform &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.uniform &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/von_mises.html
+++ b/docs/stable/_modules/torch/distributions/von_mises.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.von_mises &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.von_mises &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/distributions/weibull.html
+++ b/docs/stable/_modules/torch/distributions/weibull.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.distributions.weibull &mdash; PyTorch master documentation</title>
+  <title>torch.distributions.weibull &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/functional.html
+++ b/docs/stable/_modules/torch/functional.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.functional &mdash; PyTorch master documentation</title>
+  <title>torch.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/hub.html
+++ b/docs/stable/_modules/torch/hub.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.hub &mdash; PyTorch master documentation</title>
+  <title>torch.hub &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/jit.html
+++ b/docs/stable/_modules/torch/jit.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.jit &mdash; PyTorch master documentation</title>
+  <title>torch.jit &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/multiprocessing.html
+++ b/docs/stable/_modules/torch/multiprocessing.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.multiprocessing &mdash; PyTorch master documentation</title>
+  <title>torch.multiprocessing &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/multiprocessing/spawn.html
+++ b/docs/stable/_modules/torch/multiprocessing/spawn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.multiprocessing.spawn &mdash; PyTorch master documentation</title>
+  <title>torch.multiprocessing.spawn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/functional.html
+++ b/docs/stable/_modules/torch/nn/functional.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.functional &mdash; PyTorch master documentation</title>
+  <title>torch.nn.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/init.html
+++ b/docs/stable/_modules/torch/nn/init.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.init &mdash; PyTorch master documentation</title>
+  <title>torch.nn.init &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/intrinsic/modules/fused.html
+++ b/docs/stable/_modules/torch/nn/intrinsic/modules/fused.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.intrinsic.modules.fused &mdash; PyTorch master documentation</title>
+  <title>torch.nn.intrinsic.modules.fused &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/intrinsic/qat/modules/conv_fused.html
+++ b/docs/stable/_modules/torch/nn/intrinsic/qat/modules/conv_fused.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.intrinsic.qat.modules.conv_fused &mdash; PyTorch master documentation</title>
+  <title>torch.nn.intrinsic.qat.modules.conv_fused &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/intrinsic/qat/modules/linear_relu.html
+++ b/docs/stable/_modules/torch/nn/intrinsic/qat/modules/linear_relu.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.intrinsic.qat.modules.linear_relu &mdash; PyTorch master documentation</title>
+  <title>torch.nn.intrinsic.qat.modules.linear_relu &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/intrinsic/quantized/modules/conv_relu.html
+++ b/docs/stable/_modules/torch/nn/intrinsic/quantized/modules/conv_relu.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.intrinsic.quantized.modules.conv_relu &mdash; PyTorch master documentation</title>
+  <title>torch.nn.intrinsic.quantized.modules.conv_relu &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/intrinsic/quantized/modules/linear_relu.html
+++ b/docs/stable/_modules/torch/nn/intrinsic/quantized/modules/linear_relu.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.intrinsic.quantized.modules.linear_relu &mdash; PyTorch master documentation</title>
+  <title>torch.nn.intrinsic.quantized.modules.linear_relu &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/activation.html
+++ b/docs/stable/_modules/torch/nn/modules/activation.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.activation &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.activation &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/adaptive.html
+++ b/docs/stable/_modules/torch/nn/modules/adaptive.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.adaptive &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.adaptive &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/stable/_modules/torch/nn/modules/batchnorm.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.batchnorm &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.batchnorm &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/container.html
+++ b/docs/stable/_modules/torch/nn/modules/container.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.container &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.container &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/conv.html
+++ b/docs/stable/_modules/torch/nn/modules/conv.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.conv &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.conv &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/distance.html
+++ b/docs/stable/_modules/torch/nn/modules/distance.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.distance &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.distance &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/dropout.html
+++ b/docs/stable/_modules/torch/nn/modules/dropout.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.dropout &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.dropout &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/flatten.html
+++ b/docs/stable/_modules/torch/nn/modules/flatten.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.flatten &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.flatten &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/fold.html
+++ b/docs/stable/_modules/torch/nn/modules/fold.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.fold &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.fold &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/stable/_modules/torch/nn/modules/instancenorm.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.instancenorm &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.instancenorm &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/linear.html
+++ b/docs/stable/_modules/torch/nn/modules/linear.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.linear &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.linear &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/loss.html
+++ b/docs/stable/_modules/torch/nn/modules/loss.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.loss &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.loss &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/module.html
+++ b/docs/stable/_modules/torch/nn/modules/module.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.module &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.module &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/normalization.html
+++ b/docs/stable/_modules/torch/nn/modules/normalization.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.normalization &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.normalization &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/padding.html
+++ b/docs/stable/_modules/torch/nn/modules/padding.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.padding &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.padding &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/stable/_modules/torch/nn/modules/pixelshuffle.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.pixelshuffle &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.pixelshuffle &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/pooling.html
+++ b/docs/stable/_modules/torch/nn/modules/pooling.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.pooling &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.pooling &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/rnn.html
+++ b/docs/stable/_modules/torch/nn/modules/rnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.rnn &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.rnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/sparse.html
+++ b/docs/stable/_modules/torch/nn/modules/sparse.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.sparse &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.sparse &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/transformer.html
+++ b/docs/stable/_modules/torch/nn/modules/transformer.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.transformer &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.transformer &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/modules/upsampling.html
+++ b/docs/stable/_modules/torch/nn/modules/upsampling.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.modules.upsampling &mdash; PyTorch master documentation</title>
+  <title>torch.nn.modules.upsampling &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/stable/_modules/torch/nn/parallel/data_parallel.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.parallel.data_parallel &mdash; PyTorch master documentation</title>
+  <title>torch.nn.parallel.data_parallel &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/parallel/distributed.html
+++ b/docs/stable/_modules/torch/nn/parallel/distributed.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.parallel.distributed &mdash; PyTorch master documentation</title>
+  <title>torch.nn.parallel.distributed &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/parameter.html
+++ b/docs/stable/_modules/torch/nn/parameter.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.parameter &mdash; PyTorch master documentation</title>
+  <title>torch.nn.parameter &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/qat/modules/conv.html
+++ b/docs/stable/_modules/torch/nn/qat/modules/conv.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.qat.modules.conv &mdash; PyTorch master documentation</title>
+  <title>torch.nn.qat.modules.conv &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/qat/modules/linear.html
+++ b/docs/stable/_modules/torch/nn/qat/modules/linear.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.qat.modules.linear &mdash; PyTorch master documentation</title>
+  <title>torch.nn.qat.modules.linear &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/dynamic/modules/linear.html
+++ b/docs/stable/_modules/torch/nn/quantized/dynamic/modules/linear.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.dynamic.modules.linear &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.dynamic.modules.linear &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/dynamic/modules/rnn.html
+++ b/docs/stable/_modules/torch/nn/quantized/dynamic/modules/rnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.dynamic.modules.rnn &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.dynamic.modules.rnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/functional.html
+++ b/docs/stable/_modules/torch/nn/quantized/functional.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.functional &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/modules.html
+++ b/docs/stable/_modules/torch/nn/quantized/modules.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.modules &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.modules &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/modules/activation.html
+++ b/docs/stable/_modules/torch/nn/quantized/modules/activation.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.modules.activation &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.modules.activation &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/modules/conv.html
+++ b/docs/stable/_modules/torch/nn/quantized/modules/conv.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.modules.conv &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.modules.conv &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/modules/functional_modules.html
+++ b/docs/stable/_modules/torch/nn/quantized/modules/functional_modules.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.modules.functional_modules &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.modules.functional_modules &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/quantized/modules/linear.html
+++ b/docs/stable/_modules/torch/nn/quantized/modules/linear.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.quantized.modules.linear &mdash; PyTorch master documentation</title>
+  <title>torch.nn.quantized.modules.linear &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/stable/_modules/torch/nn/utils/clip_grad.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.clip_grad &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.clip_grad &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/convert_parameters.html
+++ b/docs/stable/_modules/torch/nn/utils/convert_parameters.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.convert_parameters &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.convert_parameters &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/prune.html
+++ b/docs/stable/_modules/torch/nn/utils/prune.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.prune &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.prune &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/rnn.html
+++ b/docs/stable/_modules/torch/nn/utils/rnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.rnn &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.rnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/spectral_norm.html
+++ b/docs/stable/_modules/torch/nn/utils/spectral_norm.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.spectral_norm &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.spectral_norm &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/stable/_modules/torch/nn/utils/weight_norm.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.utils.weight_norm &mdash; PyTorch master documentation</title>
+  <title>torch.nn.utils.weight_norm &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/onnx.html
+++ b/docs/stable/_modules/torch/onnx.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.onnx &mdash; PyTorch master documentation</title>
+  <title>torch.onnx &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/onnx/operators.html
+++ b/docs/stable/_modules/torch/onnx/operators.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.onnx.operators &mdash; PyTorch master documentation</title>
+  <title>torch.onnx.operators &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/adadelta.html
+++ b/docs/stable/_modules/torch/optim/adadelta.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.adadelta &mdash; PyTorch master documentation</title>
+  <title>torch.optim.adadelta &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/adagrad.html
+++ b/docs/stable/_modules/torch/optim/adagrad.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.adagrad &mdash; PyTorch master documentation</title>
+  <title>torch.optim.adagrad &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/adam.html
+++ b/docs/stable/_modules/torch/optim/adam.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.adam &mdash; PyTorch master documentation</title>
+  <title>torch.optim.adam &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/adamax.html
+++ b/docs/stable/_modules/torch/optim/adamax.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.adamax &mdash; PyTorch master documentation</title>
+  <title>torch.optim.adamax &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/adamw.html
+++ b/docs/stable/_modules/torch/optim/adamw.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.adamw &mdash; PyTorch master documentation</title>
+  <title>torch.optim.adamw &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/asgd.html
+++ b/docs/stable/_modules/torch/optim/asgd.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.asgd &mdash; PyTorch master documentation</title>
+  <title>torch.optim.asgd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/lbfgs.html
+++ b/docs/stable/_modules/torch/optim/lbfgs.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.lbfgs &mdash; PyTorch master documentation</title>
+  <title>torch.optim.lbfgs &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/lr_scheduler.html
+++ b/docs/stable/_modules/torch/optim/lr_scheduler.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.lr_scheduler &mdash; PyTorch master documentation</title>
+  <title>torch.optim.lr_scheduler &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/optimizer.html
+++ b/docs/stable/_modules/torch/optim/optimizer.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.optimizer &mdash; PyTorch master documentation</title>
+  <title>torch.optim.optimizer &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/rmsprop.html
+++ b/docs/stable/_modules/torch/optim/rmsprop.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.rmsprop &mdash; PyTorch master documentation</title>
+  <title>torch.optim.rmsprop &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/rprop.html
+++ b/docs/stable/_modules/torch/optim/rprop.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.rprop &mdash; PyTorch master documentation</title>
+  <title>torch.optim.rprop &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/sgd.html
+++ b/docs/stable/_modules/torch/optim/sgd.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.sgd &mdash; PyTorch master documentation</title>
+  <title>torch.optim.sgd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/optim/sparse_adam.html
+++ b/docs/stable/_modules/torch/optim/sparse_adam.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim.sparse_adam &mdash; PyTorch master documentation</title>
+  <title>torch.optim.sparse_adam &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization.html
+++ b/docs/stable/_modules/torch/quantization.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization &mdash; PyTorch master documentation</title>
+  <title>torch.quantization &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/fake_quantize.html
+++ b/docs/stable/_modules/torch/quantization/fake_quantize.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.fake_quantize &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.fake_quantize &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/fuse_modules.html
+++ b/docs/stable/_modules/torch/quantization/fuse_modules.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.fuse_modules &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.fuse_modules &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/observer.html
+++ b/docs/stable/_modules/torch/quantization/observer.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.observer &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.observer &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/qconfig.html
+++ b/docs/stable/_modules/torch/quantization/qconfig.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.qconfig &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.qconfig &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/quantize.html
+++ b/docs/stable/_modules/torch/quantization/quantize.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.quantize &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.quantize &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quantization/stubs.html
+++ b/docs/stable/_modules/torch/quantization/stubs.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quantization.stubs &mdash; PyTorch master documentation</title>
+  <title>torch.quantization.stubs &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/quasirandom.html
+++ b/docs/stable/_modules/torch/quasirandom.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.quasirandom &mdash; PyTorch master documentation</title>
+  <title>torch.quasirandom &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/random.html
+++ b/docs/stable/_modules/torch/random.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.random &mdash; PyTorch master documentation</title>
+  <title>torch.random &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/serialization.html
+++ b/docs/stable/_modules/torch/serialization.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.serialization &mdash; PyTorch master documentation</title>
+  <title>torch.serialization &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/sparse.html
+++ b/docs/stable/_modules/torch/sparse.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.sparse &mdash; PyTorch master documentation</title>
+  <title>torch.sparse &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/storage.html
+++ b/docs/stable/_modules/torch/storage.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.storage &mdash; PyTorch master documentation</title>
+  <title>torch.storage &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/tensor.html
+++ b/docs/stable/_modules/torch/tensor.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.tensor &mdash; PyTorch master documentation</title>
+  <title>torch.tensor &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/checkpoint.html
+++ b/docs/stable/_modules/torch/utils/checkpoint.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.checkpoint &mdash; PyTorch master documentation</title>
+  <title>torch.utils.checkpoint &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/cpp_extension.html
+++ b/docs/stable/_modules/torch/utils/cpp_extension.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.cpp_extension &mdash; PyTorch master documentation</title>
+  <title>torch.utils.cpp_extension &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/data/_utils/worker.html
+++ b/docs/stable/_modules/torch/utils/data/_utils/worker.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data._utils.worker &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data._utils.worker &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/data/dataloader.html
+++ b/docs/stable/_modules/torch/utils/data/dataloader.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data.dataloader &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data.dataloader &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/data/dataset.html
+++ b/docs/stable/_modules/torch/utils/data/dataset.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data.dataset &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data.dataset &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/data/distributed.html
+++ b/docs/stable/_modules/torch/utils/data/distributed.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data.distributed &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data.distributed &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/data/sampler.html
+++ b/docs/stable/_modules/torch/utils/data/sampler.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data.sampler &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data.sampler &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torch/utils/tensorboard/writer.html
+++ b/docs/stable/_modules/torch/utils/tensorboard/writer.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.tensorboard.writer &mdash; PyTorch master documentation</title>
+  <title>torch.utils.tensorboard.writer &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision.html
+++ b/docs/stable/_modules/torchvision.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; PyTorch master documentation</title>
+  <title>torchvision &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/celeba.html
+++ b/docs/stable/_modules/torchvision/datasets/celeba.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.celeba &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.celeba &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/cifar.html
+++ b/docs/stable/_modules/torchvision/datasets/cifar.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cifar &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.cifar &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/cityscapes.html
+++ b/docs/stable/_modules/torchvision/datasets/cityscapes.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.cityscapes &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.cityscapes &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/coco.html
+++ b/docs/stable/_modules/torchvision/datasets/coco.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.coco &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.coco &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/fakedata.html
+++ b/docs/stable/_modules/torchvision/datasets/fakedata.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.fakedata &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.fakedata &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/flickr.html
+++ b/docs/stable/_modules/torchvision/datasets/flickr.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.flickr &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.flickr &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/folder.html
+++ b/docs/stable/_modules/torchvision/datasets/folder.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.folder &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.folder &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/hmdb51.html
+++ b/docs/stable/_modules/torchvision/datasets/hmdb51.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.hmdb51 &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.hmdb51 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/imagenet.html
+++ b/docs/stable/_modules/torchvision/datasets/imagenet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.imagenet &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.imagenet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/kinetics.html
+++ b/docs/stable/_modules/torchvision/datasets/kinetics.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.kinetics &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.kinetics &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/lsun.html
+++ b/docs/stable/_modules/torchvision/datasets/lsun.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.lsun &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.lsun &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/mnist.html
+++ b/docs/stable/_modules/torchvision/datasets/mnist.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.mnist &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.mnist &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/phototour.html
+++ b/docs/stable/_modules/torchvision/datasets/phototour.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.phototour &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.phototour &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/sbd.html
+++ b/docs/stable/_modules/torchvision/datasets/sbd.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbd &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.sbd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/sbu.html
+++ b/docs/stable/_modules/torchvision/datasets/sbu.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.sbu &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.sbu &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/stl10.html
+++ b/docs/stable/_modules/torchvision/datasets/stl10.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.stl10 &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.stl10 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/svhn.html
+++ b/docs/stable/_modules/torchvision/datasets/svhn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.svhn &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.svhn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/ucf101.html
+++ b/docs/stable/_modules/torchvision/datasets/ucf101.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.ucf101 &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.ucf101 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/usps.html
+++ b/docs/stable/_modules/torchvision/datasets/usps.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.usps &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.usps &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/datasets/voc.html
+++ b/docs/stable/_modules/torchvision/datasets/voc.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets.voc &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets.voc &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/io/video.html
+++ b/docs/stable/_modules/torchvision/io/video.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io.video &mdash; PyTorch master documentation</title>
+  <title>torchvision.io.video &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/alexnet.html
+++ b/docs/stable/_modules/torchvision/models/alexnet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.alexnet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.alexnet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/densenet.html
+++ b/docs/stable/_modules/torchvision/models/densenet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.densenet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.densenet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/detection/faster_rcnn.html
+++ b/docs/stable/_modules/torchvision/models/detection/faster_rcnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.faster_rcnn &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.detection.faster_rcnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/detection/keypoint_rcnn.html
+++ b/docs/stable/_modules/torchvision/models/detection/keypoint_rcnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.keypoint_rcnn &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.detection.keypoint_rcnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/detection/mask_rcnn.html
+++ b/docs/stable/_modules/torchvision/models/detection/mask_rcnn.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.detection.mask_rcnn &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.detection.mask_rcnn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/googlenet.html
+++ b/docs/stable/_modules/torchvision/models/googlenet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.googlenet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.googlenet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/inception.html
+++ b/docs/stable/_modules/torchvision/models/inception.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.inception &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.inception &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/mnasnet.html
+++ b/docs/stable/_modules/torchvision/models/mnasnet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mnasnet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.mnasnet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/mobilenet.html
+++ b/docs/stable/_modules/torchvision/models/mobilenet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.mobilenet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.mobilenet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/resnet.html
+++ b/docs/stable/_modules/torchvision/models/resnet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.resnet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.resnet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/segmentation/segmentation.html
+++ b/docs/stable/_modules/torchvision/models/segmentation/segmentation.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.segmentation.segmentation &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.segmentation.segmentation &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/shufflenetv2.html
+++ b/docs/stable/_modules/torchvision/models/shufflenetv2.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.shufflenetv2 &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.shufflenetv2 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/squeezenet.html
+++ b/docs/stable/_modules/torchvision/models/squeezenet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.squeezenet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.squeezenet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/vgg.html
+++ b/docs/stable/_modules/torchvision/models/vgg.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.vgg &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.vgg &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/models/video/resnet.html
+++ b/docs/stable/_modules/torchvision/models/video/resnet.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models.video.resnet &mdash; PyTorch master documentation</title>
+  <title>torchvision.models.video.resnet &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/ops/boxes.html
+++ b/docs/stable/_modules/torchvision/ops/boxes.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.boxes &mdash; PyTorch master documentation</title>
+  <title>torchvision.ops.boxes &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/ops/roi_align.html
+++ b/docs/stable/_modules/torchvision/ops/roi_align.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_align &mdash; PyTorch master documentation</title>
+  <title>torchvision.ops.roi_align &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/ops/roi_pool.html
+++ b/docs/stable/_modules/torchvision/ops/roi_pool.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops.roi_pool &mdash; PyTorch master documentation</title>
+  <title>torchvision.ops.roi_pool &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/transforms/functional.html
+++ b/docs/stable/_modules/torchvision/transforms/functional.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.functional &mdash; PyTorch master documentation</title>
+  <title>torchvision.transforms.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/transforms/transforms.html
+++ b/docs/stable/_modules/torchvision/transforms/transforms.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms.transforms &mdash; PyTorch master documentation</title>
+  <title>torchvision.transforms.transforms &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/_modules/torchvision/utils.html
+++ b/docs/stable/_modules/torchvision/utils.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; PyTorch master documentation</title>
+  <title>torchvision.utils &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/amp.html
+++ b/docs/stable/amp.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Automatic Mixed Precision package - torch.cuda.amp &mdash; PyTorch master documentation</title>
+  <title>Automatic Mixed Precision package - torch.cuda.amp &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/autograd.html
+++ b/docs/stable/autograd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Automatic differentiation package - torch.autograd &mdash; PyTorch master documentation</title>
+  <title>Automatic differentiation package - torch.autograd &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/bottleneck.html
+++ b/docs/stable/bottleneck.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.bottleneck &mdash; PyTorch master documentation</title>
+  <title>torch.utils.bottleneck &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/checkpoint.html
+++ b/docs/stable/checkpoint.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.checkpoint &mdash; PyTorch master documentation</title>
+  <title>torch.utils.checkpoint &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/community/contribution_guide.html
+++ b/docs/stable/community/contribution_guide.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Contribution Guide &mdash; PyTorch master documentation</title>
+  <title>PyTorch Contribution Guide &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/community/governance.html
+++ b/docs/stable/community/governance.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Governance &mdash; PyTorch master documentation</title>
+  <title>PyTorch Governance &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/community/persons_of_interest.html
+++ b/docs/stable/community/persons_of_interest.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Governance | Persons of Interest &mdash; PyTorch master documentation</title>
+  <title>PyTorch Governance | Persons of Interest &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cpp_extension.html
+++ b/docs/stable/cpp_extension.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.cpp_extension &mdash; PyTorch master documentation</title>
+  <title>torch.utils.cpp_extension &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cpp_index.html
+++ b/docs/stable/cpp_index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>C++ &mdash; PyTorch master documentation</title>
+  <title>C++ &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cuda.html
+++ b/docs/stable/cuda.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.cuda &mdash; PyTorch master documentation</title>
+  <title>torch.cuda &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cuda_deterministic.html
+++ b/docs/stable/cuda_deterministic.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>&lt;no title&gt; &mdash; PyTorch master documentation</title>
+  <title>&lt;no title&gt; &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cuda_deterministic_backward.html
+++ b/docs/stable/cuda_deterministic_backward.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>&lt;no title&gt; &mdash; PyTorch master documentation</title>
+  <title>&lt;no title&gt; &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cudnn_deterministic.html
+++ b/docs/stable/cudnn_deterministic.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>&lt;no title&gt; &mdash; PyTorch master documentation</title>
+  <title>&lt;no title&gt; &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/cudnn_persistent_rnn.html
+++ b/docs/stable/cudnn_persistent_rnn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>&lt;no title&gt; &mdash; PyTorch master documentation</title>
+  <title>&lt;no title&gt; &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/data.html
+++ b/docs/stable/data.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.data &mdash; PyTorch master documentation</title>
+  <title>torch.utils.data &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/distributed.html
+++ b/docs/stable/distributed.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Distributed communication package - torch.distributed &mdash; PyTorch master documentation</title>
+  <title>Distributed communication package - torch.distributed &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/distributions.html
+++ b/docs/stable/distributions.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Probability distributions - torch.distributions &mdash; PyTorch master documentation</title>
+  <title>Probability distributions - torch.distributions &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/dlpack.html
+++ b/docs/stable/dlpack.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.dlpack &mdash; PyTorch master documentation</title>
+  <title>torch.utils.dlpack &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/genindex.html
+++ b/docs/stable/genindex.html
@@ -10,7 +10,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Index &mdash; PyTorch master documentation</title>
+  <title>Index &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/hub.html
+++ b/docs/stable/hub.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.hub &mdash; PyTorch master documentation</title>
+  <title>torch.hub &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/index.html
+++ b/docs/stable/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch documentation &mdash; PyTorch master documentation</title>
+  <title>PyTorch documentation &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/jit.html
+++ b/docs/stable/jit.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TorchScript &mdash; PyTorch master documentation</title>
+  <title>TorchScript &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/jit_builtin_functions.html
+++ b/docs/stable/jit_builtin_functions.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TorchScript Builtins &mdash; PyTorch master documentation</title>
+  <title>TorchScript Builtins &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/jit_language_reference.html
+++ b/docs/stable/jit_language_reference.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TorchScript Language Reference &mdash; PyTorch master documentation</title>
+  <title>TorchScript Language Reference &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/jit_python_reference.html
+++ b/docs/stable/jit_python_reference.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Language Reference Coverage &mdash; PyTorch master documentation</title>
+  <title>Python Language Reference Coverage &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/jit_unsupported.html
+++ b/docs/stable/jit_unsupported.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TorchScript Unsupported Pytorch Constructs &mdash; PyTorch master documentation</title>
+  <title>TorchScript Unsupported Pytorch Constructs &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/model_zoo.html
+++ b/docs/stable/model_zoo.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.model_zoo &mdash; PyTorch master documentation</title>
+  <title>torch.utils.model_zoo &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/multiprocessing.html
+++ b/docs/stable/multiprocessing.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Multiprocessing package - torch.multiprocessing &mdash; PyTorch master documentation</title>
+  <title>Multiprocessing package - torch.multiprocessing &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/name_inference.html
+++ b/docs/stable/name_inference.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Named Tensors operator coverage &mdash; PyTorch master documentation</title>
+  <title>Named Tensors operator coverage &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/named_tensor.html
+++ b/docs/stable/named_tensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Named Tensors &mdash; PyTorch master documentation</title>
+  <title>Named Tensors &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/nn.functional.html
+++ b/docs/stable/nn.functional.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.functional &mdash; PyTorch master documentation</title>
+  <title>torch.nn.functional &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/nn.html
+++ b/docs/stable/nn.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn &mdash; PyTorch master documentation</title>
+  <title>torch.nn &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/nn.init.html
+++ b/docs/stable/nn.init.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.nn.init &mdash; PyTorch master documentation</title>
+  <title>torch.nn.init &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/amp_examples.html
+++ b/docs/stable/notes/amp_examples.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Automatic Mixed Precision examples &mdash; PyTorch master documentation</title>
+  <title>Automatic Mixed Precision examples &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/autograd.html
+++ b/docs/stable/notes/autograd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Autograd mechanics &mdash; PyTorch master documentation</title>
+  <title>Autograd mechanics &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/broadcasting.html
+++ b/docs/stable/notes/broadcasting.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Broadcasting semantics &mdash; PyTorch master documentation</title>
+  <title>Broadcasting semantics &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/cpu_threading_torchscript_inference.html
+++ b/docs/stable/notes/cpu_threading_torchscript_inference.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CPU threading and TorchScript inference &mdash; PyTorch master documentation</title>
+  <title>CPU threading and TorchScript inference &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/cuda.html
+++ b/docs/stable/notes/cuda.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>CUDA semantics &mdash; PyTorch master documentation</title>
+  <title>CUDA semantics &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/ddp.html
+++ b/docs/stable/notes/ddp.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Distributed Data Parallel &mdash; PyTorch master documentation</title>
+  <title>Distributed Data Parallel &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/extending.html
+++ b/docs/stable/notes/extending.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Extending PyTorch &mdash; PyTorch master documentation</title>
+  <title>Extending PyTorch &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/faq.html
+++ b/docs/stable/notes/faq.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Frequently Asked Questions &mdash; PyTorch master documentation</title>
+  <title>Frequently Asked Questions &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/large_scale_deployments.html
+++ b/docs/stable/notes/large_scale_deployments.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Features for large-scale deployments &mdash; PyTorch master documentation</title>
+  <title>Features for large-scale deployments &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/multiprocessing.html
+++ b/docs/stable/notes/multiprocessing.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Multiprocessing best practices &mdash; PyTorch master documentation</title>
+  <title>Multiprocessing best practices &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/randomness.html
+++ b/docs/stable/notes/randomness.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Reproducibility &mdash; PyTorch master documentation</title>
+  <title>Reproducibility &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/serialization.html
+++ b/docs/stable/notes/serialization.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Serialization semantics &mdash; PyTorch master documentation</title>
+  <title>Serialization semantics &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/notes/windows.html
+++ b/docs/stable/notes/windows.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Windows FAQ &mdash; PyTorch master documentation</title>
+  <title>Windows FAQ &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/onnx.html
+++ b/docs/stable/onnx.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.onnx &mdash; PyTorch master documentation</title>
+  <title>torch.onnx &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/optim.html
+++ b/docs/stable/optim.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.optim &mdash; PyTorch master documentation</title>
+  <title>torch.optim &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/DType.html
+++ b/docs/stable/org/pytorch/DType.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>DType &mdash; PyTorch master documentation</title>
+  <title>DType &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/IValue.html
+++ b/docs/stable/org/pytorch/IValue.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>IValue &mdash; PyTorch master documentation</title>
+  <title>IValue &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Module.html
+++ b/docs/stable/org/pytorch/Module.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Module &mdash; PyTorch master documentation</title>
+  <title>Module &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_float32.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_float32.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_float32 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_float32 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_float64.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_float64.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_float64 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_float64 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_int32.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_int32.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_int32 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_int32 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_int64.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_int64.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_int64 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_int64 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_int8.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_int8.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_int8 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_int8 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor-Tensor_uint8.html
+++ b/docs/stable/org/pytorch/Tensor-Tensor_uint8.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor.Tensor_uint8 &mdash; PyTorch master documentation</title>
+  <title>Tensor.Tensor_uint8 &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/Tensor.html
+++ b/docs/stable/org/pytorch/Tensor.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor &mdash; PyTorch master documentation</title>
+  <title>Tensor &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/TensorImageUtils.html
+++ b/docs/stable/org/pytorch/TensorImageUtils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>TensorImageUtils &mdash; PyTorch master documentation</title>
+  <title>TensorImageUtils &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/package-index.html
+++ b/docs/stable/org/pytorch/package-index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>org.pytorch &mdash; PyTorch master documentation</title>
+  <title>org.pytorch &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/org/pytorch/torchvision/package-index.html
+++ b/docs/stable/org/pytorch/torchvision/package-index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>rg.pytorch.torchvision &mdash; PyTorch master documentation</title>
+  <title>rg.pytorch.torchvision &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/packages.html
+++ b/docs/stable/packages.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Javadoc &mdash; PyTorch master documentation</title>
+  <title>Javadoc &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/py-modindex.html
+++ b/docs/stable/py-modindex.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Python Module Index &mdash; PyTorch master documentation</title>
+  <title>Python Module Index &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/quantization.html
+++ b/docs/stable/quantization.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Quantization &mdash; PyTorch master documentation</title>
+  <title>Quantization &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/random.html
+++ b/docs/stable/random.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.random &mdash; PyTorch master documentation</title>
+  <title>torch.random &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/rpc.html
+++ b/docs/stable/rpc.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Distributed RPC Framework &mdash; PyTorch master documentation</title>
+  <title>Distributed RPC Framework &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/rpc/distributed_autograd.html
+++ b/docs/stable/rpc/distributed_autograd.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Distributed Autograd Design &mdash; PyTorch master documentation</title>
+  <title>Distributed Autograd Design &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/rpc/index.html
+++ b/docs/stable/rpc/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Distributed RPC Framework &mdash; PyTorch master documentation</title>
+  <title>Distributed RPC Framework &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/rpc/rref.html
+++ b/docs/stable/rpc/rref.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Remote Reference Protocol &mdash; PyTorch master documentation</title>
+  <title>Remote Reference Protocol &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/search.html
+++ b/docs/stable/search.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Search &mdash; PyTorch master documentation</title>
+  <title>Search &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/sparse.html
+++ b/docs/stable/sparse.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.sparse &mdash; PyTorch master documentation</title>
+  <title>torch.sparse &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/storage.html
+++ b/docs/stable/storage.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.Storage &mdash; PyTorch master documentation</title>
+  <title>torch.Storage &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/tensor_attributes.html
+++ b/docs/stable/tensor_attributes.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor Attributes &mdash; PyTorch master documentation</title>
+  <title>Tensor Attributes &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/tensor_view.html
+++ b/docs/stable/tensor_view.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Tensor Views &mdash; PyTorch master documentation</title>
+  <title>Tensor Views &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/tensorboard.html
+++ b/docs/stable/tensorboard.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.utils.tensorboard &mdash; PyTorch master documentation</title>
+  <title>torch.utils.tensorboard &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/tensors.html
+++ b/docs/stable/tensors.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch.Tensor &mdash; PyTorch master documentation</title>
+  <title>torch.Tensor &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torch.html
+++ b/docs/stable/torch.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torch &mdash; PyTorch master documentation</title>
+  <title>torch &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/datasets.html
+++ b/docs/stable/torchvision/datasets.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets &mdash; PyTorch master documentation</title>
+  <title>torchvision.datasets &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/index.html
+++ b/docs/stable/torchvision/index.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; PyTorch master documentation</title>
+  <title>torchvision &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/io.html
+++ b/docs/stable/torchvision/io.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io &mdash; PyTorch master documentation</title>
+  <title>torchvision.io &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/models.html
+++ b/docs/stable/torchvision/models.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models &mdash; PyTorch master documentation</title>
+  <title>torchvision.models &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/ops.html
+++ b/docs/stable/torchvision/ops.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops &mdash; PyTorch master documentation</title>
+  <title>torchvision.ops &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/transforms.html
+++ b/docs/stable/torchvision/transforms.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms &mdash; PyTorch master documentation</title>
+  <title>torchvision.transforms &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/torchvision/utils.html
+++ b/docs/stable/torchvision/utils.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; PyTorch master documentation</title>
+  <title>torchvision.utils &mdash; PyTorch 1.5.0 documentation</title>
   
 
   

--- a/docs/stable/type_info.html
+++ b/docs/stable/type_info.html
@@ -9,7 +9,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Type Info &mdash; PyTorch master documentation</title>
+  <title>Type Info &mdash; PyTorch 1.5.0 documentation</title>
   
 
   


### PR DESCRIPTION
This PR is to change the html header title from 'Pytorch master documentation' to 'Pytorch 1.5.0 documentation' for stabled version document. So google search will show 'Pytorch documentation - Pytorch 1.5.0 documentation' for current stabled version.

This change is for:
https://github.com/pytorch/pytorch/issues/21290
https://github.com/pytorch/pytorch/issues/31894