### PR TITLE
Update the iOS tutorial for 1.6.0

### DIFF
--- a/_mobile/ios.md
+++ b/_mobile/ios.md
@@ -99,7 +99,7 @@ Note that the `TorchModule` Class is an Objective-C wrapper of `torch::jit::scri
 ```cpp
 torch::jit::script::Module module = torch::jit::load(filePath.UTF8String);
 ```
-Since Swift can not talk to C++ directly, we have to either use an Objective-C class as a bridge, or create a C wrapper for the C++ library. For demo purpose, we're going to wrap everything in this Objective-C class. However, we're working on providing the Swift/Objective-C API wrappers to PyTorch. Stay tuned!
+Since Swift can not talk to C++ directly, we have to either use an Objective-C class as a bridge, or create a C wrapper for the C++ library. For demo purpose, we're going to wrap everything in this Objective-C class.
 
 #### Run Inference
 
@@ -193,36 +193,6 @@ In the build settings, search for **other linker flags**.  Add a custom linker f
 
 Currently, the iOS framework uses the Pytorch C++ front-end APIs directly. The C++ document can be found [here](https://pytorch.org/cppdocs/). To learn more about it, we recommend exploring the [C++ front-end tutorials](https://pytorch.org/tutorials/advanced/cpp_frontend.html) on PyTorch webpage. In the meantime, we're working on providing the Swift/Objective-C API wrappers to PyTorch.
 
-
-### Custom Build
-
-Starting from 1.4.0, PyTorch supports custom build. You can now build the PyTorch library that only contains the operators needed by your model. To do that, follow the steps below
-
-1\. Verify your PyTorch version is 1.4.0 or above. You can do that by checking the value of `torch.__version__`.
-
-2\. To dump the operators in your model, say `MobileNetV2`, run the following lines of Python code:
-
-```python
-import torch, yaml
-model = torch.jit.load('MobileNetV2.pt')
-ops = torch.jit.export_opnames(model)
-with open('MobileNetV2.yaml', 'w') as output:
-    yaml.dump(ops, output)
-```
-In the snippet above, you first need to load the ScriptModule. Then, use `export_opnames` to return a list of operator names of the ScriptModule and its submodules. Lastly, save the result in a yaml file.
-
-3\. To run the iOS build script locally with the prepared yaml list of operators, pass in the yaml file generate from the last step into the environment variable `SELECTED_OP_LIST`. Also in the arguments, specify `BUILD_PYTORCH_MOBILE=1` as well as the platform/architechture type. Take the arm64 build for example, the command should be:
-
-```
-SELECTED_OP_LIST=MobileNetV2.yaml BUILD_PYTORCH_MOBILE=1 IOS_ARCH=arm64 ./scripts/build_ios.sh
-```
-4\. After the build succeeds, you can integrate the result libraries to your project by following the [XCode Setup](#xcode-setup) section above.
-
-5\. The last step is to add a single line of C++ code before running `forward`. This is because by default JIT will do some optimizations on operators (fusion for example), which might break the consistency with the ops we dumped from the model.
-
-```cpp
-torch::jit::GraphOptimizerEnabledGuard guard(false);
-```
 
 ## Issues and Contribution
 


### PR DESCRIPTION
1. Delete the custom build part from iOS tutorial
2. We don't have any plan for Objective-C/Swift wrapper in short time