### PR TITLE
Truncate hub cards titles and add padding on hub detail page

### DIFF
--- a/_sass/base_styles.scss
+++ b/_sass/base_styles.scss
@@ -116,7 +116,7 @@ a, .btn {
   top: 0;
   left: 0;
   width: 100%;
-  height: 300px;
+  height: 350px;
   background-size: 100% 100%;
   background-repeat: no-repeat;
 
@@ -242,7 +242,7 @@ a, .btn {
   :-moz-placeholder { /* Firefox 18- */
     color: $orange;
   }
-  
+
   input[type="submit"] {
     position: absolute;
     right: 0;
@@ -473,6 +473,9 @@ a, .btn {
   h4 {
     color: $slate;
     margin-bottom: rem(18px);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   a {

--- a/_sass/hub.scss
+++ b/_sass/hub.scss
@@ -163,15 +163,15 @@
 
 .hub.hub-detail .main-content-wrapper {
   @include desktop {
-    margin-top: 270px + $desktop_header_height;
+    margin-top: 300px + $desktop_header_height;
   }
   @include small-desktop {
-    margin-top: 330px + $desktop_header_height;
+    margin-top: 400px + $desktop_header_height;
   }
   @media (max-width: 320px) {
-    margin-top: 300px;
+    margin-top: 330px;
   }
-  margin-top: 275px;
+  margin-top: 305px;
 }
 
 .hub .hub-cards-wrapper, .hub-cards-wrapper-right {


### PR DESCRIPTION
### This commit:
 

- Truncates multi-line hub card titles

 

- Adds padding to hub card detail page