### PR TITLE
Add github stars json file

### DIFF
--- a/github-stars.json
+++ b/github-stars.json
@@ -1,0 +1,13 @@
+---
+---
+
+{
+  "data": [
+    {% for item in site.hub %}
+      {
+        "id": "{{ item.github-id }}"
+      }
+      {% if forloop.last != true %},{% endif %}
+    {% endfor %}
+  ]
+}


### PR DESCRIPTION
This PR adds Github Stars JSON file.
The JSON file is needed to grab the github-id set on the Hub cards which are then used to get the star count.