### PR TITLE
Fix YAML parsing in nemo

### DIFF
--- a/_ecosystem/nemo
+++ b/_ecosystem/nemo
@@ -1,8 +1,8 @@
 ---
 layout: ecosystem_detail
 title: NeMo
-summary: NeMo: a toolkit for conversational AI.
+summary: "NeMo: a toolkit for conversational AI."
 link: https://github.com/NVIDIA/NeMo
-summary-home: NeMo: a toolkit for conversational AI
+summary-home: "NeMo: a toolkit for conversational AI"
 featured-home: false
 ---


### PR DESCRIPTION
This is getting treating as a YAML data structure because of the colon. We should probably just quote every string value for consistency, but this should be the bare minimum.