### PR TITLE
Removed wrong cuda note

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -147,8 +147,6 @@ torch.cuda.is_available()
 
 For the majority of PyTorch users, installing from a pre-built binary via a package manager will provide the best experience. However, there are times when you may want to install the bleeding edge PyTorch code, whether for testing or actual development on the PyTorch core. To install the latest PyTorch code, you will need to [build PyTorch from source](https://github.com/pytorch/pytorch#from-source).
 
-> You will also need to build from source if you want CUDA support.
-
 ### Prerequisites
 {: #linux-prerequisites-2}
 


### PR DESCRIPTION
Removed an old note that CUDA is only available for pytorch when building from source.

This fixes https://github.com/pytorch/pytorch/issues/39578.