### PR TITLE
Remove python 2 mentions from Get Started

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -40,7 +40,7 @@ If you decide to use APT, you can run the following command to install it:
 sudo apt install python
 ```
 
-> It is recommended that you use Python 3.6 or greater, which can be installed via any of the mechanisms above .
+> It is recommended that you use Python 3.5, 3.6, 3.7 or 3.8, which can be installed via any of the mechanisms above .
 
 > If you use [Anaconda](#anaconda) to install PyTorch, it will install a sandboxed version of Python that will be used for running PyTorch applications.
 

--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -40,7 +40,7 @@ If you decide to use APT, you can run the following command to install it:
 sudo apt install python
 ```
 
-> PyTorch can be installed with Python 2.7, but it is recommended that you use Python 3.6 or greater, which can be installed via any of the mechanisms above .
+> It is recommended that you use Python 3.6 or greater, which can be installed via any of the mechanisms above .
 
 > If you use [Anaconda](#anaconda) to install PyTorch, it will install a sandboxed version of Python that will be used for running PyTorch applications.
 
@@ -73,14 +73,6 @@ sudo apt install python3-pip
 ```
 
 > Tip: If you want to use just the command  `pip`, instead of `pip3`, you can symlink `pip` to the `pip3` binary.
-
-*Python 2*
-
-If you are using Python 2.7, you will need to use this command
-
-```bash
-sudo apt install python-pip
-```
 
 ## Installation
 {: #linux-installation}

--- a/_get_started/installation/mac.md
+++ b/_get_started/installation/mac.md
@@ -15,7 +15,7 @@ PyTorch is supported on macOS 10.10 (Yosemite) or above.
 ### Python
 {: #mac-python}
 
-It is recommended that you use Python 3.6 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
+It is recommended that you use Python 3.5 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
 
 ### Package Manager
 {: #mac-package-manager}

--- a/_get_started/installation/mac.md
+++ b/_get_started/installation/mac.md
@@ -15,7 +15,7 @@ PyTorch is supported on macOS 10.10 (Yosemite) or above.
 ### Python
 {: #mac-python}
 
-By default, macOS is installed with Python 2.7. PyTorch can be installed with Python 2.7, but it is recommended that you use Python 3.6 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
+It is recommended that you use Python 3.6 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
 
 ### Package Manager
 {: #mac-package-manager}
@@ -41,14 +41,6 @@ If you installed Python via Homebrew or the Python website, `pip` was installed 
 
 > Tip: If you want to use just the command  `pip`, instead of `pip3`, you can symlink `pip` to the `pip3` binary.
 
-*Python 2*
-
-If you are using the default installed Python 2.7, you will need to install `pip` via `easy_install`
-
-```bash
-sudo easy_install pip
-```
-
 ## Installation
 {: #mac-installation}
 
@@ -69,11 +61,6 @@ To install PyTorch via pip, use one of the following two commands, depending on 
 ```bash
 # Python 3.x
 pip3 install torch torchvision
-```
-
-```bash
-# Python 2.x`
-pip install torch torchvision
 ```
 
 ## Verification

--- a/_posts/2020-4-21-pytorch-1-dot-5-released-with-new-and-updated-apis.md
+++ b/_posts/2020-4-21-pytorch-1-dot-5-released-with-new-and-updated-apis.md
@@ -7,7 +7,7 @@ author: Team PyTorch
 
 Today, we’re announcing the availability of PyTorch 1.5, along with new and updated libraries. This release includes several major new API additions and improvements. PyTorch now includes a significant update to the C++ frontend, ‘channels last’ memory format for computer vision models, and a stable release of the distributed RPC framework used for model-parallel training. The release also has new APIs for autograd for hessians and jacobians, and an API that allows the creation of Custom C++ Classes that was inspired by pybind.
 
-You can find the detailed release notes [here](https://github.com/pytorch/pytorch/releases).  
+You can find the detailed release notes [here](https://github.com/pytorch/pytorch/releases).
 
 ## C++ Frontend API (Stable)
 
@@ -52,9 +52,9 @@ static auto testStack =
         return self->stack_.size();
       });
 ```
- 
+
  Which exposes a class you can use in Python and TorchScript like so:
- 
+
 ```python
 @torch.jit.script
 def do_stacks(s : torch.classes.myclasses.MyStackClass):
@@ -75,7 +75,7 @@ The Distributed [RPC framework](https://pytorch.org/docs/stable/rpc.html) was la
 The RPC API allows users to specify functions to run and objects to be instantiated on remote nodes. These functions are transparently recorded so that gradients can backpropagate through remote nodes using Distributed Autograd.
 
 ### Distributed Autograd
-Distributed Autograd connects the autograd graph across several nodes and allows gradients to flow through during the backwards pass. Gradients are accumulated into a context (as opposed to the .grad field as with Autograd) and users must specify their model’s forward pass under a with `dist_autograd.context()` manager in order to ensure that all RPC communication is recorded properly. Currently, only FAST mode is implemented (see [here](https://pytorch.org/docs/stable/rpc/distributed_autograd.html#distributed-autograd-design) for the difference between FAST and SMART modes). 
+Distributed Autograd connects the autograd graph across several nodes and allows gradients to flow through during the backwards pass. Gradients are accumulated into a context (as opposed to the .grad field as with Autograd) and users must specify their model’s forward pass under a with `dist_autograd.context()` manager in order to ensure that all RPC communication is recorded properly. Currently, only FAST mode is implemented (see [here](https://pytorch.org/docs/stable/rpc/distributed_autograd.html#distributed-autograd-design) for the difference between FAST and SMART modes).
 
 ### Distributed Optimizer
 The distributed optimizer creates RRefs to optimizers on each worker with parameters that require gradients, and then uses the RPC API to run the optimizer remotely. The user must collect all remote parameters and wrap them in an `RRef`, as this is required input to the distributed optimizer. The user must also specify the distributed autograd `context_id` so that the optimizer knows in which context to look for gradients.
@@ -84,13 +84,13 @@ Learn more about distributed RPC framework APIs [here](https://pytorch.org/docs/
 
 ## New High level autograd API (Experimental)
 
-PyTorch 1.5 brings new functions including jacobian, hessian, jvp, vjp, hvp and vhp to the `torch.autograd.functional` submodule. This feature builds on the current API and allows the user to easily perform these functions. 
+PyTorch 1.5 brings new functions including jacobian, hessian, jvp, vjp, hvp and vhp to the `torch.autograd.functional` submodule. This feature builds on the current API and allows the user to easily perform these functions.
 
 Detailed design discussion on GitHub can be found [here](https://github.com/pytorch/pytorch/issues/30632).
 
 ## Python 2 no longer supported
 
-Starting PyTorch 1.5.0, we will no longer support Python 2, specifically version 2.7. Going forward support for Python will be limited to Python 3, specifically Python 3.5, 3.6, 3.7 and 3.8 (first enabled in PyTorch 1.4.0). 
+Starting PyTorch 1.5.0, we will no longer support Python 2, specifically version 2.7. Going forward support for Python will be limited to Python 3, specifically Python 3.5, 3.6, 3.7 and 3.8 (first enabled in PyTorch 1.4.0).
 
 
 *We’d like to thank the entire PyTorch team and the community for all their contributions to this work.*


### PR DESCRIPTION
Remove mentions of python 2 from Get Started: https://pytorch.org/get-started/locally/

Ran a big grep of mentions of "python 2" and "python2" in pytorch.github.io. Affected files found - linux.md and mac.md.