### PR TITLE
Update javadoc url for v1.5

### DIFF
--- a/docs/stable/index.html
+++ b/docs/stable/index.html
@@ -207,7 +207,7 @@
 <p class="caption"><span class="caption-text">Language Bindings</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference internal" href="packages.html">Javadoc</a></li>
+<li class="toctree-l1"><a class="reference internal" href="https://pytorch.org/javadoc">Javadoc</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Python API</span></p>
 <ul>
@@ -361,7 +361,7 @@
 <p class="caption"><span class="caption-text">Language Bindings</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference internal" href="packages.html">Javadoc</a></li>
+<li class="toctree-l1"><a class="reference internal" href="https://pytorch.org/javadoc">Javadoc</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">


### PR DESCRIPTION
Correct javadoc url to match v1.4: https://github.com/pytorch/pytorch.github.io/blob/site-v1.4.0/docs/stable/index.html#L366