### PR TITLE
Increase font-weight of blog table headers

### DIFF
--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -139,7 +139,7 @@
         overflow: unset;
         white-space: unset;
         text-overflow: unset;
-      }    
+      }
     }
 
     h1 {
@@ -256,6 +256,14 @@
     .main-content-wrapper {
       .author-icon {
         left: rem(-30px);
+      }
+    }
+  }
+
+  table {
+    tr {
+      th {
+        font-weight: 600;
       }
     }
   }


### PR DESCRIPTION
This PR increases the font-weight of the blog table headers. Preview: https://5f32a4bef8bd096d45c04506--shiftlab-pytorch-github-io.netlify.app/blog/torchvision03/