### PR TITLE
Scroll to top of hub cards on click of next/previous page

### DIFF
--- a/_includes/hub_researcher_tags_and_cards.html
+++ b/_includes/hub_researcher_tags_and_cards.html
@@ -17,7 +17,7 @@
 
 </nav>
 
-<hr class="hub-divider">
+<hr id="pagination-scroll" class="hub-divider">
 
 {% if page.compact == true %}
 

--- a/assets/filter-hub-tags.js
+++ b/assets/filter-hub-tags.js
@@ -67,3 +67,12 @@ $(".filter-btn").on("click", function() {
 
   updateList();
 });
+
+//Scroll back to top of hub cards on click of next/previous page button
+
+$(document).on("click", ".page", function() {
+  $('html, body').animate(
+    {scrollTop: $("#pagination-scroll").position().top},
+    'slow'
+  );
+});


### PR DESCRIPTION
- This PR adds functionality to scroll back to the top of hub cards on click of pagination buttons.

- This PR solves an issue where the page would jump to the footer when clicking on a page with less than the full amount of hub cards