### PR TITLE
[Do Not Merge] Update vision docs with 0.7 release

### DIFF
--- a/docs/stable/torchvision/datasets.html
+++ b/docs/stable/torchvision/datasets.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.datasets &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.datasets &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/datasets.html"/>
   
 
   
@@ -27,28 +36,24 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="torchvision.io" href="io.html" />
     <link rel="prev" title="torchvision" href="index.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +164,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +176,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +187,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +232,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +240,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.datasets</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/datasets.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/datasets.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -339,9 +274,9 @@
               
   <div class="section" id="torchvision-datasets">
 <h1>torchvision.datasets<a class="headerlink" href="#torchvision-datasets" title="Permalink to this headline">¶</a></h1>
-<p>All datasets are subclasses of <a class="reference internal" href="../data.html#torch.utils.data.Dataset" title="torch.utils.data.Dataset"><code class="xref py py-class docutils literal notranslate"><span class="pre">torch.utils.data.Dataset</span></code></a>
+<p>All datasets are subclasses of <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.utils.data.Dataset</span></code>
 i.e, they have <code class="docutils literal notranslate"><span class="pre">__getitem__</span></code> and <code class="docutils literal notranslate"><span class="pre">__len__</span></code> methods implemented.
-Hence, they can all be passed to a <a class="reference internal" href="../data.html#torch.utils.data.DataLoader" title="torch.utils.data.DataLoader"><code class="xref py py-class docutils literal notranslate"><span class="pre">torch.utils.data.DataLoader</span></code></a>
+Hence, they can all be passed to a <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.utils.data.DataLoader</span></code>
 which can load multiple samples parallelly using <code class="docutils literal notranslate"><span class="pre">torch.multiprocessing</span></code> workers.
 For example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">imagenet_data</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">datasets</span><span class="o">.</span><span class="n">ImageNet</span><span class="p">(</span><span class="s1">&#39;path/to/imagenet_root/&#39;</span><span class="p">)</span>
@@ -353,240 +288,267 @@ For example:</p>
 </div>
 <p>The following datasets are available:</p>
 <div class="contents local topic" id="datasets">
-<p class="topic-title">Datasets</p>
+<p class="topic-title first">Datasets</p>
 <ul class="simple">
-<li><p><a class="reference internal" href="#mnist" id="id18">MNIST</a></p></li>
-<li><p><a class="reference internal" href="#fashion-mnist" id="id19">Fashion-MNIST</a></p></li>
-<li><p><a class="reference internal" href="#kmnist" id="id20">KMNIST</a></p></li>
-<li><p><a class="reference internal" href="#emnist" id="id21">EMNIST</a></p></li>
-<li><p><a class="reference internal" href="#qmnist" id="id22">QMNIST</a></p></li>
-<li><p><a class="reference internal" href="#fakedata" id="id23">FakeData</a></p></li>
-<li><p><a class="reference internal" href="#coco" id="id24">COCO</a></p>
-<ul>
-<li><p><a class="reference internal" href="#captions" id="id25">Captions</a></p></li>
-<li><p><a class="reference internal" href="#detection" id="id26">Detection</a></p></li>
+<li><a class="reference internal" href="#mnist" id="id17">MNIST</a></li>
+<li><a class="reference internal" href="#fashion-mnist" id="id18">Fashion-MNIST</a></li>
+<li><a class="reference internal" href="#kmnist" id="id19">KMNIST</a></li>
+<li><a class="reference internal" href="#emnist" id="id20">EMNIST</a></li>
+<li><a class="reference internal" href="#qmnist" id="id21">QMNIST</a></li>
+<li><a class="reference internal" href="#fakedata" id="id22">FakeData</a></li>
+<li><a class="reference internal" href="#coco" id="id23">COCO</a><ul>
+<li><a class="reference internal" href="#captions" id="id24">Captions</a></li>
+<li><a class="reference internal" href="#detection" id="id25">Detection</a></li>
 </ul>
 </li>
-<li><p><a class="reference internal" href="#lsun" id="id27">LSUN</a></p></li>
-<li><p><a class="reference internal" href="#imagefolder" id="id28">ImageFolder</a></p></li>
-<li><p><a class="reference internal" href="#datasetfolder" id="id29">DatasetFolder</a></p></li>
-<li><p><a class="reference internal" href="#imagenet" id="id30">ImageNet</a></p></li>
-<li><p><a class="reference internal" href="#cifar" id="id31">CIFAR</a></p></li>
-<li><p><a class="reference internal" href="#stl10" id="id32">STL10</a></p></li>
-<li><p><a class="reference internal" href="#svhn" id="id33">SVHN</a></p></li>
-<li><p><a class="reference internal" href="#phototour" id="id34">PhotoTour</a></p></li>
-<li><p><a class="reference internal" href="#sbu" id="id35">SBU</a></p></li>
-<li><p><a class="reference internal" href="#flickr" id="id36">Flickr</a></p></li>
-<li><p><a class="reference internal" href="#voc" id="id37">VOC</a></p></li>
-<li><p><a class="reference internal" href="#cityscapes" id="id38">Cityscapes</a></p></li>
-<li><p><a class="reference internal" href="#sbd" id="id39">SBD</a></p></li>
-<li><p><a class="reference internal" href="#usps" id="id40">USPS</a></p></li>
-<li><p><a class="reference internal" href="#kinetics-400" id="id41">Kinetics-400</a></p></li>
-<li><p><a class="reference internal" href="#hmdb51" id="id42">HMDB51</a></p></li>
-<li><p><a class="reference internal" href="#ucf101" id="id43">UCF101</a></p></li>
-<li><p><a class="reference internal" href="#celeba" id="id44">CelebA</a></p></li>
+<li><a class="reference internal" href="#lsun" id="id26">LSUN</a></li>
+<li><a class="reference internal" href="#imagefolder" id="id27">ImageFolder</a></li>
+<li><a class="reference internal" href="#datasetfolder" id="id28">DatasetFolder</a></li>
+<li><a class="reference internal" href="#imagenet" id="id29">ImageNet</a></li>
+<li><a class="reference internal" href="#cifar" id="id30">CIFAR</a></li>
+<li><a class="reference internal" href="#stl10" id="id31">STL10</a></li>
+<li><a class="reference internal" href="#svhn" id="id32">SVHN</a></li>
+<li><a class="reference internal" href="#phototour" id="id33">PhotoTour</a></li>
+<li><a class="reference internal" href="#sbu" id="id34">SBU</a></li>
+<li><a class="reference internal" href="#flickr" id="id35">Flickr</a></li>
+<li><a class="reference internal" href="#voc" id="id36">VOC</a></li>
+<li><a class="reference internal" href="#cityscapes" id="id37">Cityscapes</a></li>
+<li><a class="reference internal" href="#sbd" id="id38">SBD</a></li>
+<li><a class="reference internal" href="#usps" id="id39">USPS</a></li>
+<li><a class="reference internal" href="#kinetics-400" id="id40">Kinetics-400</a></li>
+<li><a class="reference internal" href="#hmdb51" id="id41">HMDB51</a></li>
+<li><a class="reference internal" href="#ucf101" id="id42">UCF101</a></li>
+<li><a class="reference internal" href="#celeba" id="id43">CelebA</a></li>
 </ul>
 </div>
 <p>All the datasets have almost similar API. They all have two common arguments:
 <code class="docutils literal notranslate"><span class="pre">transform</span></code> and  <code class="docutils literal notranslate"><span class="pre">target_transform</span></code> to transform the input and target respectively.</p>
 <div class="section" id="mnist">
-<h2><a class="toc-backref" href="#id18">MNIST</a><a class="headerlink" href="#mnist" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id17">MNIST</a><a class="headerlink" href="#mnist" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.MNIST">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">MNIST</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/mnist.html#MNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.MNIST" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">MNIST</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/mnist.html#MNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.MNIST" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://yann.lecun.com/exdb/mnist/">MNIST</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">MNIST/processed/training.pt</span></code>
-and  <code class="docutils literal notranslate"><span class="pre">MNIST/processed/test.pt</span></code> exist.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
-otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">MNIST/processed/training.pt</span></code>
+and  <code class="docutils literal notranslate"><span class="pre">MNIST/processed/test.pt</span></code> exist.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
+otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="fashion-mnist">
-<h2><a class="toc-backref" href="#id19">Fashion-MNIST</a><a class="headerlink" href="#fashion-mnist" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id18">Fashion-MNIST</a><a class="headerlink" href="#fashion-mnist" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.FashionMNIST">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">FashionMNIST</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/mnist.html#FashionMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.FashionMNIST" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">FashionMNIST</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/mnist.html#FashionMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.FashionMNIST" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://github.com/zalandoresearch/fashion-mnist">Fashion-MNIST</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">Fashion-MNIST/processed/training.pt</span></code>
-and  <code class="docutils literal notranslate"><span class="pre">Fashion-MNIST/processed/test.pt</span></code> exist.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
-otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">Fashion-MNIST/processed/training.pt</span></code>
+and  <code class="docutils literal notranslate"><span class="pre">Fashion-MNIST/processed/test.pt</span></code> exist.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
+otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="kmnist">
-<h2><a class="toc-backref" href="#id20">KMNIST</a><a class="headerlink" href="#kmnist" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id19">KMNIST</a><a class="headerlink" href="#kmnist" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.KMNIST">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">KMNIST</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/mnist.html#KMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.KMNIST" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">KMNIST</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/mnist.html#KMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.KMNIST" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://github.com/rois-codh/kmnist">Kuzushiji-MNIST</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">KMNIST/processed/training.pt</span></code>
-and  <code class="docutils literal notranslate"><span class="pre">KMNIST/processed/test.pt</span></code> exist.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
-otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">KMNIST/processed/training.pt</span></code>
+and  <code class="docutils literal notranslate"><span class="pre">KMNIST/processed/test.pt</span></code> exist.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
+otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="emnist">
-<h2><a class="toc-backref" href="#id21">EMNIST</a><a class="headerlink" href="#emnist" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id20">EMNIST</a><a class="headerlink" href="#emnist" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.EMNIST">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">EMNIST</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/mnist.html#EMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.EMNIST" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">EMNIST</code><span class="sig-paren">(</span><em>root</em>, <em>split</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/mnist.html#EMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.EMNIST" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.westernsydney.edu.au/bens/home/reproducible_research/emnist">EMNIST</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">EMNIST/processed/training.pt</span></code>
-and  <code class="docutils literal notranslate"><span class="pre">EMNIST/processed/test.pt</span></code> exist.</p></li>
-<li><p><strong>split</strong> (<em>string</em>) – The dataset has 6 different splits: <code class="docutils literal notranslate"><span class="pre">byclass</span></code>, <code class="docutils literal notranslate"><span class="pre">bymerge</span></code>,
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where <code class="docutils literal notranslate"><span class="pre">EMNIST/processed/training.pt</span></code>
+and  <code class="docutils literal notranslate"><span class="pre">EMNIST/processed/test.pt</span></code> exist.</li>
+<li><strong>split</strong> (<em>string</em>) – The dataset has 6 different splits: <code class="docutils literal notranslate"><span class="pre">byclass</span></code>, <code class="docutils literal notranslate"><span class="pre">bymerge</span></code>,
 <code class="docutils literal notranslate"><span class="pre">balanced</span></code>, <code class="docutils literal notranslate"><span class="pre">letters</span></code>, <code class="docutils literal notranslate"><span class="pre">digits</span></code> and <code class="docutils literal notranslate"><span class="pre">mnist</span></code>. This argument specifies
-which one to use.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
-otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+which one to use.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">training.pt</span></code>,
+otherwise from <code class="docutils literal notranslate"><span class="pre">test.pt</span></code>.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="qmnist">
-<h2><a class="toc-backref" href="#id22">QMNIST</a><a class="headerlink" href="#qmnist" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id21">QMNIST</a><a class="headerlink" href="#qmnist" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.QMNIST">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">QMNIST</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">what=None</em>, <em class="sig-param">compat=True</em>, <em class="sig-param">train=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/mnist.html#QMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.QMNIST" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">QMNIST</code><span class="sig-paren">(</span><em>root</em>, <em>what=None</em>, <em>compat=True</em>, <em>train=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/mnist.html#QMNIST"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.QMNIST" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://github.com/facebookresearch/qmnist">QMNIST</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset whose <a href="#id5"><span class="problematic" id="id6">``</span></a>processed’’
-subdir contains torch binary files with the datasets.</p></li>
-<li><p><strong>what</strong> (<em>string</em><em>,</em><em>optional</em>) – Can be ‘train’, ‘test’, ‘test10k’,
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset whose <a href="#id5"><span class="problematic" id="id6">``</span></a>processed’’
+subdir contains torch binary files with the datasets.</li>
+<li><strong>what</strong> (<em>string</em><em>,</em><em>optional</em>) – Can be ‘train’, ‘test’, ‘test10k’,
 ‘test50k’, or ‘nist’ for respectively the mnist compatible
 training set, the 60k qmnist testing set, the 10k qmnist
 examples that match the mnist testing set, the 50k
 remaining qmnist testing examples, or all the nist
 digits. The default is to select ‘train’ or ‘test’
-according to the compatibility argument ‘train’.</p></li>
-<li><p><strong>compat</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – A boolean that says whether the target
+according to the compatibility argument ‘train’.</li>
+<li><strong>compat</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – A boolean that says whether the target
 for each example is class number (for compatibility with
 the MNIST dataloader) or a torch vector containing the
-full qmnist information. Default=True.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from
+full qmnist information. Default=True.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from
 the internet and puts it in root directory. If dataset is
-already downloaded, it is not downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that
+already downloaded, it is not downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that
 takes in an PIL image and returns a transformed
-version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform
-that takes in the target and transforms it.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em><em>,</em><em>compatibility</em>) – When argument ‘what’ is
+version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform
+that takes in the target and transforms it.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em><em>,</em><em>compatibility</em>) – When argument ‘what’ is
 not specified, this boolean decides whether to load the
-training set ot the testing set.  Default: True.</p></li>
+training set ot the testing set.  Default: True.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="fakedata">
-<h2><a class="toc-backref" href="#id23">FakeData</a><a class="headerlink" href="#fakedata" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id22">FakeData</a><a class="headerlink" href="#fakedata" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.FakeData">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">FakeData</code><span class="sig-paren">(</span><em class="sig-param">size=1000</em>, <em class="sig-param">image_size=(3</em>, <em class="sig-param">224</em>, <em class="sig-param">224)</em>, <em class="sig-param">num_classes=10</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">random_offset=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/fakedata.html#FakeData"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.FakeData" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">FakeData</code><span class="sig-paren">(</span><em>size=1000</em>, <em>image_size=(3</em>, <em>224</em>, <em>224)</em>, <em>num_classes=10</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>random_offset=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/fakedata.html#FakeData"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.FakeData" title="Permalink to this definition">¶</a></dt>
 <dd><p>A fake dataset that returns randomly generated images and returns them as PIL images</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Size of the dataset. Default: 1000 images</p></li>
-<li><p><strong>image_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – Size if the returned images. Default: (3, 224, 224)</p></li>
-<li><p><strong>num_classes</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Number of classes in the datset. Default: 10</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>random_offset</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Offsets the index-based random seed used to
-generate each image. Default: 0</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Size of the dataset. Default: 1000 images</li>
+<li><strong>image_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – Size if the returned images. Default: (3, 224, 224)</li>
+<li><strong>num_classes</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Number of classes in the datset. Default: 10</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>random_offset</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Offsets the index-based random seed used to
+generate each image. Default: 0</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="coco">
-<h2><a class="toc-backref" href="#id24">COCO</a><a class="headerlink" href="#coco" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id23">COCO</a><a class="headerlink" href="#coco" title="Permalink to this headline">¶</a></h2>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>These require the <a class="reference external" href="https://github.com/pdollar/coco/tree/master/PythonAPI">COCO API to be installed</a></p>
+<p class="first admonition-title">Note</p>
+<p class="last">These require the <a class="reference external" href="https://github.com/pdollar/coco/tree/master/PythonAPI">COCO API to be installed</a></p>
 </div>
 <div class="section" id="captions">
-<h3><a class="toc-backref" href="#id25">Captions</a><a class="headerlink" href="#captions" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id24">Captions</a><a class="headerlink" href="#captions" title="Permalink to this headline">¶</a></h3>
 <dl class="class">
 <dt id="torchvision.datasets.CocoCaptions">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">CocoCaptions</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">annFile</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/coco.html#CocoCaptions"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoCaptions" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">CocoCaptions</code><span class="sig-paren">(</span><em>root</em>, <em>annFile</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/coco.html#CocoCaptions"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoCaptions" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://mscoco.org/dataset/#captions-challenge2015">MS Coco Captions</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</p></li>
-<li><p><strong>annFile</strong> (<em>string</em>) – Path to json annotation file.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</li>
+<li><strong>annFile</strong> (<em>string</em>) – Path to json annotation file.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+and returns a transformed version.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Example</p>
-<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.datasets</span> <span class="k">as</span> <span class="nn">dset</span>
+<div class="code python highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.datasets</span> <span class="k">as</span> <span class="nn">dset</span>
 <span class="kn">import</span> <span class="nn">torchvision.transforms</span> <span class="k">as</span> <span class="nn">transforms</span>
 <span class="n">cap</span> <span class="o">=</span> <span class="n">dset</span><span class="o">.</span><span class="n">CocoCaptions</span><span class="p">(</span><span class="n">root</span> <span class="o">=</span> <span class="s1">&#39;dir where images are&#39;</span><span class="p">,</span>
                         <span class="n">annFile</span> <span class="o">=</span> <span class="s1">&#39;json annotation file&#39;</span><span class="p">,</span>
@@ -611,57 +573,63 @@ and returns a transformed version.</p></li>
 </div>
 <dl class="method">
 <dt id="torchvision.datasets.CocoCaptions.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/coco.html#CocoCaptions.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoCaptions.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Tuple (image, target). target is a list of captions for the image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/coco.html#CocoCaptions.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoCaptions.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Tuple (image, target). target is a list of captions for the image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="detection">
-<h3><a class="toc-backref" href="#id26">Detection</a><a class="headerlink" href="#detection" title="Permalink to this headline">¶</a></h3>
+<h3><a class="toc-backref" href="#id25">Detection</a><a class="headerlink" href="#detection" title="Permalink to this headline">¶</a></h3>
 <dl class="class">
 <dt id="torchvision.datasets.CocoDetection">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">CocoDetection</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">annFile</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/coco.html#CocoDetection"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoDetection" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">CocoDetection</code><span class="sig-paren">(</span><em>root</em>, <em>annFile</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/coco.html#CocoDetection"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoDetection" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://mscoco.org/dataset/#detections-challenge2016">MS Coco Detection</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</p></li>
-<li><p><strong>annFile</strong> (<em>string</em>) – Path to json annotation file.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</li>
+<li><strong>annFile</strong> (<em>string</em>) – Path to json annotation file.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+and returns a transformed version.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.CocoDetection.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/coco.html#CocoDetection.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoDetection.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Tuple (image, target). target is the object returned by <code class="docutils literal notranslate"><span class="pre">coco.loadAnns</span></code>.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/coco.html#CocoDetection.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CocoDetection.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Tuple (image, target). target is the object returned by <code class="docutils literal notranslate"><span class="pre">coco.loadAnns</span></code>.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
@@ -669,48 +637,53 @@ and returns a transformed version.</p></li>
 </div>
 </div>
 <div class="section" id="lsun">
-<h2><a class="toc-backref" href="#id27">LSUN</a><a class="headerlink" href="#lsun" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id26">LSUN</a><a class="headerlink" href="#lsun" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.LSUN">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">LSUN</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">classes='train'</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/lsun.html#LSUN"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.LSUN" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">LSUN</code><span class="sig-paren">(</span><em>root</em>, <em>classes='train'</em>, <em>transform=None</em>, <em>target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/lsun.html#LSUN"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.LSUN" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.yf.io/p/lsun">LSUN</a> dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory for the database files.</p></li>
-<li><p><strong>classes</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – One of {‘train’, ‘val’, ‘test’} or a list of
-categories to load. e,g. [‘bedroom_train’, ‘church_outdoor_train’].</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory for the database files.</li>
+<li><strong>classes</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – One of {‘train’, ‘val’, ‘test’} or a list of
+categories to load. e,g. [‘bedroom_train’, ‘church_train’].</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.LSUN.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/lsun.html#LSUN.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.LSUN.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Tuple (image, target) where target is the index of the target category.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/lsun.html#LSUN.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.LSUN.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Tuple (image, target) where target is the index of the target category.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="imagefolder">
-<h2><a class="toc-backref" href="#id28">ImageFolder</a><a class="headerlink" href="#imagefolder" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id27">ImageFolder</a><a class="headerlink" href="#imagefolder" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.ImageFolder">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">ImageFolder</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">loader=&lt;function default_loader&gt;</em>, <em class="sig-param">is_valid_file=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/folder.html#ImageFolder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.ImageFolder" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">ImageFolder</code><span class="sig-paren">(</span><em>root</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>loader=&lt;function default_loader&gt;</em>, <em>is_valid_file=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/folder.html#ImageFolder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.ImageFolder" title="Permalink to this definition">¶</a></dt>
 <dd><p>A generic data loader where the images are arranged in this way:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">root</span><span class="o">/</span><span class="n">dog</span><span class="o">/</span><span class="n">xxx</span><span class="o">.</span><span class="n">png</span>
 <span class="n">root</span><span class="o">/</span><span class="n">dog</span><span class="o">/</span><span class="n">xxy</span><span class="o">.</span><span class="n">png</span>
@@ -721,44 +694,49 @@ target and transforms it.</p></li>
 <span class="n">root</span><span class="o">/</span><span class="n">cat</span><span class="o">/</span><span class="n">asd932_</span><span class="o">.</span><span class="n">png</span>
 </pre></div>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory path.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>loader</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function to load an image given its path.</p></li>
-<li><p><strong>is_valid_file</strong> – A function that takes path of an Image file
-and check if the file is a valid file (used to check of corrupt files)</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory path.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>loader</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function to load an image given its path.</li>
+<li><strong>is_valid_file</strong> – A function that takes path of an Image file
+and check if the file is a valid file (used to check of corrupt files)</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.ImageFolder.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="headerlink" href="#torchvision.datasets.ImageFolder.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(sample, target) where target is class_index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="headerlink" href="#torchvision.datasets.ImageFolder.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(sample, target) where target is class_index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="datasetfolder">
-<h2><a class="toc-backref" href="#id29">DatasetFolder</a><a class="headerlink" href="#datasetfolder" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id28">DatasetFolder</a><a class="headerlink" href="#datasetfolder" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.DatasetFolder">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">DatasetFolder</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">loader</em>, <em class="sig-param">extensions=None</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">is_valid_file=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/folder.html#DatasetFolder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.DatasetFolder" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">DatasetFolder</code><span class="sig-paren">(</span><em>root</em>, <em>loader</em>, <em>extensions=None</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>is_valid_file=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/folder.html#DatasetFolder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.DatasetFolder" title="Permalink to this definition">¶</a></dt>
 <dd><p>A generic data loader where the samples are arranged in this way:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">root</span><span class="o">/</span><span class="n">class_x</span><span class="o">/</span><span class="n">xxx</span><span class="o">.</span><span class="n">ext</span>
 <span class="n">root</span><span class="o">/</span><span class="n">class_x</span><span class="o">/</span><span class="n">xxy</span><span class="o">.</span><span class="n">ext</span>
@@ -769,477 +747,530 @@ and check if the file is a valid file (used to check of corrupt files)</p></li>
 <span class="n">root</span><span class="o">/</span><span class="n">class_y</span><span class="o">/</span><span class="n">asd932_</span><span class="o">.</span><span class="n">ext</span>
 </pre></div>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory path.</p></li>
-<li><p><strong>loader</strong> (<em>callable</em>) – A function to load a sample given its path.</p></li>
-<li><p><strong>extensions</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>[</em><em>string</em><em>]</em>) – A list of allowed extensions.
-both extensions and is_valid_file should not be passed.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory path.</li>
+<li><strong>loader</strong> (<em>callable</em>) – A function to load a sample given its path.</li>
+<li><strong>extensions</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>[</em><em>string</em><em>]</em>) – A list of allowed extensions.
+both extensions and is_valid_file should not be passed.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in
 a sample and returns a transformed version.
-E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code> for images.</p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes
-in the target and transforms it.</p></li>
-<li><p><strong>is_valid_file</strong> – A function that takes path of a file
+E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code> for images.</li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes
+in the target and transforms it.</li>
+<li><strong>is_valid_file</strong> – A function that takes path of a file
 and check if the file is a valid file (used to check of corrupt files)
-both extensions and is_valid_file should not be passed.</p></li>
+both extensions and is_valid_file should not be passed.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.DatasetFolder.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/folder.html#DatasetFolder.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.DatasetFolder.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(sample, target) where target is class_index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/folder.html#DatasetFolder.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.DatasetFolder.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(sample, target) where target is class_index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="imagenet">
-<h2><a class="toc-backref" href="#id30">ImageNet</a><a class="headerlink" href="#imagenet" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id29">ImageNet</a><a class="headerlink" href="#imagenet" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.ImageNet">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">ImageNet</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split='train'</em>, <em class="sig-param">download=None</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/imagenet.html#ImageNet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.ImageNet" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">ImageNet</code><span class="sig-paren">(</span><em>root</em>, <em>split='train'</em>, <em>download=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/imagenet.html#ImageNet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.ImageNet" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://image-net.org/">ImageNet</a> 2012 Classification Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the ImageNet Dataset.</p></li>
-<li><p><strong>split</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset split, supports <code class="docutils literal notranslate"><span class="pre">train</span></code>, or <code class="docutils literal notranslate"><span class="pre">val</span></code>.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>loader</strong> – A function to load an image given its path.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the ImageNet Dataset.</li>
+<li><strong>split</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset split, supports <code class="docutils literal notranslate"><span class="pre">train</span></code>, or <code class="docutils literal notranslate"><span class="pre">val</span></code>.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>loader</strong> – A function to load an image given its path.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This requires <cite>scipy</cite> to be installed</p>
+<p class="first admonition-title">Note</p>
+<p class="last">This requires <cite>scipy</cite> to be installed</p>
 </div>
 </div>
 <div class="section" id="cifar">
-<h2><a class="toc-backref" href="#id31">CIFAR</a><a class="headerlink" href="#cifar" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id30">CIFAR</a><a class="headerlink" href="#cifar" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.CIFAR10">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">CIFAR10</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/cifar.html#CIFAR10"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR10" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">CIFAR10</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/cifar.html#CIFAR10"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR10" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.cs.toronto.edu/~kriz/cifar.html">CIFAR10</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
-<code class="docutils literal notranslate"><span class="pre">cifar-10-batches-py</span></code> exists or will be saved to if download is set to True.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from training set, otherwise
-creates from test set.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
+<code class="docutils literal notranslate"><span class="pre">cifar-10-batches-py</span></code> exists or will be saved to if download is set to True.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from training set, otherwise
+creates from test set.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.CIFAR10.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/cifar.html#CIFAR10.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR10.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/cifar.html#CIFAR10.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR10.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.datasets.CIFAR100">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">CIFAR100</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/cifar.html#CIFAR100"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR100" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">CIFAR100</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/cifar.html#CIFAR100"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CIFAR100" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.cs.toronto.edu/~kriz/cifar.html">CIFAR100</a> Dataset.</p>
 <p>This is a subclass of the <cite>CIFAR10</cite> Dataset.</p>
 </dd></dl>
 
 </div>
 <div class="section" id="stl10">
-<h2><a class="toc-backref" href="#id32">STL10</a><a class="headerlink" href="#stl10" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id31">STL10</a><a class="headerlink" href="#stl10" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.STL10">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">STL10</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split='train'</em>, <em class="sig-param">folds=None</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/stl10.html#STL10"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.STL10" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">STL10</code><span class="sig-paren">(</span><em>root</em>, <em>split='train'</em>, <em>folds=None</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/stl10.html#STL10"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.STL10" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://cs.stanford.edu/~acoates/stl10/">STL10</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
-<code class="docutils literal notranslate"><span class="pre">stl10_binary</span></code> exists.</p></li>
-<li><p><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘test’, ‘unlabeled’, ‘train+unlabeled’}.
-Accordingly dataset is selected.</p></li>
-<li><p><strong>folds</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – <p>One of {0-9} or None.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
+<code class="docutils literal notranslate"><span class="pre">stl10_binary</span></code> exists.</li>
+<li><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘test’, ‘unlabeled’, ‘train+unlabeled’}.
+Accordingly dataset is selected.</li>
+<li><strong>folds</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – <p>One of {0-9} or None.
 For training, loads one of the 10 pre-defined folds of 1k samples for the</p>
 <blockquote>
-<div><p>standard evaluation procedure. If no value is passed, loads the 5k samples.</p>
-</div></blockquote>
-</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<div>standard evaluation procedure. If no value is passed, loads the 5k samples.</div></blockquote>
+</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.STL10.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/stl10.html#STL10.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.STL10.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/stl10.html#STL10.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.STL10.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="svhn">
-<h2><a class="toc-backref" href="#id33">SVHN</a><a class="headerlink" href="#svhn" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id32">SVHN</a><a class="headerlink" href="#svhn" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.SVHN">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">SVHN</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split='train'</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/svhn.html#SVHN"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SVHN" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">SVHN</code><span class="sig-paren">(</span><em>root</em>, <em>split='train'</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/svhn.html#SVHN"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SVHN" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://ufldl.stanford.edu/housenumbers/">SVHN</a> Dataset.
 Note: The SVHN dataset assigns the label <cite>10</cite> to the digit <cite>0</cite>. However, in this Dataset,
 we assign the label <cite>0</cite> to the digit <cite>0</cite> to be compatible with PyTorch loss functions which
 expect the class labels to be in the range <cite>[0, C-1]</cite></p>
-<div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>This class needs <a class="reference external" href="https://docs.scipy.org/doc/">scipy</a> to load data from <cite>.mat</cite> format.</p>
-</div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
-<code class="docutils literal notranslate"><span class="pre">SVHN</span></code> exists.</p></li>
-<li><p><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘test’, ‘extra’}.
-Accordingly dataset is selected. ‘extra’ is Extra training set.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory
+<code class="docutils literal notranslate"><span class="pre">SVHN</span></code> exists.</li>
+<li><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘test’, ‘extra’}.
+Accordingly dataset is selected. ‘extra’ is Extra training set.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.SVHN.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/svhn.html#SVHN.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SVHN.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/svhn.html#SVHN.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SVHN.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="phototour">
-<h2><a class="toc-backref" href="#id34">PhotoTour</a><a class="headerlink" href="#phototour" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id33">PhotoTour</a><a class="headerlink" href="#phototour" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.PhotoTour">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">PhotoTour</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">name</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/phototour.html#PhotoTour"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.PhotoTour" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">PhotoTour</code><span class="sig-paren">(</span><em>root</em>, <em>name</em>, <em>train=True</em>, <em>transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/phototour.html#PhotoTour"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.PhotoTour" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://phototour.cs.washington.edu/patches/default.htm">Learning Local Image Descriptors Data</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are.</p></li>
-<li><p><strong>name</strong> (<em>string</em>) – Name of the dataset to load.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are.</li>
+<li><strong>name</strong> (<em>string</em>) – Name of the dataset to load.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.PhotoTour.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/phototour.html#PhotoTour.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.PhotoTour.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(data1, data2, matches)</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/phototour.html#PhotoTour.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.PhotoTour.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(data1, data2, matches)</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="sbu">
-<h2><a class="toc-backref" href="#id35">SBU</a><a class="headerlink" href="#sbu" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id34">SBU</a><a class="headerlink" href="#sbu" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.SBU">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">SBU</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=True</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/sbu.html#SBU"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBU" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">SBU</code><span class="sig-paren">(</span><em>root</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=True</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/sbu.html#SBU"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBU" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://www.cs.virginia.edu/~vicente/sbucaptions/">SBU Captioned Photo</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where tarball
-<code class="docutils literal notranslate"><span class="pre">SBUCaptionedPhotoDataset.tar.gz</span></code> exists.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where tarball
+<code class="docutils literal notranslate"><span class="pre">SBUCaptionedPhotoDataset.tar.gz</span></code> exists.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.SBU.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/sbu.html#SBU.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBU.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is a caption for the photo.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/sbu.html#SBU.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBU.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is a caption for the photo.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="flickr">
-<h2><a class="toc-backref" href="#id36">Flickr</a><a class="headerlink" href="#flickr" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id35">Flickr</a><a class="headerlink" href="#flickr" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.Flickr8k">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">Flickr8k</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">ann_file</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/flickr.html#Flickr8k"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr8k" title="Permalink to this definition">¶</a></dt>
-<dd><p><a class="reference external" href="http://hockenmaier.cs.illinois.edu/8k-pictures.html">Flickr8k Entities</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</p></li>
-<li><p><strong>ann_file</strong> (<em>string</em>) – Path to annotation file.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">Flickr8k</code><span class="sig-paren">(</span><em>root</em>, <em>ann_file</em>, <em>transform=None</em>, <em>target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/flickr.html#Flickr8k"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr8k" title="Permalink to this definition">¶</a></dt>
+<dd><p><a class="reference external" href="http://nlp.cs.illinois.edu/HockenmaierGroup/8k-pictures.html">Flickr8k Entities</a> Dataset.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</li>
+<li><strong>ann_file</strong> (<em>string</em>) – Path to annotation file.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.Flickr8k.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/flickr.html#Flickr8k.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr8k.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Tuple (image, target). target is a list of captions for the image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/flickr.html#Flickr8k.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr8k.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Tuple (image, target). target is a list of captions for the image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.datasets.Flickr30k">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">Flickr30k</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">ann_file</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/flickr.html#Flickr30k"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr30k" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">Flickr30k</code><span class="sig-paren">(</span><em>root</em>, <em>ann_file</em>, <em>transform=None</em>, <em>target_transform=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/flickr.html#Flickr30k"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr30k" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://web.engr.illinois.edu/~bplumme2/Flickr30kEntities/">Flickr30k Entities</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</p></li>
-<li><p><strong>ann_file</strong> (<em>string</em>) – Path to annotation file.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</li>
+<li><strong>ann_file</strong> (<em>string</em>) – Path to annotation file.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.Flickr30k.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/flickr.html#Flickr30k.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr30k.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Tuple (image, target). target is a list of captions for the image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/flickr.html#Flickr30k.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Flickr30k.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Tuple (image, target). target is a list of captions for the image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="voc">
-<h2><a class="toc-backref" href="#id37">VOC</a><a class="headerlink" href="#voc" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id36">VOC</a><a class="headerlink" href="#voc" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.VOCSegmentation">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">VOCSegmentation</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">year='2012'</em>, <em class="sig-param">image_set='train'</em>, <em class="sig-param">download=False</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/voc.html#VOCSegmentation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCSegmentation" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">VOCSegmentation</code><span class="sig-paren">(</span><em>root</em>, <em>year='2012'</em>, <em>image_set='train'</em>, <em>download=False</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/voc.html#VOCSegmentation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCSegmentation" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://host.robots.ox.ac.uk/pascal/VOC/">Pascal VOC</a> Segmentation Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the VOC Dataset.</p></li>
-<li><p><strong>year</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset year, supports years 2007 to 2012.</p></li>
-<li><p><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">trainval</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the VOC Dataset.</li>
+<li><strong>year</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset year, supports years 2007 to 2012.</li>
+<li><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">trainval</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
-and returns a transformed version.</p></li>
+downloaded again.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+and returns a transformed version.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.VOCSegmentation.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/voc.html#VOCSegmentation.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCSegmentation.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is the image segmentation.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/voc.html#VOCSegmentation.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCSegmentation.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is the image segmentation.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.datasets.VOCDetection">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">VOCDetection</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">year='2012'</em>, <em class="sig-param">image_set='train'</em>, <em class="sig-param">download=False</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/voc.html#VOCDetection"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCDetection" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">VOCDetection</code><span class="sig-paren">(</span><em>root</em>, <em>year='2012'</em>, <em>image_set='train'</em>, <em>download=False</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/voc.html#VOCDetection"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCDetection" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://host.robots.ox.ac.uk/pascal/VOC/">Pascal VOC</a> Detection Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the VOC Dataset.</p></li>
-<li><p><strong>year</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset year, supports years 2007 to 2012.</p></li>
-<li><p><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">trainval</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the VOC Dataset.</li>
+<li><strong>year</strong> (<em>string</em><em>, </em><em>optional</em>) – The dataset year, supports years 2007 to 2012.</li>
+<li><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">trainval</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
 downloaded again.
-(default: alphabetic indexing of VOC’s 20 classes).</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>required</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
-and returns a transformed version.</p></li>
+(default: alphabetic indexing of VOC’s 20 classes).</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>required</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+and returns a transformed version.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.VOCDetection.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/voc.html#VOCDetection.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCDetection.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is a dictionary of the XML tree.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/voc.html#VOCDetection.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.VOCDetection.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is a dictionary of the XML tree.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="cityscapes">
-<h2><a class="toc-backref" href="#id38">Cityscapes</a><a class="headerlink" href="#cityscapes" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id37">Cityscapes</a><a class="headerlink" href="#cityscapes" title="Permalink to this headline">¶</a></h2>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>Requires Cityscape to be downloaded.</p>
+<p class="first admonition-title">Note</p>
+<p class="last">Requires Cityscape to be downloaded.</p>
 </div>
 <dl class="class">
 <dt id="torchvision.datasets.Cityscapes">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">Cityscapes</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split='train'</em>, <em class="sig-param">mode='fine'</em>, <em class="sig-param">target_type='instance'</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/cityscapes.html#Cityscapes"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Cityscapes" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">Cityscapes</code><span class="sig-paren">(</span><em>root</em>, <em>split='train'</em>, <em>mode='fine'</em>, <em>target_type='instance'</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/cityscapes.html#Cityscapes"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Cityscapes" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://www.cityscapes-dataset.com/">Cityscapes</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory <code class="docutils literal notranslate"><span class="pre">leftImg8bit</span></code>
-and <code class="docutils literal notranslate"><span class="pre">gtFine</span></code> or <code class="docutils literal notranslate"><span class="pre">gtCoarse</span></code> are located.</p></li>
-<li><p><strong>split</strong> (<em>string</em><em>, </em><em>optional</em>) – The image split to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">test</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code> if mode=”fine”
-otherwise <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">train_extra</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></p></li>
-<li><p><strong>mode</strong> (<em>string</em><em>, </em><em>optional</em>) – The quality mode to use, <code class="docutils literal notranslate"><span class="pre">fine</span></code> or <code class="docutils literal notranslate"><span class="pre">coarse</span></code></p></li>
-<li><p><strong>target_type</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>, </em><em>optional</em>) – Type of target to use, <code class="docutils literal notranslate"><span class="pre">instance</span></code>, <code class="docutils literal notranslate"><span class="pre">semantic</span></code>, <code class="docutils literal notranslate"><span class="pre">polygon</span></code>
-or <code class="docutils literal notranslate"><span class="pre">color</span></code>. Can also be a list to output a tuple with all specified target types.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset where directory <code class="docutils literal notranslate"><span class="pre">leftImg8bit</span></code>
+and <code class="docutils literal notranslate"><span class="pre">gtFine</span></code> or <code class="docutils literal notranslate"><span class="pre">gtCoarse</span></code> are located.</li>
+<li><strong>split</strong> (<em>string</em><em>, </em><em>optional</em>) – The image split to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">test</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code> if mode=”gtFine”
+otherwise <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">train_extra</span></code> or <code class="docutils literal notranslate"><span class="pre">val</span></code></li>
+<li><strong>mode</strong> (<em>string</em><em>, </em><em>optional</em>) – The quality mode to use, <code class="docutils literal notranslate"><span class="pre">gtFine</span></code> or <code class="docutils literal notranslate"><span class="pre">gtCoarse</span></code></li>
+<li><strong>target_type</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>, </em><em>optional</em>) – Type of target to use, <code class="docutils literal notranslate"><span class="pre">instance</span></code>, <code class="docutils literal notranslate"><span class="pre">semantic</span></code>, <code class="docutils literal notranslate"><span class="pre">polygon</span></code>
+or <code class="docutils literal notranslate"><span class="pre">color</span></code>. Can also be a list to output a tuple with all specified target types.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+and returns a transformed version.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Examples</p>
 <p>Get semantic segmentation target</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="n">dataset</span> <span class="o">=</span> <span class="n">Cityscapes</span><span class="p">(</span><span class="s1">&#39;./data/cityscapes&#39;</span><span class="p">,</span> <span class="n">split</span><span class="o">=</span><span class="s1">&#39;train&#39;</span><span class="p">,</span> <span class="n">mode</span><span class="o">=</span><span class="s1">&#39;fine&#39;</span><span class="p">,</span>
@@ -1264,113 +1295,123 @@ and returns a transformed version.</p></li>
 </div>
 <dl class="method">
 <dt id="torchvision.datasets.Cityscapes.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/cityscapes.html#Cityscapes.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Cityscapes.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is a tuple of all target types if target_type is a list with more
-than one item. Otherwise target is a json object if target_type=”polygon”, else the image segmentation.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/cityscapes.html#Cityscapes.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Cityscapes.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is a tuple of all target types if target_type is a list with more
+than one item. Otherwise target is a json object if target_type=”polygon”, else the image segmentation.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="sbd">
-<h2><a class="toc-backref" href="#id39">SBD</a><a class="headerlink" href="#sbd" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id38">SBD</a><a class="headerlink" href="#sbd" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.SBDataset">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">SBDataset</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">image_set='train'</em>, <em class="sig-param">mode='boundaries'</em>, <em class="sig-param">download=False</em>, <em class="sig-param">transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/sbd.html#SBDataset"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBDataset" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">SBDataset</code><span class="sig-paren">(</span><em>root</em>, <em>image_set='train'</em>, <em>mode='boundaries'</em>, <em>download=False</em>, <em>transforms=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/sbd.html#SBDataset"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.SBDataset" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://home.bharathh.info/pubs/codes/SBD/download.html">Semantic Boundaries Dataset</a></p>
 <p>The SBD currently contains annotations from 11355 images taken from the PASCAL VOC 2011 dataset.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>Please note that the train and val splits included with this dataset are different from
+<p class="first admonition-title">Note</p>
+<p class="last">Please note that the train and val splits included with this dataset are different from
 the splits in the PASCAL VOC dataset. In particular some “train” images might be part of
 VOC2012 val.
 If you are interested in testing on VOC 2012 val, then use <cite>image_set=’train_noval’</cite>,
 which excludes all val images.</p>
 </div>
 <div class="admonition warning">
-<p class="admonition-title">Warning</p>
-<p>This class needs <a class="reference external" href="https://docs.scipy.org/doc/">scipy</a> to load target files from <cite>.mat</cite> format.</p>
+<p class="first admonition-title">Warning</p>
+<p class="last">This class needs <a class="reference external" href="https://docs.scipy.org/doc/">scipy</a> to load target files from <cite>.mat</cite> format.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the Semantic Boundaries Dataset</p></li>
-<li><p><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">val</span></code> or <code class="docutils literal notranslate"><span class="pre">train_noval</span></code>.
-Image set <code class="docutils literal notranslate"><span class="pre">train_noval</span></code> excludes VOC 2012 val images.</p></li>
-<li><p><strong>mode</strong> (<em>string</em><em>, </em><em>optional</em>) – Select target type. Possible values ‘boundaries’ or ‘segmentation’.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the Semantic Boundaries Dataset</li>
+<li><strong>image_set</strong> (<em>string</em><em>, </em><em>optional</em>) – Select the image_set to use, <code class="docutils literal notranslate"><span class="pre">train</span></code>, <code class="docutils literal notranslate"><span class="pre">val</span></code> or <code class="docutils literal notranslate"><span class="pre">train_noval</span></code>.
+Image set <code class="docutils literal notranslate"><span class="pre">train_noval</span></code> excludes VOC 2012 val images.</li>
+<li><strong>mode</strong> (<em>string</em><em>, </em><em>optional</em>) – Select target type. Possible values ‘boundaries’ or ‘segmentation’.
 In case of ‘boundaries’, the target is an array of shape <cite>[num_classes, H, W]</cite>,
-where <cite>num_classes=20</cite>.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+where <cite>num_classes=20</cite>.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
-<li><p><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
+downloaded again.</li>
+<li><strong>transforms</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes input sample and its target as entry
 and returns a transformed version. Input sample is PIL image and target is a numpy array
-if <cite>mode=’boundaries’</cite> or PIL image if <cite>mode=’segmentation’</cite>.</p></li>
+if <cite>mode=’boundaries’</cite> or PIL image if <cite>mode=’segmentation’</cite>.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="usps">
-<h2><a class="toc-backref" href="#id40">USPS</a><a class="headerlink" href="#usps" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id39">USPS</a><a class="headerlink" href="#usps" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.USPS">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">USPS</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/usps.html#USPS"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.USPS" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">USPS</code><span class="sig-paren">(</span><em>root</em>, <em>train=True</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/usps.html#USPS"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.USPS" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multiclass.html#usps">USPS</a> Dataset.
 The data-format is : [label [index:value ]*256 n] * num_lines, where <code class="docutils literal notranslate"><span class="pre">label</span></code> lies in <code class="docutils literal notranslate"><span class="pre">[1,</span> <span class="pre">10]</span></code>.
 The value for each pixel lies in <code class="docutils literal notranslate"><span class="pre">[-1,</span> <span class="pre">1]</span></code>. Here we transform the <code class="docutils literal notranslate"><span class="pre">label</span></code> into <code class="docutils literal notranslate"><span class="pre">[0,</span> <span class="pre">9]</span></code>
 and make pixel values in <code class="docutils literal notranslate"><span class="pre">[0,</span> <span class="pre">255]</span></code>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of dataset to store``USPS`` data files.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">usps.bz2</span></code>,
-otherwise from <code class="docutils literal notranslate"><span class="pre">usps.t.bz2</span></code>.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of dataset to store``USPS`` data files.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, creates dataset from <code class="docutils literal notranslate"><span class="pre">usps.bz2</span></code>,
+otherwise from <code class="docutils literal notranslate"><span class="pre">usps.t.bz2</span></code>.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.RandomCrop</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.datasets.USPS.__getitem__">
-<code class="sig-name descname">__getitem__</code><span class="sig-paren">(</span><em class="sig-param">index</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/usps.html#USPS.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.USPS.__getitem__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>(image, target) where target is index of the target class.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+<code class="descname">__getitem__</code><span class="sig-paren">(</span><em>index</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/usps.html#USPS.__getitem__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.USPS.__getitem__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>index</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Index</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">(image, target) where target is index of the target class.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 </div>
 <div class="section" id="kinetics-400">
-<h2><a class="toc-backref" href="#id41">Kinetics-400</a><a class="headerlink" href="#kinetics-400" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id40">Kinetics-400</a><a class="headerlink" href="#kinetics-400" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.Kinetics400">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">Kinetics400</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">frames_per_clip</em>, <em class="sig-param">step_between_clips=1</em>, <em class="sig-param">frame_rate=None</em>, <em class="sig-param">extensions=('avi'</em>, <em class="sig-param">)</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">_precomputed_metadata=None</em>, <em class="sig-param">num_workers=1</em>, <em class="sig-param">_video_width=0</em>, <em class="sig-param">_video_height=0</em>, <em class="sig-param">_video_min_dimension=0</em>, <em class="sig-param">_audio_samples=0</em>, <em class="sig-param">_audio_channels=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/kinetics.html#Kinetics400"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Kinetics400" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">Kinetics400</code><span class="sig-paren">(</span><em>root</em>, <em>frames_per_clip</em>, <em>step_between_clips=1</em>, <em>frame_rate=None</em>, <em>extensions=('avi'</em>, <em>)</em>, <em>transform=None</em>, <em>_precomputed_metadata=None</em>, <em>num_workers=1</em>, <em>_video_width=0</em>, <em>_video_height=0</em>, <em>_video_min_dimension=0</em>, <em>_audio_samples=0</em>, <em>_audio_channels=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/kinetics.html#Kinetics400"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.Kinetics400" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://deepmind.com/research/open-source/open-source-datasets/kinetics/">Kinetics-400</a>
 dataset.</p>
 <p>Kinetics-400 is an action recognition video dataset.
@@ -1383,37 +1424,41 @@ elements will come from video 1, and the next three elements from video 2.
 Note that we drop clips which do not have exactly <code class="docutils literal notranslate"><span class="pre">frames_per_clip</span></code> elements, so not all
 frames in a video might be present.</p>
 <p>Internally, it uses a VideoClips object to handle clip creation.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the Kinetics-400 Dataset.</p></li>
-<li><p><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames in a clip</p></li>
-<li><p><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames between each clip</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in a TxHxWxC video
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the Kinetics-400 Dataset.</li>
+<li><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames in a clip</li>
+<li><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames between each clip</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in a TxHxWxC video
+and returns a transformed version.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><p>the <cite>T</cite> video frames
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first"><p>the <cite>T</cite> video frames
 audio(Tensor[K, L]): the audio frames, where <cite>K</cite> is the number of channels</p>
 <blockquote>
 <div><p>and <cite>L</cite> is the number of points</p>
 </div></blockquote>
 <p>label (int): class of the video clip</p>
 </p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>video (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a>[T, H, W, C])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">video (Tensor[T, H, W, C])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="hmdb51">
-<h2><a class="toc-backref" href="#id42">HMDB51</a><a class="headerlink" href="#hmdb51" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id41">HMDB51</a><a class="headerlink" href="#hmdb51" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.HMDB51">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">HMDB51</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">annotation_path</em>, <em class="sig-param">frames_per_clip</em>, <em class="sig-param">step_between_clips=1</em>, <em class="sig-param">frame_rate=None</em>, <em class="sig-param">fold=1</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">_precomputed_metadata=None</em>, <em class="sig-param">num_workers=1</em>, <em class="sig-param">_video_width=0</em>, <em class="sig-param">_video_height=0</em>, <em class="sig-param">_video_min_dimension=0</em>, <em class="sig-param">_audio_samples=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/hmdb51.html#HMDB51"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.HMDB51" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">HMDB51</code><span class="sig-paren">(</span><em>root</em>, <em>annotation_path</em>, <em>frames_per_clip</em>, <em>step_between_clips=1</em>, <em>frame_rate=None</em>, <em>fold=1</em>, <em>train=True</em>, <em>transform=None</em>, <em>_precomputed_metadata=None</em>, <em>num_workers=1</em>, <em>_video_width=0</em>, <em>_video_height=0</em>, <em>_video_min_dimension=0</em>, <em>_audio_samples=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/hmdb51.html#HMDB51"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.HMDB51" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://serre-lab.clps.brown.edu/resource/hmdb-a-large-human-motion-database/">HMDB51</a>
 dataset.</p>
 <p>HMDB51 is an action recognition video dataset.
@@ -1426,41 +1471,45 @@ elements will come from video 1, and the next three elements from video 2.
 Note that we drop clips which do not have exactly <code class="docutils literal notranslate"><span class="pre">frames_per_clip</span></code> elements, so not all
 frames in a video might be present.</p>
 <p>Internally, it uses a VideoClips object to handle clip creation.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the HMDB51 Dataset.</p></li>
-<li><p><strong>annotation_path</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – Path to the folder containing the split files.</p></li>
-<li><p><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Number of frames in a clip.</p></li>
-<li><p><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Number of frames between each clip.</p></li>
-<li><p><strong>fold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Which fold to use. Should be between 1 and 3.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, creates a dataset from the train split,
-otherwise from the <code class="docutils literal notranslate"><span class="pre">test</span></code> split.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in a TxHxWxC video
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the HMDB51 Dataset.</li>
+<li><strong>annotation_path</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the folder containing the split files</li>
+<li><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames in a clip.</li>
+<li><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames between each clip.</li>
+<li><strong>fold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – which fold to use. Should be between 1 and 3.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – if <code class="docutils literal notranslate"><span class="pre">True</span></code>, creates a dataset from the train split,
+otherwise from the <code class="docutils literal notranslate"><span class="pre">test</span></code> split.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in a TxHxWxC video
+and returns a transformed version.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><p>the <cite>T</cite> video frames
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first"><p>the <cite>T</cite> video frames
 audio(Tensor[K, L]): the audio frames, where <cite>K</cite> is the number of channels</p>
 <blockquote>
 <div><p>and <cite>L</cite> is the number of points</p>
 </div></blockquote>
 <p>label (int): class of the video clip</p>
 </p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>video (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a>[T, H, W, C])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">video (Tensor[T, H, W, C])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="ucf101">
-<h2><a class="toc-backref" href="#id43">UCF101</a><a class="headerlink" href="#ucf101" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id42">UCF101</a><a class="headerlink" href="#ucf101" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.UCF101">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">UCF101</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">annotation_path</em>, <em class="sig-param">frames_per_clip</em>, <em class="sig-param">step_between_clips=1</em>, <em class="sig-param">frame_rate=None</em>, <em class="sig-param">fold=1</em>, <em class="sig-param">train=True</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">_precomputed_metadata=None</em>, <em class="sig-param">num_workers=1</em>, <em class="sig-param">_video_width=0</em>, <em class="sig-param">_video_height=0</em>, <em class="sig-param">_video_min_dimension=0</em>, <em class="sig-param">_audio_samples=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/ucf101.html#UCF101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.UCF101" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">UCF101</code><span class="sig-paren">(</span><em>root</em>, <em>annotation_path</em>, <em>frames_per_clip</em>, <em>step_between_clips=1</em>, <em>frame_rate=None</em>, <em>fold=1</em>, <em>train=True</em>, <em>transform=None</em>, <em>_precomputed_metadata=None</em>, <em>num_workers=1</em>, <em>_video_width=0</em>, <em>_video_height=0</em>, <em>_video_min_dimension=0</em>, <em>_audio_samples=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/ucf101.html#UCF101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.UCF101" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="https://www.crcv.ucf.edu/data/UCF101.php">UCF101</a> dataset.</p>
 <p>UCF101 is an action recognition video dataset.
 This dataset consider every video as a collection of video clips of fixed size, specified
@@ -1472,72 +1521,78 @@ elements will come from video 1, and the next three elements from video 2.
 Note that we drop clips which do not have exactly <code class="docutils literal notranslate"><span class="pre">frames_per_clip</span></code> elements, so not all
 frames in a video might be present.</p>
 <p>Internally, it uses a VideoClips object to handle clip creation.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory of the UCF101 Dataset.</p></li>
-<li><p><strong>annotation_path</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the folder containing the split files</p></li>
-<li><p><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames in a clip.</p></li>
-<li><p><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – number of frames between each clip.</p></li>
-<li><p><strong>fold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – which fold to use. Should be between 1 and 3.</p></li>
-<li><p><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – if <code class="docutils literal notranslate"><span class="pre">True</span></code>, creates a dataset from the train split,
-otherwise from the <code class="docutils literal notranslate"><span class="pre">test</span></code> split.</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in a TxHxWxC video
-and returns a transformed version.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory of the UCF101 Dataset.</li>
+<li><strong>annotation_path</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the folder containing the split files</li>
+<li><strong>frames_per_clip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of frames in a clip.</li>
+<li><strong>step_between_clips</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – number of frames between each clip.</li>
+<li><strong>fold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – which fold to use. Should be between 1 and 3.</li>
+<li><strong>train</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – if <code class="docutils literal notranslate"><span class="pre">True</span></code>, creates a dataset from the train split,
+otherwise from the <code class="docutils literal notranslate"><span class="pre">test</span></code> split.</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in a TxHxWxC video
+and returns a transformed version.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><p>the <cite>T</cite> video frames
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first"><p>the <cite>T</cite> video frames
 audio(Tensor[K, L]): the audio frames, where <cite>K</cite> is the number of channels</p>
 <blockquote>
 <div><p>and <cite>L</cite> is the number of points</p>
 </div></blockquote>
 <p>label (int): class of the video clip</p>
 </p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>video (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a>[T, H, W, C])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">video (Tensor[T, H, W, C])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
 <div class="section" id="celeba">
-<h2><a class="toc-backref" href="#id44">CelebA</a><a class="headerlink" href="#celeba" title="Permalink to this headline">¶</a></h2>
+<h2><a class="toc-backref" href="#id43">CelebA</a><a class="headerlink" href="#celeba" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.datasets.CelebA">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.datasets.</code><code class="sig-name descname">CelebA</code><span class="sig-paren">(</span><em class="sig-param">root</em>, <em class="sig-param">split='train'</em>, <em class="sig-param">target_type='attr'</em>, <em class="sig-param">transform=None</em>, <em class="sig-param">target_transform=None</em>, <em class="sig-param">download=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/datasets/celeba.html#CelebA"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CelebA" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.datasets.</code><code class="descname">CelebA</code><span class="sig-paren">(</span><em>root</em>, <em>split='train'</em>, <em>target_type='attr'</em>, <em>transform=None</em>, <em>target_transform=None</em>, <em>download=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/datasets/celeba.html#CelebA"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.datasets.CelebA" title="Permalink to this definition">¶</a></dt>
 <dd><p><a class="reference external" href="http://mmlab.ie.cuhk.edu.hk/projects/CelebA.html">Large-scale CelebFaces Attributes (CelebA) Dataset</a> Dataset.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</p></li>
-<li><p><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘valid’, ‘test’, ‘all’}.
-Accordingly dataset is selected.</p></li>
-<li><p><strong>target_type</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>, </em><em>optional</em>) – <p>Type of target to use, <code class="docutils literal notranslate"><span class="pre">attr</span></code>, <code class="docutils literal notranslate"><span class="pre">identity</span></code>, <code class="docutils literal notranslate"><span class="pre">bbox</span></code>,
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>root</strong> (<em>string</em>) – Root directory where images are downloaded to.</li>
+<li><strong>split</strong> (<em>string</em>) – One of {‘train’, ‘valid’, ‘test’, ‘all’}.
+Accordingly dataset is selected.</li>
+<li><strong>target_type</strong> (<em>string</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>, </em><em>optional</em>) – <p>Type of target to use, <code class="docutils literal notranslate"><span class="pre">attr</span></code>, <code class="docutils literal notranslate"><span class="pre">identity</span></code>, <code class="docutils literal notranslate"><span class="pre">bbox</span></code>,
 or <code class="docutils literal notranslate"><span class="pre">landmarks</span></code>. Can also be a list to output a tuple with all specified target types.
 The targets represent:</p>
 <blockquote>
-<div><p><code class="docutils literal notranslate"><span class="pre">attr</span></code> (np.array shape=(40,) dtype=int): binary (0, 1) labels for attributes
+<div><code class="docutils literal notranslate"><span class="pre">attr</span></code> (np.array shape=(40,) dtype=int): binary (0, 1) labels for attributes
 <code class="docutils literal notranslate"><span class="pre">identity</span></code> (int): label for each person (data points with the same identity are the same person)
 <code class="docutils literal notranslate"><span class="pre">bbox</span></code> (np.array shape=(4,) dtype=int): bounding box (x, y, width, height)
-<code class="docutils literal notranslate"><span class="pre">landmarks</span></code> (np.array shape=(10,) dtype=int): landmark points (lefteye_x, lefteye_y, righteye_x,</p>
-<blockquote>
-<div><p>righteye_y, nose_x, nose_y, leftmouth_x, leftmouth_y, rightmouth_x, rightmouth_y)</p>
-</div></blockquote>
+<code class="docutils literal notranslate"><span class="pre">landmarks</span></code> (np.array shape=(10,) dtype=int): landmark points (lefteye_x, lefteye_y, righteye_x,<blockquote>
+<div>righteye_y, nose_x, nose_y, leftmouth_x, leftmouth_y, rightmouth_x, rightmouth_y)</div></blockquote>
 </div></blockquote>
 <p>Defaults to <code class="docutils literal notranslate"><span class="pre">attr</span></code>. If empty, <code class="docutils literal notranslate"><span class="pre">None</span></code> will be returned as target.</p>
-</p></li>
-<li><p><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
-and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></p></li>
-<li><p><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
-target and transforms it.</p></li>
-<li><p><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
+</li>
+<li><strong>transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that  takes in an PIL image
+and returns a transformed version. E.g, <code class="docutils literal notranslate"><span class="pre">transforms.ToTensor</span></code></li>
+<li><strong>target_transform</strong> (<em>callable</em><em>, </em><em>optional</em>) – A function/transform that takes in the
+target and transforms it.</li>
+<li><strong>download</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If true, downloads the dataset from the internet and
 puts it in root directory. If dataset is already downloaded, it is not
-downloaded again.</p></li>
+downloaded again.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1551,10 +1606,10 @@ downloaded again.</p></li>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="io.html" class="btn btn-neutral float-right" title="torchvision.io" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="io.html" class="btn btn-neutral float-right" title="torchvision.io" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="index.html" class="btn btn-neutral" title="torchvision" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="index.html" class="btn btn-neutral" title="torchvision" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -1567,7 +1622,7 @@ downloaded again.</p></li>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -1632,50 +1687,35 @@ downloaded again.</p></li>
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -1781,7 +1821,7 @@ downloaded again.</p></li>
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -1848,7 +1888,7 @@ downloaded again.</p></li>
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/index.html
+++ b/docs/stable/torchvision/index.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/index.html"/>
   
 
   
@@ -27,28 +36,23 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
-    <link rel="next" title="torchvision.datasets" href="datasets.html" />
-    <link rel="prev" title="torch.__config__" href="../__config__.html" /> 
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
+    <link rel="next" title="torchvision.datasets" href="datasets.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +163,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +175,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +186,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
-<ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +231,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="#">
           
             Docs
           
@@ -309,7 +245,7 @@
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/index.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/index.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -395,37 +331,47 @@ architectures, and common image transformations for computer vision.</p>
 </div>
 <span class="target" id="module-torchvision"></span><dl class="function">
 <dt id="torchvision.get_image_backend">
-<code class="sig-prename descclassname">torchvision.</code><code class="sig-name descname">get_image_backend</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision.html#get_image_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.get_image_backend" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.</code><code class="descname">get_image_backend</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision.html#get_image_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.get_image_backend" title="Permalink to this definition">¶</a></dt>
 <dd><p>Gets the name of the package used to load images</p>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.set_image_backend">
-<code class="sig-prename descclassname">torchvision.</code><code class="sig-name descname">set_image_backend</code><span class="sig-paren">(</span><em class="sig-param">backend</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision.html#set_image_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.set_image_backend" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.</code><code class="descname">set_image_backend</code><span class="sig-paren">(</span><em>backend</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision.html#set_image_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.set_image_backend" title="Permalink to this definition">¶</a></dt>
 <dd><p>Specifies the package used to load images.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>backend</strong> (<em>string</em>) – Name of the image backend. one of {‘PIL’, ‘accimage’}.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>backend</strong> (<em>string</em>) – Name of the image backend. one of {‘PIL’, ‘accimage’}.
 The <code class="xref py py-mod docutils literal notranslate"><span class="pre">accimage</span></code> package uses the Intel IPP library. It is
-generally faster than PIL, but does not support as many operations.</p>
-</dd>
-</dl>
+generally faster than PIL, but does not support as many operations.</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.set_video_backend">
-<code class="sig-prename descclassname">torchvision.</code><code class="sig-name descname">set_video_backend</code><span class="sig-paren">(</span><em class="sig-param">backend</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision.html#set_video_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.set_video_backend" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.</code><code class="descname">set_video_backend</code><span class="sig-paren">(</span><em>backend</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision.html#set_video_backend"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.set_video_backend" title="Permalink to this definition">¶</a></dt>
 <dd><p>Specifies the package used to decode videos.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>backend</strong> (<em>string</em>) – Name of the video backend. one of {‘pyav’, ‘video_reader’}.
-The <code class="xref py py-mod docutils literal notranslate"><span class="pre">pyav</span></code> package uses the 3rd party PyAv library. It is a Pythonic
-binding for the FFmpeg libraries.
-The <code class="xref py py-mod docutils literal notranslate"><span class="pre">video_reader</span></code> package includes a native C++ implementation on
-top of FFMPEG libraries, and a python API of TorchScript custom operator.
-It is generally decoding faster than <code class="xref py py-mod docutils literal notranslate"><span class="pre">pyav</span></code>, but perhaps is less robust.</p>
-</dd>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>backend</strong> (<em>string</em>) – <p>Name of the video backend. one of {‘pyav’, ‘video_reader’}.
+The <code class="xref py py-mod docutils literal notranslate"><span class="pre">pyav</span></code> package uses the 3rd party PyAv library. It is a Pythonic</p>
+<blockquote>
+<div>binding for the FFmpeg libraries.</div></blockquote>
+<dl class="docutils">
+<dt>The <code class="xref py py-mod docutils literal notranslate"><span class="pre">video_reader</span></code> package includes a native c++ implementation on</dt>
+<dd>top of FFMPEG libraries, and a python API of TorchScript custom operator.
+It is generally decoding faster than pyav, but perhaps is less robust.</dd>
 </dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -438,10 +384,8 @@ It is generally decoding faster than <code class="xref py py-mod docutils litera
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="datasets.html" class="btn btn-neutral float-right" title="torchvision.datasets" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="datasets.html" class="btn btn-neutral float-right" title="torchvision.datasets" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
-      
-        <a href="../__config__.html" class="btn btn-neutral" title="torch.__config__" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -454,7 +398,7 @@ It is generally decoding faster than <code class="xref py py-mod docutils litera
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -488,50 +432,35 @@ It is generally decoding faster than <code class="xref py py-mod docutils litera
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -637,7 +566,7 @@ It is generally decoding faster than <code class="xref py py-mod docutils litera
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -704,7 +633,7 @@ It is generally decoding faster than <code class="xref py py-mod docutils litera
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/io.html
+++ b/docs/stable/torchvision/io.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.io &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.io &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/io.html"/>
   
 
   
@@ -27,28 +36,24 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="torchvision.models" href="models.html" />
     <link rel="prev" title="torchvision.datasets" href="datasets.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +164,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +176,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +187,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +232,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +240,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.io</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/io.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/io.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -345,69 +280,81 @@ operations. They are currently specific to reading and writing video.</p>
 <h2>Video<a class="headerlink" href="#video" title="Permalink to this headline">¶</a></h2>
 <dl class="function">
 <dt id="torchvision.io.read_video">
-<code class="sig-prename descclassname">torchvision.io.</code><code class="sig-name descname">read_video</code><span class="sig-paren">(</span><em class="sig-param">filename</em>, <em class="sig-param">start_pts=0</em>, <em class="sig-param">end_pts=None</em>, <em class="sig-param">pts_unit='pts'</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/io/video.html#read_video"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.read_video" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.io.</code><code class="descname">read_video</code><span class="sig-paren">(</span><em>filename</em>, <em>start_pts=0</em>, <em>end_pts=None</em>, <em>pts_unit='pts'</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/io/video.html#read_video"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.read_video" title="Permalink to this definition">¶</a></dt>
 <dd><p>Reads a video from a file, returning both the video frames as well as
 the audio frames</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the video file</p></li>
-<li><p><strong>start_pts</strong> (<em>int if pts_unit = 'pts'</em><em>, </em><em>optional</em>) – float / Fraction if pts_unit = ‘sec’, optional
-the start presentation time of the video</p></li>
-<li><p><strong>end_pts</strong> (<em>int if pts_unit = 'pts'</em><em>, </em><em>optional</em>) – float / Fraction if pts_unit = ‘sec’, optional
-the end presentation time</p></li>
-<li><p><strong>pts_unit</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>, </em><em>optional</em>) – unit in which start_pts and end_pts values will be interpreted, either ‘pts’ or ‘sec’. Defaults to ‘pts’.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the video file</li>
+<li><strong>start_pts</strong> (<em>int if pts_unit = 'pts'</em><em>, </em><em>optional</em>) – float / Fraction if pts_unit = ‘sec’, optional
+the start presentation time of the video</li>
+<li><strong>end_pts</strong> (<em>int if pts_unit = 'pts'</em><em>, </em><em>optional</em>) – float / Fraction if pts_unit = ‘sec’, optional
+the end presentation time</li>
+<li><strong>pts_unit</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>, </em><em>optional</em>) – unit in which start_pts and end_pts values will be interpreted, either ‘pts’ or ‘sec’. Defaults to ‘pts’.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><ul class="simple">
-<li><p><strong>vframes</strong> (<em>Tensor[T, H, W, C]</em>) – the <cite>T</cite> video frames</p></li>
-<li><p><strong>aframes</strong> (<em>Tensor[K, L]</em>) – the audio frames, where <cite>K</cite> is the number of channels and <cite>L</cite> is the
-number of points</p></li>
-<li><p><strong>info</strong> (<em>Dict</em>) – metadata for the video and audio. Can contain the fields video_fps (float)
-and audio_fps (int)</p></li>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last"><ul class="simple">
+<li><strong>vframes</strong> (<em>Tensor[T, H, W, C]</em>) – the <cite>T</cite> video frames</li>
+<li><strong>aframes</strong> (<em>Tensor[K, L]</em>) – the audio frames, where <cite>K</cite> is the number of channels and <cite>L</cite> is the
+number of points</li>
+<li><strong>info</strong> (<em>Dict</em>) – metadata for the video and audio. Can contain the fields video_fps (float)
+and audio_fps (int)</li>
 </ul>
 </p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.io.read_video_timestamps">
-<code class="sig-prename descclassname">torchvision.io.</code><code class="sig-name descname">read_video_timestamps</code><span class="sig-paren">(</span><em class="sig-param">filename</em>, <em class="sig-param">pts_unit='pts'</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/io/video.html#read_video_timestamps"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.read_video_timestamps" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.io.</code><code class="descname">read_video_timestamps</code><span class="sig-paren">(</span><em>filename</em>, <em>pts_unit='pts'</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/io/video.html#read_video_timestamps"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.read_video_timestamps" title="Permalink to this definition">¶</a></dt>
 <dd><p>List the video frames timestamps.</p>
 <p>Note that the function decodes the whole video frame-by-frame.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the video file</p></li>
-<li><p><strong>pts_unit</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>, </em><em>optional</em>) – unit in which timestamp values will be returned either ‘pts’ or ‘sec’. Defaults to ‘pts’.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path to the video file</li>
+<li><strong>pts_unit</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>, </em><em>optional</em>) – unit in which timestamp values will be returned either ‘pts’ or ‘sec’. Defaults to ‘pts’.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><ul class="simple">
-<li><p><strong>pts</strong> (<em>List[int] if pts_unit = ‘pts’</em>) – List[Fraction] if pts_unit = ‘sec’
-presentation timestamps for each one of the frames in the video.</p></li>
-<li><p><strong>video_fps</strong> (<em>int</em>) – the frame rate for the video</p></li>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last"><ul class="simple">
+<li><strong>pts</strong> (<em>List[int] if pts_unit = ‘pts’</em>) – List[Fraction] if pts_unit = ‘sec’
+presentation timestamps for each one of the frames in the video.</li>
+<li><strong>video_fps</strong> (<em>int</em>) – the frame rate for the video</li>
 </ul>
 </p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.io.write_video">
-<code class="sig-prename descclassname">torchvision.io.</code><code class="sig-name descname">write_video</code><span class="sig-paren">(</span><em class="sig-param">filename, video_array, fps: Union[int, float], video_codec='libx264', options=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/io/video.html#write_video"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.write_video" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.io.</code><code class="descname">write_video</code><span class="sig-paren">(</span><em>filename</em>, <em>video_array</em>, <em>fps</em>, <em>video_codec='libx264'</em>, <em>options=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/io/video.html#write_video"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.io.write_video" title="Permalink to this definition">¶</a></dt>
 <dd><p>Writes a 4d tensor in [T, H, W, C] format in a video file</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path where the video will be saved</p></li>
-<li><p><strong>video_array</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>T</em><em>, </em><em>H</em><em>, </em><em>W</em><em>, </em><em>C</em><em>]</em>) – tensor containing the individual frames, as a uint8 tensor in [T, H, W, C] format</p></li>
-<li><p><strong>fps</strong> (<em>Number</em>) – frames per second</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>filename</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – path where the video will be saved</li>
+<li><strong>video_array</strong> (<em>Tensor</em><em>[</em><em>T</em><em>, </em><em>H</em><em>, </em><em>W</em><em>, </em><em>C</em><em>]</em>) – tensor containing the individual frames, as a uint8 tensor in [T, H, W, C] format</li>
+<li><strong>fps</strong> (<em>Number</em>) – frames per second</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -421,10 +368,10 @@ presentation timestamps for each one of the frames in the video.</p></li>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="models.html" class="btn btn-neutral float-right" title="torchvision.models" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="models.html" class="btn btn-neutral float-right" title="torchvision.models" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="datasets.html" class="btn btn-neutral" title="torchvision.datasets" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="datasets.html" class="btn btn-neutral" title="torchvision.datasets" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -437,7 +384,7 @@ presentation timestamps for each one of the frames in the video.</p></li>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -474,50 +421,35 @@ presentation timestamps for each one of the frames in the video.</p></li>
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -623,7 +555,7 @@ presentation timestamps for each one of the frames in the video.</p></li>
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -690,7 +622,7 @@ presentation timestamps for each one of the frames in the video.</p></li>
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/models.html
+++ b/docs/stable/torchvision/models.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.models &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.models &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/models.html"/>
   
 
   
@@ -27,28 +36,24 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="torchvision.ops" href="ops.html" />
     <link rel="prev" title="torchvision.io" href="io.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +164,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +176,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +187,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +232,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +240,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.models</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/models.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/models.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -348,21 +283,21 @@ keypoint detection and video classification.</p>
 <p>The models subpackage contains definitions for the following model
 architectures for image classification:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://arxiv.org/abs/1404.5997">AlexNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1409.1556">VGG</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1512.03385">ResNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1602.07360">SqueezeNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1608.06993">DenseNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1512.00567">Inception</a> v3</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1409.4842">GoogLeNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1807.11164">ShuffleNet</a> v2</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1801.04381">MobileNet</a> v2</p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1611.05431">ResNeXt</a></p></li>
-<li><p><a class="reference internal" href="#wide-resnet">Wide ResNet</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1807.11626">MNASNet</a></p></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1404.5997">AlexNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1409.1556">VGG</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1512.03385">ResNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1602.07360">SqueezeNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1608.06993">DenseNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1512.00567">Inception</a> v3</li>
+<li><a class="reference external" href="https://arxiv.org/abs/1409.4842">GoogLeNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1807.11164">ShuffleNet</a> v2</li>
+<li><a class="reference external" href="https://arxiv.org/abs/1801.04381">MobileNet</a> v2</li>
+<li><a class="reference external" href="https://arxiv.org/abs/1611.05431">ResNeXt</a></li>
+<li><a class="reference internal" href="#wide-resnet">Wide ResNet</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1807.11626">MNASNet</a></li>
 </ul>
 <p>You can construct a model with random weights by calling its constructor:</p>
-<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.models</span> <span class="k">as</span> <span class="nn">models</span>
+<div class="code python highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.models</span> <span class="k">as</span> <span class="nn">models</span>
 <span class="n">resnet18</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">resnet18</span><span class="p">()</span>
 <span class="n">alexnet</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">alexnet</span><span class="p">()</span>
 <span class="n">vgg16</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">vgg16</span><span class="p">()</span>
@@ -377,9 +312,9 @@ architectures for image classification:</p>
 <span class="n">mnasnet</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">mnasnet1_0</span><span class="p">()</span>
 </pre></div>
 </div>
-<p>We provide pre-trained models, using the PyTorch <a class="reference internal" href="../model_zoo.html#module-torch.utils.model_zoo" title="torch.utils.model_zoo"><code class="xref py py-mod docutils literal notranslate"><span class="pre">torch.utils.model_zoo</span></code></a>.
+<p>We provide pre-trained models, using the PyTorch <code class="xref py py-mod docutils literal notranslate"><span class="pre">torch.utils.model_zoo</span></code>.
 These can be constructed by passing <code class="docutils literal notranslate"><span class="pre">pretrained=True</span></code>:</p>
-<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.models</span> <span class="k">as</span> <span class="nn">models</span>
+<div class="code python highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.models</span> <span class="k">as</span> <span class="nn">models</span>
 <span class="n">resnet18</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">resnet18</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="n">alexnet</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">alexnet</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="n">squeezenet</span> <span class="o">=</span> <span class="n">models</span><span class="o">.</span><span class="n">squeezenet1_0</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
@@ -396,11 +331,11 @@ These can be constructed by passing <code class="docutils literal notranslate"><
 </div>
 <p>Instancing a pre-trained model will download its weights to a cache directory.
 This directory can be set using the <cite>TORCH_MODEL_ZOO</cite> environment variable. See
-<a class="reference internal" href="../model_zoo.html#torch.utils.model_zoo.load_url" title="torch.utils.model_zoo.load_url"><code class="xref py py-func docutils literal notranslate"><span class="pre">torch.utils.model_zoo.load_url()</span></code></a> for details.</p>
+<code class="xref py py-func docutils literal notranslate"><span class="pre">torch.utils.model_zoo.load_url()</span></code> for details.</p>
 <p>Some models use modules which have different training and evaluation
 behavior, such as batch normalization. To switch between these modes, use
 <code class="docutils literal notranslate"><span class="pre">model.train()</span></code> or <code class="docutils literal notranslate"><span class="pre">model.eval()</span></code> as appropriate. See
-<a class="reference internal" href="../generated/torch.nn.Module.html#torch.nn.Module.train" title="torch.nn.Module.train"><code class="xref py py-meth docutils literal notranslate"><span class="pre">train()</span></code></a> or <a class="reference internal" href="../generated/torch.nn.Module.html#torch.nn.Module.eval" title="torch.nn.Module.eval"><code class="xref py py-meth docutils literal notranslate"><span class="pre">eval()</span></code></a> for details.</p>
+<code class="xref py py-meth docutils literal notranslate"><span class="pre">train()</span></code> or <code class="xref py py-meth docutils literal notranslate"><span class="pre">eval()</span></code> for details.</p>
 <p>All pre-trained models expect input images normalized in the same way,
 i.e. mini-batches of 3-channel RGB images of shape (3 x H x W),
 where H and W are expected to be at least 224.
@@ -416,7 +351,7 @@ You can use the following transform to normalize:</p>
 <p>The process for obtaining the values of <cite>mean</cite> and <cite>std</cite> is roughly equivalent
 to:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torch</span>
-<span class="kn">from</span> <span class="nn">torchvision</span> <span class="kn">import</span> <span class="n">datasets</span><span class="p">,</span> <span class="n">transforms</span> <span class="k">as</span> <span class="n">T</span>
+<span class="kn">from</span> <span class="nn">torchvision</span> <span class="k">import</span> <span class="n">datasets</span><span class="p">,</span> <span class="n">transforms</span> <span class="k">as</span> <span class="n">T</span>
 
 <span class="n">transform</span> <span class="o">=</span> <span class="n">T</span><span class="o">.</span><span class="n">Compose</span><span class="p">([</span><span class="n">T</span><span class="o">.</span><span class="n">Resize</span><span class="p">(</span><span class="mi">256</span><span class="p">),</span> <span class="n">T</span><span class="o">.</span><span class="n">CenterCrop</span><span class="p">(</span><span class="mi">224</span><span class="p">),</span> <span class="n">T</span><span class="o">.</span><span class="n">ToTensor</span><span class="p">()])</span>
 <span class="n">dataset</span> <span class="o">=</span> <span class="n">datasets</span><span class="o">.</span><span class="n">ImageNet</span><span class="p">(</span><span class="s2">&quot;.&quot;</span><span class="p">,</span> <span class="n">split</span><span class="o">=</span><span class="s2">&quot;train&quot;</span><span class="p">,</span> <span class="n">transform</span><span class="o">=</span><span class="n">transform</span><span class="p">)</span>
@@ -435,129 +370,134 @@ to:</p>
 information see <a class="reference external" href="https://github.com/pytorch/vision/issues/1439">this discussion</a>
 or <a class="reference external" href="https://github.com/pytorch/vision/pull/1965">these experiments</a>.</p>
 <p>ImageNet 1-crop error rates (224x224)</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>Top-1 error</p></th>
-<th class="head"><p>Top-5 error</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="55%" />
+<col width="22%" />
+<col width="22%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">Top-1 error</th>
+<th class="head">Top-5 error</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>AlexNet</p></td>
-<td><p>43.45</p></td>
-<td><p>20.91</p></td>
+<tbody valign="top">
+<tr class="row-even"><td>AlexNet</td>
+<td>43.45</td>
+<td>20.91</td>
 </tr>
-<tr class="row-odd"><td><p>VGG-11</p></td>
-<td><p>30.98</p></td>
-<td><p>11.37</p></td>
+<tr class="row-odd"><td>VGG-11</td>
+<td>30.98</td>
+<td>11.37</td>
 </tr>
-<tr class="row-even"><td><p>VGG-13</p></td>
-<td><p>30.07</p></td>
-<td><p>10.75</p></td>
+<tr class="row-even"><td>VGG-13</td>
+<td>30.07</td>
+<td>10.75</td>
 </tr>
-<tr class="row-odd"><td><p>VGG-16</p></td>
-<td><p>28.41</p></td>
-<td><p>9.62</p></td>
+<tr class="row-odd"><td>VGG-16</td>
+<td>28.41</td>
+<td>9.62</td>
 </tr>
-<tr class="row-even"><td><p>VGG-19</p></td>
-<td><p>27.62</p></td>
-<td><p>9.12</p></td>
+<tr class="row-even"><td>VGG-19</td>
+<td>27.62</td>
+<td>9.12</td>
 </tr>
-<tr class="row-odd"><td><p>VGG-11 with batch normalization</p></td>
-<td><p>29.62</p></td>
-<td><p>10.19</p></td>
+<tr class="row-odd"><td>VGG-11 with batch normalization</td>
+<td>29.62</td>
+<td>10.19</td>
 </tr>
-<tr class="row-even"><td><p>VGG-13 with batch normalization</p></td>
-<td><p>28.45</p></td>
-<td><p>9.63</p></td>
+<tr class="row-even"><td>VGG-13 with batch normalization</td>
+<td>28.45</td>
+<td>9.63</td>
 </tr>
-<tr class="row-odd"><td><p>VGG-16 with batch normalization</p></td>
-<td><p>26.63</p></td>
-<td><p>8.50</p></td>
+<tr class="row-odd"><td>VGG-16 with batch normalization</td>
+<td>26.63</td>
+<td>8.50</td>
 </tr>
-<tr class="row-even"><td><p>VGG-19 with batch normalization</p></td>
-<td><p>25.76</p></td>
-<td><p>8.15</p></td>
+<tr class="row-even"><td>VGG-19 with batch normalization</td>
+<td>25.76</td>
+<td>8.15</td>
 </tr>
-<tr class="row-odd"><td><p>ResNet-18</p></td>
-<td><p>30.24</p></td>
-<td><p>10.92</p></td>
+<tr class="row-odd"><td>ResNet-18</td>
+<td>30.24</td>
+<td>10.92</td>
 </tr>
-<tr class="row-even"><td><p>ResNet-34</p></td>
-<td><p>26.70</p></td>
-<td><p>8.58</p></td>
+<tr class="row-even"><td>ResNet-34</td>
+<td>26.70</td>
+<td>8.58</td>
 </tr>
-<tr class="row-odd"><td><p>ResNet-50</p></td>
-<td><p>23.85</p></td>
-<td><p>7.13</p></td>
+<tr class="row-odd"><td>ResNet-50</td>
+<td>23.85</td>
+<td>7.13</td>
 </tr>
-<tr class="row-even"><td><p>ResNet-101</p></td>
-<td><p>22.63</p></td>
-<td><p>6.44</p></td>
+<tr class="row-even"><td>ResNet-101</td>
+<td>22.63</td>
+<td>6.44</td>
 </tr>
-<tr class="row-odd"><td><p>ResNet-152</p></td>
-<td><p>21.69</p></td>
-<td><p>5.94</p></td>
+<tr class="row-odd"><td>ResNet-152</td>
+<td>21.69</td>
+<td>5.94</td>
 </tr>
-<tr class="row-even"><td><p>SqueezeNet 1.0</p></td>
-<td><p>41.90</p></td>
-<td><p>19.58</p></td>
+<tr class="row-even"><td>SqueezeNet 1.0</td>
+<td>41.90</td>
+<td>19.58</td>
 </tr>
-<tr class="row-odd"><td><p>SqueezeNet 1.1</p></td>
-<td><p>41.81</p></td>
-<td><p>19.38</p></td>
+<tr class="row-odd"><td>SqueezeNet 1.1</td>
+<td>41.81</td>
+<td>19.38</td>
 </tr>
-<tr class="row-even"><td><p>Densenet-121</p></td>
-<td><p>25.35</p></td>
-<td><p>7.83</p></td>
+<tr class="row-even"><td>Densenet-121</td>
+<td>25.35</td>
+<td>7.83</td>
 </tr>
-<tr class="row-odd"><td><p>Densenet-169</p></td>
-<td><p>24.00</p></td>
-<td><p>7.00</p></td>
+<tr class="row-odd"><td>Densenet-169</td>
+<td>24.00</td>
+<td>7.00</td>
 </tr>
-<tr class="row-even"><td><p>Densenet-201</p></td>
-<td><p>22.80</p></td>
-<td><p>6.43</p></td>
+<tr class="row-even"><td>Densenet-201</td>
+<td>22.80</td>
+<td>6.43</td>
 </tr>
-<tr class="row-odd"><td><p>Densenet-161</p></td>
-<td><p>22.35</p></td>
-<td><p>6.20</p></td>
+<tr class="row-odd"><td>Densenet-161</td>
+<td>22.35</td>
+<td>6.20</td>
 </tr>
-<tr class="row-even"><td><p>Inception v3</p></td>
-<td><p>22.55</p></td>
-<td><p>6.44</p></td>
+<tr class="row-even"><td>Inception v3</td>
+<td>22.55</td>
+<td>6.44</td>
 </tr>
-<tr class="row-odd"><td><p>GoogleNet</p></td>
-<td><p>30.22</p></td>
-<td><p>10.47</p></td>
+<tr class="row-odd"><td>GoogleNet</td>
+<td>30.22</td>
+<td>10.47</td>
 </tr>
-<tr class="row-even"><td><p>ShuffleNet V2</p></td>
-<td><p>30.64</p></td>
-<td><p>11.68</p></td>
+<tr class="row-even"><td>ShuffleNet V2</td>
+<td>30.64</td>
+<td>11.68</td>
 </tr>
-<tr class="row-odd"><td><p>MobileNet V2</p></td>
-<td><p>28.12</p></td>
-<td><p>9.71</p></td>
+<tr class="row-odd"><td>MobileNet V2</td>
+<td>28.12</td>
+<td>9.71</td>
 </tr>
-<tr class="row-even"><td><p>ResNeXt-50-32x4d</p></td>
-<td><p>22.38</p></td>
-<td><p>6.30</p></td>
+<tr class="row-even"><td>ResNeXt-50-32x4d</td>
+<td>22.38</td>
+<td>6.30</td>
 </tr>
-<tr class="row-odd"><td><p>ResNeXt-101-32x8d</p></td>
-<td><p>20.69</p></td>
-<td><p>5.47</p></td>
+<tr class="row-odd"><td>ResNeXt-101-32x8d</td>
+<td>20.69</td>
+<td>5.47</td>
 </tr>
-<tr class="row-even"><td><p>Wide ResNet-50-2</p></td>
-<td><p>21.49</p></td>
-<td><p>5.91</p></td>
+<tr class="row-even"><td>Wide ResNet-50-2</td>
+<td>21.49</td>
+<td>5.91</td>
 </tr>
-<tr class="row-odd"><td><p>Wide ResNet-101-2</p></td>
-<td><p>21.16</p></td>
-<td><p>5.72</p></td>
+<tr class="row-odd"><td>Wide ResNet-101-2</td>
+<td>21.16</td>
+<td>5.72</td>
 </tr>
-<tr class="row-even"><td><p>MNASNet 1.0</p></td>
-<td><p>26.49</p></td>
-<td><p>8.456</p></td>
+<tr class="row-even"><td>MNASNet 1.0</td>
+<td>26.49</td>
+<td>8.456</td>
 </tr>
 </tbody>
 </table>
@@ -565,17 +505,21 @@ or <a class="reference external" href="https://github.com/pytorch/vision/pull/19
 <h3>Alexnet<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.alexnet">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">alexnet</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/alexnet.html#alexnet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.alexnet" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">alexnet</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/alexnet.html#alexnet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.alexnet" title="Permalink to this definition">¶</a></dt>
 <dd><p>AlexNet model architecture from the
 <a class="reference external" href="https://arxiv.org/abs/1404.5997">“One weird trick…”</a> paper.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -583,122 +527,154 @@ or <a class="reference external" href="https://github.com/pytorch/vision/pull/19
 <h3>VGG<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.vgg11">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg11</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg11"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg11" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg11</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg11"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg11" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 11-layer model (configuration “A”) from
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg11_bn">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg11_bn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg11_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg11_bn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg11_bn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg11_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg11_bn" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 11-layer model (configuration “A”) with batch normalization
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg13">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg13</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg13"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg13" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg13</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg13"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg13" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 13-layer model (configuration “B”)
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg13_bn">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg13_bn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg13_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg13_bn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg13_bn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg13_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg13_bn" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 13-layer model (configuration “B”) with batch normalization
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg16">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg16</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg16"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg16" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg16</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg16"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg16" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 16-layer model (configuration “D”)
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg16_bn">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg16_bn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg16_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg16_bn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg16_bn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg16_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg16_bn" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 16-layer model (configuration “D”) with batch normalization
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg19">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg19</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg19"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg19" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg19</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg19"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg19" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 19-layer model (configuration “E”)
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.vgg19_bn">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">vgg19_bn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/vgg.html#vgg19_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg19_bn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">vgg19_bn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/vgg.html#vgg19_bn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.vgg19_bn" title="Permalink to this definition">¶</a></dt>
 <dd><p>VGG 19-layer model (configuration ‘E’) with batch normalization
 <a class="reference external" href="https://arxiv.org/pdf/1409.1556.pdf">“Very Deep Convolutional Networks For Large-Scale Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -706,77 +682,97 @@ or <a class="reference external" href="https://github.com/pytorch/vision/pull/19
 <h3>ResNet<a class="headerlink" href="#id10" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.resnet18">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnet18</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnet18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet18" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnet18</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnet18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet18" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNet-18 model from
 <a class="reference external" href="https://arxiv.org/pdf/1512.03385.pdf">“Deep Residual Learning for Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.resnet34">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnet34</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnet34"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet34" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnet34</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnet34"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet34" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNet-34 model from
 <a class="reference external" href="https://arxiv.org/pdf/1512.03385.pdf">“Deep Residual Learning for Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.resnet50">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnet50</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet50" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnet50</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet50" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNet-50 model from
 <a class="reference external" href="https://arxiv.org/pdf/1512.03385.pdf">“Deep Residual Learning for Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.resnet101">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnet101</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet101" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnet101</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet101" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNet-101 model from
 <a class="reference external" href="https://arxiv.org/pdf/1512.03385.pdf">“Deep Residual Learning for Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.resnet152">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnet152</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnet152"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet152" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnet152</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnet152"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnet152" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNet-152 model from
 <a class="reference external" href="https://arxiv.org/pdf/1512.03385.pdf">“Deep Residual Learning for Image Recognition”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -784,33 +780,41 @@ or <a class="reference external" href="https://github.com/pytorch/vision/pull/19
 <h3>SqueezeNet<a class="headerlink" href="#id15" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.squeezenet1_0">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">squeezenet1_0</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/squeezenet.html#squeezenet1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.squeezenet1_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">squeezenet1_0</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/squeezenet.html#squeezenet1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.squeezenet1_0" title="Permalink to this definition">¶</a></dt>
 <dd><p>SqueezeNet model architecture from the <a class="reference external" href="https://arxiv.org/abs/1602.07360">“SqueezeNet: AlexNet-level
 accuracy with 50x fewer parameters and &lt;0.5MB model size”</a> paper.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.squeezenet1_1">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">squeezenet1_1</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/squeezenet.html#squeezenet1_1"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.squeezenet1_1" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">squeezenet1_1</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/squeezenet.html#squeezenet1_1"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.squeezenet1_1" title="Permalink to this definition">¶</a></dt>
 <dd><p>SqueezeNet 1.1 model from the <a class="reference external" href="https://github.com/DeepScale/SqueezeNet/tree/master/SqueezeNet_v1.1">official SqueezeNet repo</a>.
 SqueezeNet 1.1 has 2.4x less computation and slightly fewer parameters
 than SqueezeNet 1.0, without sacrificing accuracy.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -818,69 +822,85 @@ than SqueezeNet 1.0, without sacrificing accuracy.</p>
 <h3>DenseNet<a class="headerlink" href="#id16" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.densenet121">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">densenet121</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/densenet.html#densenet121"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet121" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">densenet121</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/densenet.html#densenet121"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet121" title="Permalink to this definition">¶</a></dt>
 <dd><p>Densenet-121 model from
 <a class="reference external" href="https://arxiv.org/pdf/1608.06993.pdf">“Densely Connected Convolutional Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.densenet169">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">densenet169</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/densenet.html#densenet169"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet169" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">densenet169</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/densenet.html#densenet169"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet169" title="Permalink to this definition">¶</a></dt>
 <dd><p>Densenet-169 model from
 <a class="reference external" href="https://arxiv.org/pdf/1608.06993.pdf">“Densely Connected Convolutional Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
-</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
+</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.densenet161">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">densenet161</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/densenet.html#densenet161"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet161" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">densenet161</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/densenet.html#densenet161"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet161" title="Permalink to this definition">¶</a></dt>
 <dd><p>Densenet-161 model from
 <a class="reference external" href="https://arxiv.org/pdf/1608.06993.pdf">“Densely Connected Convolutional Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
-</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
+</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.densenet201">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">densenet201</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/densenet.html#densenet201"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet201" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">densenet201</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/densenet.html#densenet201"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.densenet201" title="Permalink to this definition">¶</a></dt>
 <dd><p>Densenet-201 model from
 <a class="reference external" href="https://arxiv.org/pdf/1608.06993.pdf">“Densely Connected Convolutional Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
-</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>memory_efficient</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – <p>but slower. Default: <em>False</em>. See <a class="reference external" href="https://arxiv.org/pdf/1707.06990.pdf">“paper”</a></p>
+</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -888,119 +908,143 @@ than SqueezeNet 1.0, without sacrificing accuracy.</p>
 <h3>Inception v3<a class="headerlink" href="#inception-v3" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.inception_v3">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">inception_v3</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/inception.html#inception_v3"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.inception_v3" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">inception_v3</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/inception.html#inception_v3"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.inception_v3" title="Permalink to this definition">¶</a></dt>
 <dd><p>Inception v3 model architecture from
 <a class="reference external" href="http://arxiv.org/abs/1512.00567">“Rethinking the Inception Architecture for Computer Vision”</a>.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p><strong>Important</strong>: In contrast to the other models the inception_v3 expects tensors with a size of
+<p class="first admonition-title">Note</p>
+<p class="last"><strong>Important</strong>: In contrast to the other models the inception_v3 expects tensors with a size of
 N x 3 x 299 x 299, so ensure your images are sized accordingly.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>aux_logits</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, add an auxiliary branch that can improve training.
-Default: <em>True</em></p></li>
-<li><p><strong>transform_input</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, preprocesses the input according to the method with which it
-was trained on ImageNet. Default: <em>False</em></p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>aux_logits</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, add an auxiliary branch that can improve training.
+Default: <em>True</em></li>
+<li><strong>transform_input</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, preprocesses the input according to the method with which it
+was trained on ImageNet. Default: <em>False</em></li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This requires <cite>scipy</cite> to be installed</p>
+<p class="first admonition-title">Note</p>
+<p class="last">This requires <cite>scipy</cite> to be installed</p>
 </div>
 </div>
 <div class="section" id="id23">
 <h3>GoogLeNet<a class="headerlink" href="#id23" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.googlenet">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">googlenet</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/googlenet.html#googlenet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.googlenet" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">googlenet</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/googlenet.html#googlenet"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.googlenet" title="Permalink to this definition">¶</a></dt>
 <dd><p>GoogLeNet (Inception v1) model architecture from
 <a class="reference external" href="http://arxiv.org/abs/1409.4842">“Going Deeper with Convolutions”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>aux_logits</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, adds two auxiliary branches that can improve training.
-Default: <em>False</em> when pretrained is True otherwise <em>True</em></p></li>
-<li><p><strong>transform_input</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, preprocesses the input according to the method with which it
-was trained on ImageNet. Default: <em>False</em></p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
+<li><strong>aux_logits</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, adds two auxiliary branches that can improve training.
+Default: <em>False</em> when pretrained is True otherwise <em>True</em></li>
+<li><strong>transform_input</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, preprocesses the input according to the method with which it
+was trained on ImageNet. Default: <em>False</em></li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This requires <cite>scipy</cite> to be installed</p>
+<p class="first admonition-title">Note</p>
+<p class="last">This requires <cite>scipy</cite> to be installed</p>
 </div>
 </div>
 <div class="section" id="shufflenet-v2">
 <h3>ShuffleNet v2<a class="headerlink" href="#shufflenet-v2" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.shufflenet_v2_x0_5">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">shufflenet_v2_x0_5</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x0_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x0_5" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">shufflenet_v2_x0_5</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x0_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x0_5" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a ShuffleNetV2 with 0.5x output channels, as described in
 <a class="reference external" href="https://arxiv.org/abs/1807.11164">“ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.shufflenet_v2_x1_0">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">shufflenet_v2_x1_0</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x1_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">shufflenet_v2_x1_0</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x1_0" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a ShuffleNetV2 with 1.0x output channels, as described in
 <a class="reference external" href="https://arxiv.org/abs/1807.11164">“ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.shufflenet_v2_x1_5">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">shufflenet_v2_x1_5</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x1_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x1_5" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">shufflenet_v2_x1_5</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x1_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x1_5" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a ShuffleNetV2 with 1.5x output channels, as described in
 <a class="reference external" href="https://arxiv.org/abs/1807.11164">“ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.shufflenet_v2_x2_0">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">shufflenet_v2_x2_0</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x2_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x2_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">shufflenet_v2_x2_0</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/shufflenetv2.html#shufflenet_v2_x2_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.shufflenet_v2_x2_0" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a ShuffleNetV2 with 2.0x output channels, as described in
 <a class="reference external" href="https://arxiv.org/abs/1807.11164">“ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1008,17 +1052,21 @@ was trained on ImageNet. Default: <em>False</em></p></li>
 <h3>MobileNet v2<a class="headerlink" href="#mobilenet-v2" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.mobilenet_v2">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">mobilenet_v2</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/mobilenet.html#mobilenet_v2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mobilenet_v2" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">mobilenet_v2</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/mobilenet.html#mobilenet_v2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mobilenet_v2" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a MobileNetV2 architecture from
 <a class="reference external" href="https://arxiv.org/abs/1801.04381">“MobileNetV2: Inverted Residuals and Linear Bottlenecks”</a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1026,32 +1074,40 @@ was trained on ImageNet. Default: <em>False</em></p></li>
 <h3>ResNext<a class="headerlink" href="#id27" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.resnext50_32x4d">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnext50_32x4d</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnext50_32x4d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnext50_32x4d" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnext50_32x4d</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnext50_32x4d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnext50_32x4d" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNeXt-50 32x4d model from
 <a class="reference external" href="https://arxiv.org/pdf/1611.05431.pdf">“Aggregated Residual Transformation for Deep Neural Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.resnext101_32x8d">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">resnext101_32x8d</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#resnext101_32x8d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnext101_32x8d" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">resnext101_32x8d</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#resnext101_32x8d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.resnext101_32x8d" title="Permalink to this definition">¶</a></dt>
 <dd><p>ResNeXt-101 32x8d model from
 <a class="reference external" href="https://arxiv.org/pdf/1611.05431.pdf">“Aggregated Residual Transformation for Deep Neural Networks”</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1059,40 +1115,48 @@ was trained on ImageNet. Default: <em>False</em></p></li>
 <h3>Wide ResNet<a class="headerlink" href="#wide-resnet" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.wide_resnet50_2">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">wide_resnet50_2</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#wide_resnet50_2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.wide_resnet50_2" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">wide_resnet50_2</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#wide_resnet50_2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.wide_resnet50_2" title="Permalink to this definition">¶</a></dt>
 <dd><p>Wide ResNet-50-2 model from
 <a class="reference external" href="https://arxiv.org/pdf/1605.07146.pdf">“Wide Residual Networks”</a></p>
 <p>The model is the same as ResNet except for the bottleneck number of channels
 which is twice larger in every block. The number of channels in outer 1x1
 convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
 channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.wide_resnet101_2">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">wide_resnet101_2</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/resnet.html#wide_resnet101_2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.wide_resnet101_2" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">wide_resnet101_2</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/resnet.html#wide_resnet101_2"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.wide_resnet101_2" title="Permalink to this definition">¶</a></dt>
 <dd><p>Wide ResNet-101-2 model from
 <a class="reference external" href="https://arxiv.org/pdf/1605.07146.pdf">“Wide Residual Networks”</a></p>
 <p>The model is the same as ResNet except for the bottleneck number of channels
 which is twice larger in every block. The number of channels in outer 1x1
 convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
 channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on ImageNet</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1100,7 +1164,7 @@ channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
 <h3>MNASNet<a class="headerlink" href="#id30" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.mnasnet0_5">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">mnasnet0_5</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/mnasnet.html#mnasnet0_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet0_5" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">mnasnet0_5</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/mnasnet.html#mnasnet0_5"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet0_5" title="Permalink to this definition">¶</a></dt>
 <dd><p>MNASNet with depth multiplier of 0.5 from
 <a class="reference external" href="https://arxiv.org/pdf/1807.11626.pdf">“MnasNet: Platform-Aware Neural Architecture Search for Mobile”</a>.
 :param pretrained: If True, returns a model pre-trained on ImageNet
@@ -1111,7 +1175,7 @@ channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
 
 <dl class="function">
 <dt id="torchvision.models.mnasnet0_75">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">mnasnet0_75</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/mnasnet.html#mnasnet0_75"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet0_75" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">mnasnet0_75</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/mnasnet.html#mnasnet0_75"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet0_75" title="Permalink to this definition">¶</a></dt>
 <dd><p>MNASNet with depth multiplier of 0.75 from
 <a class="reference external" href="https://arxiv.org/pdf/1807.11626.pdf">“MnasNet: Platform-Aware Neural Architecture Search for Mobile”</a>.
 :param pretrained: If True, returns a model pre-trained on ImageNet
@@ -1122,7 +1186,7 @@ channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
 
 <dl class="function">
 <dt id="torchvision.models.mnasnet1_0">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">mnasnet1_0</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/mnasnet.html#mnasnet1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet1_0" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">mnasnet1_0</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/mnasnet.html#mnasnet1_0"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet1_0" title="Permalink to this definition">¶</a></dt>
 <dd><p>MNASNet with depth multiplier of 1.0 from
 <a class="reference external" href="https://arxiv.org/pdf/1807.11626.pdf">“MnasNet: Platform-Aware Neural Architecture Search for Mobile”</a>.
 :param pretrained: If True, returns a model pre-trained on ImageNet
@@ -1133,7 +1197,7 @@ channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
 
 <dl class="function">
 <dt id="torchvision.models.mnasnet1_3">
-<code class="sig-prename descclassname">torchvision.models.</code><code class="sig-name descname">mnasnet1_3</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/mnasnet.html#mnasnet1_3"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet1_3" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.</code><code class="descname">mnasnet1_3</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/mnasnet.html#mnasnet1_3"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.mnasnet1_3" title="Permalink to this definition">¶</a></dt>
 <dd><p>MNASNet with depth multiplier of 1.3 from
 <a class="reference external" href="https://arxiv.org/pdf/1807.11626.pdf">“MnasNet: Platform-Aware Neural Architecture Search for Mobile”</a>.
 :param pretrained: If True, returns a model pre-trained on ImageNet
@@ -1149,8 +1213,8 @@ channels, and in Wide ResNet-50-2 has 2048-1024-2048.</p>
 <p>The models subpackage contains definitions for the following model
 architectures for semantic segmentation:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://arxiv.org/abs/1411.4038">FCN ResNet50, ResNet101</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1706.05587">DeepLabV3 ResNet50, ResNet101</a></p></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1411.4038">FCN ResNet50, ResNet101</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1706.05587">DeepLabV3 ResNet50, ResNet101</a></li>
 </ul>
 <p>As with image classification models, all pre-trained models expect input images normalized in the same way.
 The images have to be loaded in to a range of <code class="docutils literal notranslate"><span class="pre">[0,</span> <span class="pre">1]</span></code> and then normalized using
@@ -1168,29 +1232,34 @@ in order:</p>
 </div>
 </div></blockquote>
 <p>The accuracies of the pre-trained models evaluated on COCO val2017 are as follows</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>mean IoU</p></th>
-<th class="head"><p>global pixelwise acc</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="49%" />
+<col width="20%" />
+<col width="31%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">mean IoU</th>
+<th class="head">global pixelwise acc</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>FCN ResNet50</p></td>
-<td><p>60.5</p></td>
-<td><p>91.4</p></td>
+<tbody valign="top">
+<tr class="row-even"><td>FCN ResNet50</td>
+<td>60.5</td>
+<td>91.4</td>
 </tr>
-<tr class="row-odd"><td><p>FCN ResNet101</p></td>
-<td><p>63.7</p></td>
-<td><p>91.9</p></td>
+<tr class="row-odd"><td>FCN ResNet101</td>
+<td>63.7</td>
+<td>91.9</td>
 </tr>
-<tr class="row-even"><td><p>DeepLabV3 ResNet50</p></td>
-<td><p>66.4</p></td>
-<td><p>92.4</p></td>
+<tr class="row-even"><td>DeepLabV3 ResNet50</td>
+<td>66.4</td>
+<td>92.4</td>
 </tr>
-<tr class="row-odd"><td><p>DeepLabV3 ResNet101</p></td>
-<td><p>67.4</p></td>
-<td><p>92.4</p></td>
+<tr class="row-odd"><td>DeepLabV3 ResNet101</td>
+<td>67.4</td>
+<td>92.4</td>
 </tr>
 </tbody>
 </table>
@@ -1198,32 +1267,40 @@ in order:</p>
 <h3>Fully Convolutional Networks<a class="headerlink" href="#fully-convolutional-networks" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.segmentation.fcn_resnet50">
-<code class="sig-prename descclassname">torchvision.models.segmentation.</code><code class="sig-name descname">fcn_resnet50</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=21</em>, <em class="sig-param">aux_loss=None</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/segmentation/segmentation.html#fcn_resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.fcn_resnet50" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.segmentation.</code><code class="descname">fcn_resnet50</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=21</em>, <em>aux_loss=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/segmentation/segmentation.html#fcn_resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.fcn_resnet50" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a Fully-Convolutional Network model with a ResNet-50 backbone.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
-contains the same classes as Pascal VOC</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
+contains the same classes as Pascal VOC</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.segmentation.fcn_resnet101">
-<code class="sig-prename descclassname">torchvision.models.segmentation.</code><code class="sig-name descname">fcn_resnet101</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=21</em>, <em class="sig-param">aux_loss=None</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/segmentation/segmentation.html#fcn_resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.fcn_resnet101" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.segmentation.</code><code class="descname">fcn_resnet101</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=21</em>, <em>aux_loss=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/segmentation/segmentation.html#fcn_resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.fcn_resnet101" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a Fully-Convolutional Network model with a ResNet-101 backbone.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
-contains the same classes as Pascal VOC</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
+contains the same classes as Pascal VOC</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1231,32 +1308,40 @@ contains the same classes as Pascal VOC</p></li>
 <h3>DeepLabV3<a class="headerlink" href="#deeplabv3" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.segmentation.deeplabv3_resnet50">
-<code class="sig-prename descclassname">torchvision.models.segmentation.</code><code class="sig-name descname">deeplabv3_resnet50</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=21</em>, <em class="sig-param">aux_loss=None</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/segmentation/segmentation.html#deeplabv3_resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.deeplabv3_resnet50" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.segmentation.</code><code class="descname">deeplabv3_resnet50</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=21</em>, <em>aux_loss=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/segmentation/segmentation.html#deeplabv3_resnet50"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.deeplabv3_resnet50" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a DeepLabV3 model with a ResNet-50 backbone.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
-contains the same classes as Pascal VOC</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
+contains the same classes as Pascal VOC</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.models.segmentation.deeplabv3_resnet101">
-<code class="sig-prename descclassname">torchvision.models.segmentation.</code><code class="sig-name descname">deeplabv3_resnet101</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=21</em>, <em class="sig-param">aux_loss=None</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/segmentation/segmentation.html#deeplabv3_resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.deeplabv3_resnet101" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.segmentation.</code><code class="descname">deeplabv3_resnet101</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=21</em>, <em>aux_loss=None</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/segmentation/segmentation.html#deeplabv3_resnet101"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.segmentation.deeplabv3_resnet101" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a DeepLabV3 model with a ResNet-101 backbone.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
-contains the same classes as Pascal VOC</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017 which
+contains the same classes as Pascal VOC</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1266,8 +1351,8 @@ contains the same classes as Pascal VOC</p></li>
 <p>The models subpackage contains definitions for the following model
 architectures for detection:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://arxiv.org/abs/1506.01497">Faster R-CNN ResNet-50 FPN</a></p></li>
-<li><p><a class="reference external" href="https://arxiv.org/abs/1703.06870">Mask R-CNN ResNet-50 FPN</a></p></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1506.01497">Faster R-CNN ResNet-50 FPN</a></li>
+<li><a class="reference external" href="https://arxiv.org/abs/1703.06870">Mask R-CNN ResNet-50 FPN</a></li>
 </ul>
 <p>The pre-trained models for detection, instance segmentation and
 keypoint detection are initialized with the classification models
@@ -1298,30 +1383,36 @@ models return the predictions of the following classes:</p>
 </div></blockquote>
 <p>Here are the summary of the accuracies for the models trained on
 the instances set of COCO train2017 and evaluated on COCO val2017.</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>box AP</p></th>
-<th class="head"><p>mask AP</p></th>
-<th class="head"><p>keypoint AP</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="55%" />
+<col width="12%" />
+<col width="14%" />
+<col width="19%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">box AP</th>
+<th class="head">mask AP</th>
+<th class="head">keypoint AP</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>Faster R-CNN ResNet-50 FPN</p></td>
-<td><p>37.0</p></td>
-<td><ul class="simple">
+<tbody valign="top">
+<tr class="row-even"><td>Faster R-CNN ResNet-50 FPN</td>
+<td>37.0</td>
+<td><ul class="first last simple">
 <li></li>
 </ul>
 </td>
-<td><ul class="simple">
+<td><ul class="first last simple">
 <li></li>
 </ul>
 </td>
 </tr>
-<tr class="row-odd"><td><p>Mask R-CNN ResNet-50 FPN</p></td>
-<td><p>37.9</p></td>
-<td><p>34.6</p></td>
-<td><ul class="simple">
+<tr class="row-odd"><td>Mask R-CNN ResNet-50 FPN</td>
+<td>37.9</td>
+<td>34.6</td>
+<td><ul class="first last simple">
 <li></li>
 </ul>
 </td>
@@ -1330,22 +1421,28 @@ the instances set of COCO train2017 and evaluated on COCO val2017.</p>
 </table>
 <p>For person keypoint detection, the accuracies for the pre-trained
 models are as follows</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>box AP</p></th>
-<th class="head"><p>mask AP</p></th>
-<th class="head"><p>keypoint AP</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="55%" />
+<col width="12%" />
+<col width="14%" />
+<col width="19%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">box AP</th>
+<th class="head">mask AP</th>
+<th class="head">keypoint AP</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>Keypoint R-CNN ResNet-50 FPN</p></td>
-<td><p>54.6</p></td>
-<td><ul class="simple">
+<tbody valign="top">
+<tr class="row-even"><td>Keypoint R-CNN ResNet-50 FPN</td>
+<td>54.6</td>
+<td><ul class="first last simple">
 <li></li>
 </ul>
 </td>
-<td><p>65.0</p></td>
+<td>65.0</td>
 </tr>
 </tbody>
 </table>
@@ -1384,29 +1481,35 @@ during testing a batch size of 1 is used.</p>
 <p>For test time, we report the time for the model evaluation and postprocessing
 (including mask pasting in image), but not the time for computing the
 precision-recall.</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>train time (s / it)</p></th>
-<th class="head"><p>test time (s / it)</p></th>
-<th class="head"><p>memory (GB)</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="38%" />
+<col width="24%" />
+<col width="23%" />
+<col width="14%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">train time (s / it)</th>
+<th class="head">test time (s / it)</th>
+<th class="head">memory (GB)</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>Faster R-CNN ResNet-50 FPN</p></td>
-<td><p>0.2288</p></td>
-<td><p>0.0590</p></td>
-<td><p>5.2</p></td>
+<tbody valign="top">
+<tr class="row-even"><td>Faster R-CNN ResNet-50 FPN</td>
+<td>0.2288</td>
+<td>0.0590</td>
+<td>5.2</td>
 </tr>
-<tr class="row-odd"><td><p>Mask R-CNN ResNet-50 FPN</p></td>
-<td><p>0.2728</p></td>
-<td><p>0.0903</p></td>
-<td><p>5.4</p></td>
+<tr class="row-odd"><td>Mask R-CNN ResNet-50 FPN</td>
+<td>0.2728</td>
+<td>0.0903</td>
+<td>5.4</td>
 </tr>
-<tr class="row-even"><td><p>Keypoint R-CNN ResNet-50 FPN</p></td>
-<td><p>0.3789</p></td>
-<td><p>0.1242</p></td>
-<td><p>6.8</p></td>
+<tr class="row-even"><td>Keypoint R-CNN ResNet-50 FPN</td>
+<td>0.3789</td>
+<td>0.1242</td>
+<td>6.8</td>
 </tr>
 </tbody>
 </table>
@@ -1415,7 +1518,7 @@ precision-recall.</p>
 <h3>Faster R-CNN<a class="headerlink" href="#faster-r-cnn" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.detection.fasterrcnn_resnet50_fpn">
-<code class="sig-prename descclassname">torchvision.models.detection.</code><code class="sig-name descname">fasterrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=91</em>, <em class="sig-param">pretrained_backbone=True</em>, <em class="sig-param">trainable_backbone_layers=3</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/detection/faster_rcnn.html#fasterrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.fasterrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.detection.</code><code class="descname">fasterrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=91</em>, <em>pretrained_backbone=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/detection/faster_rcnn.html#fasterrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.fasterrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a Faster R-CNN model with a ResNet-50-FPN backbone.</p>
 <p>The input to the model is expected to be a list of tensors, each of shape <code class="docutils literal notranslate"><span class="pre">[C,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>, one for each
 image, and should be in <code class="docutils literal notranslate"><span class="pre">0-1</span></code> range. Different images can have different sizes.</p>
@@ -1424,9 +1527,9 @@ image, and should be in <code class="docutils literal notranslate"><span class="
 containing:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</p></li>
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values
+between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</li>
 </ul>
 </div></blockquote>
 <p>The model returns a <code class="docutils literal notranslate"><span class="pre">Dict[Tensor]</span></code> during training, containing the classification and regression
@@ -1436,13 +1539,12 @@ predictions as a <code class="docutils literal notranslate"><span class="pre">Li
 follows:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</p></li>
-<li><p>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</p></li>
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values between
+<code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</li>
+<li>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</li>
 </ul>
 </div></blockquote>
-<p>Faster R-CNN is exportable to ONNX for a fixed batch size with inputs images of fixed size.</p>
 <p>Example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">model</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">models</span><span class="o">.</span><span class="n">detection</span><span class="o">.</span><span class="n">fasterrcnn_resnet50_fpn</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="c1"># For training</span>
@@ -1460,23 +1562,20 @@ between <code class="docutils literal notranslate"><span class="pre">0</span></c
 <span class="gp">&gt;&gt;&gt; </span><span class="n">model</span><span class="o">.</span><span class="n">eval</span><span class="p">()</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">x</span> <span class="o">=</span> <span class="p">[</span><span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">300</span><span class="p">,</span> <span class="mi">400</span><span class="p">),</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">500</span><span class="p">,</span> <span class="mi">400</span><span class="p">)]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">predictions</span> <span class="o">=</span> <span class="n">model</span><span class="p">(</span><span class="n">x</span><span class="p">)</span>
-<span class="go">&gt;&gt;&gt;</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="c1"># optionally, if you want to export the model to ONNX:</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">torch</span><span class="o">.</span><span class="n">onnx</span><span class="o">.</span><span class="n">export</span><span class="p">(</span><span class="n">model</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="s2">&quot;faster_rcnn.onnx&quot;</span><span class="p">,</span> <span class="n">opset_version</span> <span class="o">=</span> <span class="mi">11</span><span class="p">)</span>
 </pre></div>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>pretrained_backbone</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model with backbone pre-trained on Imagenet</p></li>
-<li><p><strong>num_classes</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of output classes of the model (including the background)</p></li>
-<li><p><strong>trainable_backbone_layers</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of trainable (not frozen) resnet layers starting from final block.
-Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1484,7 +1583,7 @@ Valid values are between 0 and 5, with 5 meaning all backbone layers are trainab
 <h3>Mask R-CNN<a class="headerlink" href="#mask-r-cnn" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.detection.maskrcnn_resnet50_fpn">
-<code class="sig-prename descclassname">torchvision.models.detection.</code><code class="sig-name descname">maskrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=91</em>, <em class="sig-param">pretrained_backbone=True</em>, <em class="sig-param">trainable_backbone_layers=3</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/detection/mask_rcnn.html#maskrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.maskrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.detection.</code><code class="descname">maskrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=91</em>, <em>pretrained_backbone=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/detection/mask_rcnn.html#maskrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.maskrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a Mask R-CNN model with a ResNet-50-FPN backbone.</p>
 <p>The input to the model is expected to be a list of tensors, each of shape <code class="docutils literal notranslate"><span class="pre">[C,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>, one for each
 image, and should be in <code class="docutils literal notranslate"><span class="pre">0-1</span></code> range. Different images can have different sizes.</p>
@@ -1493,10 +1592,10 @@ image, and should be in <code class="docutils literal notranslate"><span class="
 containing:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format,  with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</p></li>
-<li><p>masks (<code class="docutils literal notranslate"><span class="pre">UInt8Tensor[N,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>): the segmentation binary masks for each instance</p></li>
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values
+between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</li>
+<li>masks (<code class="docutils literal notranslate"><span class="pre">UInt8Tensor[N,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>): the segmentation binary masks for each instance</li>
 </ul>
 </div></blockquote>
 <p>The model returns a <code class="docutils literal notranslate"><span class="pre">Dict[Tensor]</span></code> during training, containing the classification and regression
@@ -1506,38 +1605,34 @@ predictions as a <code class="docutils literal notranslate"><span class="pre">Li
 follows:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format,  with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</p></li>
-<li><p>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</p></li>
-<li><p>masks (<code class="docutils literal notranslate"><span class="pre">UInt8Tensor[N,</span> <span class="pre">1,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>): the predicted masks for each instance, in <code class="docutils literal notranslate"><span class="pre">0-1</span></code> range. In order to
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values between
+<code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</li>
+<li>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</li>
+<li>masks (<code class="docutils literal notranslate"><span class="pre">UInt8Tensor[N,</span> <span class="pre">1,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>): the predicted masks for each instance, in <code class="docutils literal notranslate"><span class="pre">0-1</span></code> range. In order to
 obtain the final segmentation masks, the soft masks can be thresholded, generally
-with a value of 0.5 (<code class="docutils literal notranslate"><span class="pre">mask</span> <span class="pre">&gt;=</span> <span class="pre">0.5</span></code>)</p></li>
+with a value of 0.5 (<code class="docutils literal notranslate"><span class="pre">mask</span> <span class="pre">&gt;=</span> <span class="pre">0.5</span></code>)</li>
 </ul>
 </div></blockquote>
-<p>Mask R-CNN is exportable to ONNX for a fixed batch size with inputs images of fixed size.</p>
 <p>Example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">model</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">models</span><span class="o">.</span><span class="n">detection</span><span class="o">.</span><span class="n">maskrcnn_resnet50_fpn</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">model</span><span class="o">.</span><span class="n">eval</span><span class="p">()</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">x</span> <span class="o">=</span> <span class="p">[</span><span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">300</span><span class="p">,</span> <span class="mi">400</span><span class="p">),</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">500</span><span class="p">,</span> <span class="mi">400</span><span class="p">)]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">predictions</span> <span class="o">=</span> <span class="n">model</span><span class="p">(</span><span class="n">x</span><span class="p">)</span>
-<span class="go">&gt;&gt;&gt;</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="c1"># optionally, if you want to export the model to ONNX:</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">torch</span><span class="o">.</span><span class="n">onnx</span><span class="o">.</span><span class="n">export</span><span class="p">(</span><span class="n">model</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="s2">&quot;mask_rcnn.onnx&quot;</span><span class="p">,</span> <span class="n">opset_version</span> <span class="o">=</span> <span class="mi">11</span><span class="p">)</span>
 </pre></div>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>pretrained_backbone</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model with backbone pre-trained on Imagenet</p></li>
-<li><p><strong>num_classes</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of output classes of the model (including the background)</p></li>
-<li><p><strong>trainable_backbone_layers</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of trainable (not frozen) resnet layers starting from final block.
-Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1545,7 +1640,7 @@ Valid values are between 0 and 5, with 5 meaning all backbone layers are trainab
 <h3>Keypoint R-CNN<a class="headerlink" href="#keypoint-r-cnn" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.detection.keypointrcnn_resnet50_fpn">
-<code class="sig-prename descclassname">torchvision.models.detection.</code><code class="sig-name descname">keypointrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">num_classes=2</em>, <em class="sig-param">num_keypoints=17</em>, <em class="sig-param">pretrained_backbone=True</em>, <em class="sig-param">trainable_backbone_layers=3</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/detection/keypoint_rcnn.html#keypointrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.keypointrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.detection.</code><code class="descname">keypointrcnn_resnet50_fpn</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>num_classes=2</em>, <em>num_keypoints=17</em>, <em>pretrained_backbone=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/detection/keypoint_rcnn.html#keypointrcnn_resnet50_fpn"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.detection.keypointrcnn_resnet50_fpn" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructs a Keypoint R-CNN model with a ResNet-50-FPN backbone.</p>
 <p>The input to the model is expected to be a list of tensors, each of shape <code class="docutils literal notranslate"><span class="pre">[C,</span> <span class="pre">H,</span> <span class="pre">W]</span></code>, one for each
 image, and should be in <code class="docutils literal notranslate"><span class="pre">0-1</span></code> range. Different images can have different sizes.</p>
@@ -1554,11 +1649,11 @@ image, and should be in <code class="docutils literal notranslate"><span class="
 containing:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</p></li>
-<li><p>keypoints (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">K,</span> <span class="pre">3]</span></code>): the <code class="docutils literal notranslate"><span class="pre">K</span></code> keypoints location for each of the <code class="docutils literal notranslate"><span class="pre">N</span></code> instances, in the
-format <code class="docutils literal notranslate"><span class="pre">[x,</span> <span class="pre">y,</span> <span class="pre">visibility]</span></code>, where <code class="docutils literal notranslate"><span class="pre">visibility=0</span></code> means that the keypoint is not visible.</p></li>
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the ground-truth boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values
+between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the class label for each ground-truth box</li>
+<li>keypoints (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">K,</span> <span class="pre">3]</span></code>): the <code class="docutils literal notranslate"><span class="pre">K</span></code> keypoints location for each of the <code class="docutils literal notranslate"><span class="pre">N</span></code> instances, in the
+format <code class="docutils literal notranslate"><span class="pre">[x,</span> <span class="pre">y,</span> <span class="pre">visibility]</span></code>, where <code class="docutils literal notranslate"><span class="pre">visibility=0</span></code> means that the keypoint is not visible.</li>
 </ul>
 </div></blockquote>
 <p>The model returns a <code class="docutils literal notranslate"><span class="pre">Dict[Tensor]</span></code> during training, containing the classification and regression
@@ -1568,36 +1663,32 @@ predictions as a <code class="docutils literal notranslate"><span class="pre">Li
 follows:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format,  with values of <code class="docutils literal notranslate"><span class="pre">x</span></code>
-between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code> and values of <code class="docutils literal notranslate"><span class="pre">y</span></code> between <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code></p></li>
-<li><p>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</p></li>
-<li><p>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</p></li>
-<li><p>keypoints (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">K,</span> <span class="pre">3]</span></code>): the locations of the predicted keypoints, in <code class="docutils literal notranslate"><span class="pre">[x,</span> <span class="pre">y,</span> <span class="pre">v]</span></code> format.</p></li>
+<li>boxes (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">4]</span></code>): the predicted boxes in <code class="docutils literal notranslate"><span class="pre">[x1,</span> <span class="pre">y1,</span> <span class="pre">x2,</span> <span class="pre">y2]</span></code> format, with values between
+<code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">H</span></code> and <code class="docutils literal notranslate"><span class="pre">0</span></code> and <code class="docutils literal notranslate"><span class="pre">W</span></code></li>
+<li>labels (<code class="docutils literal notranslate"><span class="pre">Int64Tensor[N]</span></code>): the predicted labels for each image</li>
+<li>scores (<code class="docutils literal notranslate"><span class="pre">Tensor[N]</span></code>): the scores or each prediction</li>
+<li>keypoints (<code class="docutils literal notranslate"><span class="pre">FloatTensor[N,</span> <span class="pre">K,</span> <span class="pre">3]</span></code>): the locations of the predicted keypoints, in <code class="docutils literal notranslate"><span class="pre">[x,</span> <span class="pre">y,</span> <span class="pre">v]</span></code> format.</li>
 </ul>
 </div></blockquote>
-<p>Keypoint R-CNN is exportable to ONNX for a fixed batch size with inputs images of fixed size.</p>
 <p>Example:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">model</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">models</span><span class="o">.</span><span class="n">detection</span><span class="o">.</span><span class="n">keypointrcnn_resnet50_fpn</span><span class="p">(</span><span class="n">pretrained</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">model</span><span class="o">.</span><span class="n">eval</span><span class="p">()</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">x</span> <span class="o">=</span> <span class="p">[</span><span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">300</span><span class="p">,</span> <span class="mi">400</span><span class="p">),</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">3</span><span class="p">,</span> <span class="mi">500</span><span class="p">,</span> <span class="mi">400</span><span class="p">)]</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">predictions</span> <span class="o">=</span> <span class="n">model</span><span class="p">(</span><span class="n">x</span><span class="p">)</span>
-<span class="go">&gt;&gt;&gt;</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="c1"># optionally, if you want to export the model to ONNX:</span>
-<span class="gp">&gt;&gt;&gt; </span><span class="n">torch</span><span class="o">.</span><span class="n">onnx</span><span class="o">.</span><span class="n">export</span><span class="p">(</span><span class="n">model</span><span class="p">,</span> <span class="n">x</span><span class="p">,</span> <span class="s2">&quot;keypoint_rcnn.onnx&quot;</span><span class="p">,</span> <span class="n">opset_version</span> <span class="o">=</span> <span class="mi">11</span><span class="p">)</span>
 </pre></div>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
-<li><p><strong>pretrained_backbone</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model with backbone pre-trained on Imagenet</p></li>
-<li><p><strong>num_classes</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of output classes of the model (including the background)</p></li>
-<li><p><strong>trainable_backbone_layers</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of trainable (not frozen) resnet layers starting from final block.
-Valid values are between 0 and 5, with 5 meaning all backbone layers are trainable.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on COCO train2017</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1612,36 +1703,41 @@ where H and W are expected to be 112, and T is a number of video frames in a cli
 The images have to be loaded in to a range of [0, 1] and then normalized
 using <code class="docutils literal notranslate"><span class="pre">mean</span> <span class="pre">=</span> <span class="pre">[0.43216,</span> <span class="pre">0.394666,</span> <span class="pre">0.37645]</span></code> and <code class="docutils literal notranslate"><span class="pre">std</span> <span class="pre">=</span> <span class="pre">[0.22803,</span> <span class="pre">0.22145,</span> <span class="pre">0.216989]</span></code>.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>The normalization parameters are different from the image classification ones, and correspond
+<p class="first admonition-title">Note</p>
+<p class="last">The normalization parameters are different from the image classification ones, and correspond
 to the mean and std from Kinetics-400.</p>
 </div>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>For now, normalization code can be found in <code class="docutils literal notranslate"><span class="pre">references/video_classification/transforms.py</span></code>,
+<p class="first admonition-title">Note</p>
+<p class="last">For now, normalization code can be found in <code class="docutils literal notranslate"><span class="pre">references/video_classification/transforms.py</span></code>,
 see the <code class="docutils literal notranslate"><span class="pre">Normalize</span></code> function there. Note that it differs from standard normalization for
 images because it assumes the video is 4d.</p>
 </div>
 <p>Kinetics 1-crop accuracies for clip length 16 (16x112x112)</p>
-<table class="docutils colwidths-auto align-default">
-<thead>
-<tr class="row-odd"><th class="head"><p>Network</p></th>
-<th class="head"><p>Clip acc&#64;1</p></th>
-<th class="head"><p>Clip acc&#64;5</p></th>
+<table border="1" class="docutils">
+<colgroup>
+<col width="55%" />
+<col width="22%" />
+<col width="22%" />
+</colgroup>
+<thead valign="bottom">
+<tr class="row-odd"><th class="head">Network</th>
+<th class="head">Clip acc&#64;1</th>
+<th class="head">Clip acc&#64;5</th>
 </tr>
 </thead>
-<tbody>
-<tr class="row-even"><td><p>ResNet 3D 18</p></td>
-<td><p>52.75</p></td>
-<td><p>75.45</p></td>
+<tbody valign="top">
+<tr class="row-even"><td>ResNet 3D 18</td>
+<td>52.75</td>
+<td>75.45</td>
 </tr>
-<tr class="row-odd"><td><p>ResNet MC 18</p></td>
-<td><p>53.90</p></td>
-<td><p>76.29</p></td>
+<tr class="row-odd"><td>ResNet MC 18</td>
+<td>53.90</td>
+<td>76.29</td>
 </tr>
-<tr class="row-even"><td><p>ResNet (2+1)D</p></td>
-<td><p>57.50</p></td>
-<td><p>78.81</p></td>
+<tr class="row-even"><td>ResNet (2+1)D</td>
+<td>57.50</td>
+<td>78.81</td>
 </tr>
 </tbody>
 </table>
@@ -1649,23 +1745,27 @@ images because it assumes the video is 4d.</p>
 <h3>ResNet 3D<a class="headerlink" href="#resnet-3d" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.video.r3d_18">
-<code class="sig-prename descclassname">torchvision.models.video.</code><code class="sig-name descname">r3d_18</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/video/resnet.html#r3d_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.r3d_18" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.video.</code><code class="descname">r3d_18</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/video/resnet.html#r3d_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.r3d_18" title="Permalink to this definition">¶</a></dt>
 <dd><p>Construct 18 layer Resnet3D model as in
 <a class="reference external" href="https://arxiv.org/abs/1711.11248">https://arxiv.org/abs/1711.11248</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>R3D-18 network</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../generated/torch.nn.Module.html#torch.nn.Module" title="torch.nn.Module">nn.Module</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">R3D-18 network</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">nn.Module</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1673,23 +1773,27 @@ images because it assumes the video is 4d.</p>
 <h3>ResNet Mixed Convolution<a class="headerlink" href="#resnet-mixed-convolution" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.video.mc3_18">
-<code class="sig-prename descclassname">torchvision.models.video.</code><code class="sig-name descname">mc3_18</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/video/resnet.html#mc3_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.mc3_18" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.video.</code><code class="descname">mc3_18</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/video/resnet.html#mc3_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.mc3_18" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructor for 18 layer Mixed Convolution network as in
 <a class="reference external" href="https://arxiv.org/abs/1711.11248">https://arxiv.org/abs/1711.11248</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>MC3 Network definition</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../generated/torch.nn.Module.html#torch.nn.Module" title="torch.nn.Module">nn.Module</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">MC3 Network definition</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">nn.Module</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1697,23 +1801,27 @@ images because it assumes the video is 4d.</p>
 <h3>ResNet (2+1)D<a class="headerlink" href="#resnet-2-1-d" title="Permalink to this headline">¶</a></h3>
 <dl class="function">
 <dt id="torchvision.models.video.r2plus1d_18">
-<code class="sig-prename descclassname">torchvision.models.video.</code><code class="sig-name descname">r2plus1d_18</code><span class="sig-paren">(</span><em class="sig-param">pretrained=False</em>, <em class="sig-param">progress=True</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/models/video/resnet.html#r2plus1d_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.r2plus1d_18" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.models.video.</code><code class="descname">r2plus1d_18</code><span class="sig-paren">(</span><em>pretrained=False</em>, <em>progress=True</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/models/video/resnet.html#r2plus1d_18"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.models.video.r2plus1d_18" title="Permalink to this definition">¶</a></dt>
 <dd><p>Constructor for the 18 layer deep R(2+1)D network as in
 <a class="reference external" href="https://arxiv.org/abs/1711.11248">https://arxiv.org/abs/1711.11248</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</p></li>
-<li><p><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>pretrained</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, returns a model pre-trained on Kinetics-400</li>
+<li><strong>progress</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If True, displays a progress bar of the download to stderr</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>R(2+1)D-18 network</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../generated/torch.nn.Module.html#torch.nn.Module" title="torch.nn.Module">nn.Module</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">R(2+1)D-18 network</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">nn.Module</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1728,10 +1836,10 @@ images because it assumes the video is 4d.</p>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="ops.html" class="btn btn-neutral float-right" title="torchvision.ops" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="ops.html" class="btn btn-neutral float-right" title="torchvision.ops" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="io.html" class="btn btn-neutral" title="torchvision.io" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="io.html" class="btn btn-neutral" title="torchvision.io" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -1744,7 +1852,7 @@ images because it assumes the video is 4d.</p>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -1813,50 +1921,35 @@ images because it assumes the video is 4d.</p>
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -1962,7 +2055,7 @@ images because it assumes the video is 4d.</p>
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -2029,7 +2122,7 @@ images because it assumes the video is 4d.</p>
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/ops.html
+++ b/docs/stable/torchvision/ops.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.ops &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.ops &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/ops.html"/>
   
 
   
@@ -27,28 +36,24 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="torchvision.transforms" href="transforms.html" />
     <link rel="prev" title="torchvision.models" href="models.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +164,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +176,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +187,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +232,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +240,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.ops</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/ops.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/ops.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -341,184 +276,202 @@
 <h1>torchvision.ops<a class="headerlink" href="#torchvision-ops" title="Permalink to this headline">¶</a></h1>
 <p><code class="xref py py-mod docutils literal notranslate"><span class="pre">torchvision.ops</span></code> implements operators that are specific for Computer Vision.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>All operators have native support for TorchScript.</p>
+<p class="first admonition-title">Note</p>
+<p class="last">All operators have native support for TorchScript.</p>
 </div>
 <dl class="function">
 <dt id="torchvision.ops.nms">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">nms</code><span class="sig-paren">(</span><em class="sig-param">boxes: torch.Tensor</em>, <em class="sig-param">scores: torch.Tensor</em>, <em class="sig-param">iou_threshold: float</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/boxes.html#nms"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.nms" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">nms</code><span class="sig-paren">(</span><em>boxes</em>, <em>scores</em>, <em>iou_threshold</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/boxes.html#nms"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.nms" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs non-maximum suppression (NMS) on the boxes according
 to their intersection-over-union (IoU).</p>
 <p>NMS iteratively removes lower scoring boxes which have an
 IoU greater than iou_threshold with another (higher scoring)
 box.</p>
-<p>If multiple boxes have the exact same score and satisfy the IoU
-criterion with respect to a reference box, the selected box is
-not guaranteed to be the same between CPU and GPU. This is similar
-to the behavior of argsort in PyTorch when repeated values are present.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>boxes</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>, </em><em>4</em><em>]</em><em>)</em>) – boxes to perform NMS on. They
-are expected to be in (x1, y1, x2, y2) format</p></li>
-<li><p><strong>scores</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>]</em>) – scores for each one of the boxes</p></li>
-<li><p><strong>iou_threshold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – discards all overlapping
-boxes with IoU &gt; iou_threshold</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>boxes</strong> (<em>Tensor</em><em>[</em><em>N</em><em>, </em><em>4</em><em>]</em><em>)</em>) – boxes to perform NMS on. They
+are expected to be in (x1, y1, x2, y2) format</li>
+<li><strong>scores</strong> (<em>Tensor</em><em>[</em><em>N</em><em>]</em>) – scores for each one of the boxes</li>
+<li><strong>iou_threshold</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – discards all overlapping
+boxes with IoU &gt; iou_threshold</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><strong>keep</strong> – int64 tensor with the indices
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first"><strong>keep</strong> – int64 tensor with the indices
 of the elements that have been kept
 by NMS, sorted in decreasing order of scores</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">Tensor</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.ops.roi_align">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">roi_align</code><span class="sig-paren">(</span><em class="sig-param">input: torch.Tensor</em>, <em class="sig-param">boxes: torch.Tensor</em>, <em class="sig-param">output_size: None</em>, <em class="sig-param">spatial_scale: float = 1.0</em>, <em class="sig-param">sampling_ratio: int = -1</em>, <em class="sig-param">aligned: bool = False</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/roi_align.html#roi_align"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.roi_align" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">roi_align</code><span class="sig-paren">(</span><em>input</em>, <em>boxes</em>, <em>output_size</em>, <em>spatial_scale=1.0</em>, <em>sampling_ratio=-1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/roi_align.html#roi_align"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.roi_align" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Region of Interest (RoI) Align operator described in Mask R-CNN</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>input</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</p></li>
-<li><p><strong>boxes</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>input</strong> (<em>Tensor</em><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</li>
+<li><strong>boxes</strong> (<em>Tensor</em><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><em>Tensor</em><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
 format where the regions will be taken from. If a single Tensor is passed,
 then the first column should contain the batch index. If a list of Tensors
 is passed, then each Tensor will correspond to the boxes for an element i
-in a batch</p></li>
-<li><p><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
-is performed, as (height, width)</p></li>
-<li><p><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
-the box coordinates. Default: 1.0</p></li>
-<li><p><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of sampling points in the interpolation grid
+in a batch</li>
+<li><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
+is performed, as (height, width)</li>
+<li><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
+the box coordinates. Default: 1.0</li>
+<li><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of sampling points in the interpolation grid
 used to compute the output value of each pooled output bin. If &gt; 0,
 then exactly sampling_ratio x sampling_ratio grid points are used. If
 &lt;= 0, then an adaptive number of grid points are used (computed as
-ceil(roi_width / pooled_w), and likewise for height). Default: -1</p></li>
-<li><p><strong>aligned</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – If False, use the legacy implementation.
-If True, pixel shift it by -0.5 for align more perfectly about two neighboring pixel indices.
-This version in Detectron2</p></li>
+ceil(roi_width / pooled_w), and likewise for height). Default: -1</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>output (Tensor[K, C, output_size[0], output_size[1]])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">output (Tensor[K, C, output_size[0], output_size[1]])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.ops.ps_roi_align">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">ps_roi_align</code><span class="sig-paren">(</span><em class="sig-param">input: torch.Tensor</em>, <em class="sig-param">boxes: torch.Tensor</em>, <em class="sig-param">output_size: int</em>, <em class="sig-param">spatial_scale: float = 1.0</em>, <em class="sig-param">sampling_ratio: int = -1</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/ps_roi_align.html#ps_roi_align"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.ps_roi_align" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">ps_roi_align</code><span class="sig-paren">(</span><em>input</em>, <em>boxes</em>, <em>output_size</em>, <em>spatial_scale=1.0</em>, <em>sampling_ratio=-1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/ps_roi_align.html#ps_roi_align"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.ps_roi_align" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Position-Sensitive Region of Interest (RoI) Align operator
 mentioned in Light-Head R-CNN.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>input</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</p></li>
-<li><p><strong>boxes</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>input</strong> (<em>Tensor</em><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</li>
+<li><strong>boxes</strong> (<em>Tensor</em><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><em>Tensor</em><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
 format where the regions will be taken from. If a single Tensor is passed,
 then the first column should contain the batch index. If a list of Tensors
 is passed, then each Tensor will correspond to the boxes for an element i
-in a batch</p></li>
-<li><p><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
-is performed, as (height, width)</p></li>
-<li><p><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
-the box coordinates. Default: 1.0</p></li>
-<li><p><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of sampling points in the interpolation grid
+in a batch</li>
+<li><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
+is performed, as (height, width)</li>
+<li><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
+the box coordinates. Default: 1.0</li>
+<li><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of sampling points in the interpolation grid
 used to compute the output value of each pooled output bin. If &gt; 0
 then exactly sampling_ratio x sampling_ratio grid points are used.
 If &lt;= 0, then an adaptive number of grid points are used (computed as
-ceil(roi_width / pooled_w), and likewise for height). Default: -1</p></li>
+ceil(roi_width / pooled_w), and likewise for height). Default: -1</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>output (Tensor[K, C, output_size[0], output_size[1]])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">output (Tensor[K, C, output_size[0], output_size[1]])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.ops.roi_pool">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">roi_pool</code><span class="sig-paren">(</span><em class="sig-param">input: torch.Tensor</em>, <em class="sig-param">boxes: torch.Tensor</em>, <em class="sig-param">output_size: None</em>, <em class="sig-param">spatial_scale: float = 1.0</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/roi_pool.html#roi_pool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.roi_pool" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">roi_pool</code><span class="sig-paren">(</span><em>input</em>, <em>boxes</em>, <em>output_size</em>, <em>spatial_scale=1.0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/roi_pool.html#roi_pool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.roi_pool" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Region of Interest (RoI) Pool operator described in Fast R-CNN</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>input</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</p></li>
-<li><p><strong>boxes</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>input</strong> (<em>Tensor</em><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</li>
+<li><strong>boxes</strong> (<em>Tensor</em><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><em>Tensor</em><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
 format where the regions will be taken from. If a single Tensor is passed,
 then the first column should contain the batch index. If a list of Tensors
 is passed, then each Tensor will correspond to the boxes for an element i
-in a batch</p></li>
-<li><p><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
-is performed, as (height, width)</p></li>
-<li><p><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
-the box coordinates. Default: 1.0</p></li>
+in a batch</li>
+<li><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
+is performed, as (height, width)</li>
+<li><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
+the box coordinates. Default: 1.0</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>output (Tensor[K, C, output_size[0], output_size[1]])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">output (Tensor[K, C, output_size[0], output_size[1]])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.ops.ps_roi_pool">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">ps_roi_pool</code><span class="sig-paren">(</span><em class="sig-param">input: torch.Tensor</em>, <em class="sig-param">boxes: torch.Tensor</em>, <em class="sig-param">output_size: int</em>, <em class="sig-param">spatial_scale: float = 1.0</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/ps_roi_pool.html#ps_roi_pool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.ps_roi_pool" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">ps_roi_pool</code><span class="sig-paren">(</span><em>input</em>, <em>boxes</em>, <em>output_size</em>, <em>spatial_scale=1.0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/ps_roi_pool.html#ps_roi_pool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.ps_roi_pool" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Position-Sensitive Region of Interest (RoI) Pool operator
 described in R-FCN</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>input</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</p></li>
-<li><p><strong>boxes</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>input</strong> (<em>Tensor</em><em>[</em><em>N</em><em>, </em><em>C</em><em>, </em><em>H</em><em>, </em><em>W</em><em>]</em>) – input tensor</li>
+<li><strong>boxes</strong> (<em>Tensor</em><em>[</em><em>K</em><em>, </em><em>5</em><em>] or </em><em>List</em><em>[</em><em>Tensor</em><em>[</em><em>L</em><em>, </em><em>4</em><em>]</em><em>]</em>) – the box coordinates in (x1, y1, x2, y2)
 format where the regions will be taken from. If a single Tensor is passed,
 then the first column should contain the batch index. If a list of Tensors
 is passed, then each Tensor will correspond to the boxes for an element i
-in a batch</p></li>
-<li><p><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
-is performed, as (height, width)</p></li>
-<li><p><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
-the box coordinates. Default: 1.0</p></li>
+in a batch</li>
+<li><strong>output_size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the size of the output after the cropping
+is performed, as (height, width)</li>
+<li><strong>spatial_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – a scaling factor that maps the input coordinates to
+the box coordinates. Default: 1.0</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>output (Tensor[K, C, output_size[0], output_size[1]])</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">output (Tensor[K, C, output_size[0], output_size[1]])</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.ops.deform_conv2d">
-<code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">deform_conv2d</code><span class="sig-paren">(</span><em class="sig-param">input: torch.Tensor</em>, <em class="sig-param">offset: torch.Tensor</em>, <em class="sig-param">weight: torch.Tensor</em>, <em class="sig-param">bias: Optional[torch.Tensor] = None</em>, <em class="sig-param">stride: Tuple[int</em>, <em class="sig-param">int] = (1</em>, <em class="sig-param">1)</em>, <em class="sig-param">padding: Tuple[int</em>, <em class="sig-param">int] = (0</em>, <em class="sig-param">0)</em>, <em class="sig-param">dilation: Tuple[int</em>, <em class="sig-param">int] = (1</em>, <em class="sig-param">1)</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/ops/deform_conv.html#deform_conv2d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.deform_conv2d" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.ops.</code><code class="descname">deform_conv2d</code><span class="sig-paren">(</span><em>input</em>, <em>offset</em>, <em>weight</em>, <em>bias=None</em>, <em>stride=(1</em>, <em>1)</em>, <em>padding=(0</em>, <em>0)</em>, <em>dilation=(1</em>, <em>1)</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/deform_conv.html#deform_conv2d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.deform_conv2d" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Deformable Convolution, described in Deformable Convolutional Networks</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>input</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>batch_size</em><em>, </em><em>in_channels</em><em>, </em><em>in_height</em><em>, </em><em>in_width</em><em>]</em>) – input tensor</p></li>
-<li><p><strong>(Tensor[batch_size, 2 * offset_groups * kernel_height * kernel_width,</strong> (<em>offset</em>) – out_height, out_width]): offsets to be applied for each position in the
-convolution kernel.</p></li>
-<li><p><strong>weight</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>out_channels</em><em>, </em><em>in_channels // groups</em><em>, </em><em>kernel_height</em><em>, </em><em>kernel_width</em><em>]</em>) – convolution weights, split into groups of size (in_channels // groups)</p></li>
-<li><p><strong>bias</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em>[</em><em>out_channels</em><em>]</em>) – optional bias of shape (out_channels,). Default: None</p></li>
-<li><p><strong>stride</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – distance between convolution centers. Default: 1</p></li>
-<li><p><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – height/width of padding of zeroes around
-each image. Default: 0</p></li>
-<li><p><strong>dilation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the spacing between kernel elements. Default: 1</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>input</strong> (<em>Tensor</em><em>[</em><em>batch_size</em><em>, </em><em>in_channels</em><em>, </em><em>in_height</em><em>, </em><em>in_width</em><em>]</em>) – input tensor</li>
+<li><strong>(Tensor[batch_size, 2 * offset_groups * kernel_height * kernel_width,</strong> (<em>offset</em>) – out_height, out_width]): offsets to be applied for each position in the
+convolution kernel.</li>
+<li><strong>weight</strong> (<em>Tensor</em><em>[</em><em>out_channels</em><em>, </em><em>in_channels // groups</em><em>, </em><em>kernel_height</em><em>, </em><em>kernel_width</em><em>]</em>) – convolution weights, split into groups of size (in_channels // groups)</li>
+<li><strong>bias</strong> (<em>Tensor</em><em>[</em><em>out_channels</em><em>]</em>) – optional bias of shape (out_channels,). Default: None</li>
+<li><strong>stride</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – distance between convolution centers. Default: 1</li>
+<li><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – height/width of padding of zeroes around
+each image. Default: 0</li>
+<li><strong>dilation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – the spacing between kernel elements. Default: 1</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>result of convolution</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>output (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a>[batch_sz, out_channels, out_h, out_w])</p>
-</dd>
-</dl>
-<dl>
-<dt>Examples::</dt><dd><div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="nb">input</span> <span class="o">=</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">10</span><span class="p">,</span> <span class="mi">10</span><span class="p">)</span>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">result of convolution</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">output (Tensor[batch_sz, out_channels, out_h, out_w])</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt>Examples::</dt>
+<dd><div class="first last highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="nb">input</span> <span class="o">=</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">10</span><span class="p">,</span> <span class="mi">10</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">kh</span><span class="p">,</span> <span class="n">kw</span> <span class="o">=</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">3</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">weight</span> <span class="o">=</span> <span class="n">torch</span><span class="o">.</span><span class="n">rand</span><span class="p">(</span><span class="mi">5</span><span class="p">,</span> <span class="mi">3</span><span class="p">,</span> <span class="n">kh</span><span class="p">,</span> <span class="n">kw</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="c1"># offset should have the same spatial size as the output</span>
@@ -537,49 +490,53 @@ each image. Default: 0</p></li>
 
 <dl class="class">
 <dt id="torchvision.ops.RoIAlign">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">RoIAlign</code><span class="sig-paren">(</span><em class="sig-param">output_size: None</em>, <em class="sig-param">spatial_scale: float</em>, <em class="sig-param">sampling_ratio: int</em>, <em class="sig-param">aligned: bool = False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/roi_align.html#RoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.RoIAlign" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">RoIAlign</code><span class="sig-paren">(</span><em>output_size</em>, <em>spatial_scale</em>, <em>sampling_ratio</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/roi_align.html#RoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.RoIAlign" title="Permalink to this definition">¶</a></dt>
 <dd><p>See roi_align</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.ops.PSRoIAlign">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">PSRoIAlign</code><span class="sig-paren">(</span><em class="sig-param">output_size: int</em>, <em class="sig-param">spatial_scale: float</em>, <em class="sig-param">sampling_ratio: int</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/ps_roi_align.html#PSRoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.PSRoIAlign" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">PSRoIAlign</code><span class="sig-paren">(</span><em>output_size</em>, <em>spatial_scale</em>, <em>sampling_ratio</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/ps_roi_align.html#PSRoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.PSRoIAlign" title="Permalink to this definition">¶</a></dt>
 <dd><p>See ps_roi_align</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.ops.RoIPool">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">RoIPool</code><span class="sig-paren">(</span><em class="sig-param">output_size: None</em>, <em class="sig-param">spatial_scale: float</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/roi_pool.html#RoIPool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.RoIPool" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">RoIPool</code><span class="sig-paren">(</span><em>output_size</em>, <em>spatial_scale</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/roi_pool.html#RoIPool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.RoIPool" title="Permalink to this definition">¶</a></dt>
 <dd><p>See roi_pool</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.ops.PSRoIPool">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">PSRoIPool</code><span class="sig-paren">(</span><em class="sig-param">output_size: int</em>, <em class="sig-param">spatial_scale: float</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/ps_roi_pool.html#PSRoIPool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.PSRoIPool" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">PSRoIPool</code><span class="sig-paren">(</span><em>output_size</em>, <em>spatial_scale</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/ps_roi_pool.html#PSRoIPool"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.PSRoIPool" title="Permalink to this definition">¶</a></dt>
 <dd><p>See ps_roi_pool</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.ops.DeformConv2d">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">DeformConv2d</code><span class="sig-paren">(</span><em class="sig-param">in_channels: int</em>, <em class="sig-param">out_channels: int</em>, <em class="sig-param">kernel_size: int</em>, <em class="sig-param">stride: int = 1</em>, <em class="sig-param">padding: int = 0</em>, <em class="sig-param">dilation: int = 1</em>, <em class="sig-param">groups: int = 1</em>, <em class="sig-param">bias: bool = True</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/deform_conv.html#DeformConv2d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.DeformConv2d" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">DeformConv2d</code><span class="sig-paren">(</span><em>in_channels</em>, <em>out_channels</em>, <em>kernel_size</em>, <em>stride=1</em>, <em>padding=0</em>, <em>dilation=1</em>, <em>groups=1</em>, <em>bias=True</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/deform_conv.html#DeformConv2d"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.DeformConv2d" title="Permalink to this definition">¶</a></dt>
 <dd><p>See deform_conv2d</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.ops.MultiScaleRoIAlign">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">MultiScaleRoIAlign</code><span class="sig-paren">(</span><em class="sig-param">featmap_names: List[str], output_size: List[int], sampling_ratio: int</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/poolers.html#MultiScaleRoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.MultiScaleRoIAlign" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">MultiScaleRoIAlign</code><span class="sig-paren">(</span><em>featmap_names</em>, <em>output_size</em>, <em>sampling_ratio</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/poolers.html#MultiScaleRoIAlign"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.MultiScaleRoIAlign" title="Permalink to this definition">¶</a></dt>
 <dd><p>Multi-scale RoIAlign pooling, which is useful for detection with or without FPN.</p>
 <p>It infers the scale of the pooling via the heuristics present in the FPN paper.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>featmap_names</strong> (<em>List</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>]</em>) – the names of the feature maps that will be used
-for the pooling.</p></li>
-<li><p><strong>output_size</strong> (<em>List</em><em>[</em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em><em>] or </em><em>List</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – output size for the pooled region</p></li>
-<li><p><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – sampling ratio for ROIAlign</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>featmap_names</strong> (<em>List</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em>]</em>) – the names of the feature maps that will be used
+for the pooling.</li>
+<li><strong>output_size</strong> (<em>List</em><em>[</em><em>Tuple</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em><em>] or </em><em>List</em><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – output size for the pooled region</li>
+<li><strong>sampling_ratio</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – sampling ratio for ROIAlign</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p>Examples:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">m</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">ops</span><span class="o">.</span><span class="n">MultiScaleRoIAlign</span><span class="p">([</span><span class="s1">&#39;feat1&#39;</span><span class="p">,</span> <span class="s1">&#39;feat3&#39;</span><span class="p">],</span> <span class="mi">3</span><span class="p">,</span> <span class="mi">2</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="n">i</span> <span class="o">=</span> <span class="n">OrderedDict</span><span class="p">()</span>
@@ -599,26 +556,30 @@ for the pooling.</p></li>
 
 <dl class="class">
 <dt id="torchvision.ops.FeaturePyramidNetwork">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.ops.</code><code class="sig-name descname">FeaturePyramidNetwork</code><span class="sig-paren">(</span><em class="sig-param">in_channels_list: List[int], out_channels: int, extra_blocks: Optional[torchvision.ops.feature_pyramid_network.ExtraFPNBlock] = None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/ops/feature_pyramid_network.html#FeaturePyramidNetwork"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.FeaturePyramidNetwork" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.ops.</code><code class="descname">FeaturePyramidNetwork</code><span class="sig-paren">(</span><em>in_channels_list</em>, <em>out_channels</em>, <em>extra_blocks=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/ops/feature_pyramid_network.html#FeaturePyramidNetwork"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.ops.FeaturePyramidNetwork" title="Permalink to this definition">¶</a></dt>
 <dd><p>Module that adds a FPN from on top of a set of feature maps. This is based on
 <a class="reference external" href="https://arxiv.org/abs/1612.03144">“Feature Pyramid Network for Object Detection”</a>.</p>
 <p>The feature maps are currently supposed to be in increasing depth
 order.</p>
 <p>The input to the model is expected to be an OrderedDict[Tensor], containing
 the feature maps on top of which the FPN will be added.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>in_channels_list</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – number of channels for each feature map that
-is passed to the module</p></li>
-<li><p><strong>out_channels</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of channels of the FPN representation</p></li>
-<li><p><strong>extra_blocks</strong> (<em>ExtraFPNBlock</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/constants.html#None" title="(in Python v3.8)"><em>None</em></a>) – if provided, extra operations will
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>in_channels_list</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em>[</em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>]</em>) – number of channels for each feature map that
+is passed to the module</li>
+<li><strong>out_channels</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – number of channels of the FPN representation</li>
+<li><strong>extra_blocks</strong> (<em>ExtraFPNBlock</em><em> or </em><em>None</em>) – if provided, extra operations will
 be performed. It is expected to take the fpn features, the original
 features and the names of the original features as input, and returns
-a new list of feature maps and their corresponding names</p></li>
+a new list of feature maps and their corresponding names</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p>Examples:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">m</span> <span class="o">=</span> <span class="n">torchvision</span><span class="o">.</span><span class="n">ops</span><span class="o">.</span><span class="n">FeaturePyramidNetwork</span><span class="p">([</span><span class="mi">10</span><span class="p">,</span> <span class="mi">20</span><span class="p">,</span> <span class="mi">30</span><span class="p">],</span> <span class="mi">5</span><span class="p">)</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="c1"># get some dummy data</span>
@@ -647,10 +608,10 @@ a new list of feature maps and their corresponding names</p></li>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="transforms.html" class="btn btn-neutral float-right" title="torchvision.transforms" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="transforms.html" class="btn btn-neutral float-right" title="torchvision.transforms" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="models.html" class="btn btn-neutral" title="torchvision.models" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="models.html" class="btn btn-neutral" title="torchvision.models" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -663,7 +624,7 @@ a new list of feature maps and their corresponding names</p></li>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -697,50 +658,35 @@ a new list of feature maps and their corresponding names</p></li>
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -846,7 +792,7 @@ a new list of feature maps and their corresponding names</p></li>
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -913,7 +859,7 @@ a new list of feature maps and their corresponding names</p></li>
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/transforms.html
+++ b/docs/stable/torchvision/transforms.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.transforms &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.transforms &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/transforms.html"/>
   
 
   
@@ -27,28 +36,24 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="next" title="torchvision.utils" href="utils.html" />
     <link rel="prev" title="torchvision.ops" href="ops.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +164,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +176,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +187,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.transforms</a></li>
+<li class="toctree-l1"><a class="reference internal" href="utils.html">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +232,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +240,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.transforms</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/transforms.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/transforms.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -346,15 +281,18 @@ This is useful if you have to build a more complex transformation pipeline
 (e.g. in the case of segmentation tasks).</p>
 <dl class="class">
 <dt id="torchvision.transforms.Compose">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Compose</code><span class="sig-paren">(</span><em class="sig-param">transforms</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Compose"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Compose" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Compose</code><span class="sig-paren">(</span><em>transforms</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Compose"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Compose" title="Permalink to this definition">¶</a></dt>
 <dd><p>Composes several transforms together.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>transforms</strong> (list of <code class="docutils literal notranslate"><span class="pre">Transform</span></code> objects) – list of transforms to compose.</p>
-</dd>
-</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>transforms</strong> (list of <code class="docutils literal notranslate"><span class="pre">Transform</span></code> objects) – list of transforms to compose.</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Example</p>
-<div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">Compose</span><span class="p">([</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">Compose</span><span class="p">([</span>
 <span class="gp">&gt;&gt;&gt; </span>    <span class="n">transforms</span><span class="o">.</span><span class="n">CenterCrop</span><span class="p">(</span><span class="mi">10</span><span class="p">),</span>
 <span class="gp">&gt;&gt;&gt; </span>    <span class="n">transforms</span><span class="o">.</span><span class="n">ToTensor</span><span class="p">(),</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="p">])</span>
@@ -366,65 +304,69 @@ This is useful if you have to build a more complex transformation pipeline
 <h2>Transforms on PIL Image<a class="headerlink" href="#transforms-on-pil-image" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.transforms.CenterCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">CenterCrop</code><span class="sig-paren">(</span><em class="sig-param">size</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#CenterCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.CenterCrop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crops the given image at the center.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">CenterCrop</code><span class="sig-paren">(</span><em>size</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#CenterCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.CenterCrop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crops the given PIL Image at the center.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
 int instead of sequence like (h, w), a square crop (size, size) is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p>
-</dd>
-</dl>
+made.</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.ColorJitter">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">ColorJitter</code><span class="sig-paren">(</span><em class="sig-param">brightness=0</em>, <em class="sig-param">contrast=0</em>, <em class="sig-param">saturation=0</em>, <em class="sig-param">hue=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#ColorJitter"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ColorJitter" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">ColorJitter</code><span class="sig-paren">(</span><em>brightness=0</em>, <em>contrast=0</em>, <em>saturation=0</em>, <em>hue=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#ColorJitter"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ColorJitter" title="Permalink to this definition">¶</a></dt>
 <dd><p>Randomly change the brightness, contrast and saturation of an image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>brightness</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter brightness.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>brightness</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter brightness.
 brightness_factor is chosen uniformly from [max(0, 1 - brightness), 1 + brightness]
-or the given [min, max]. Should be non negative numbers.</p></li>
-<li><p><strong>contrast</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter contrast.
+or the given [min, max]. Should be non negative numbers.</li>
+<li><strong>contrast</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter contrast.
 contrast_factor is chosen uniformly from [max(0, 1 - contrast), 1 + contrast]
-or the given [min, max]. Should be non negative numbers.</p></li>
-<li><p><strong>saturation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter saturation.
+or the given [min, max]. Should be non negative numbers.</li>
+<li><strong>saturation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter saturation.
 saturation_factor is chosen uniformly from [max(0, 1 - saturation), 1 + saturation]
-or the given [min, max]. Should be non negative numbers.</p></li>
-<li><p><strong>hue</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter hue.
+or the given [min, max]. Should be non negative numbers.</li>
+<li><strong>hue</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><em>tuple of python:float</em><em> (</em><em>min</em><em>, </em><em>max</em><em>)</em>) – How much to jitter hue.
 hue_factor is chosen uniformly from [-hue, hue] or the given [min, max].
-Should have 0&lt;= hue &lt;= 0.5 or -0.5 &lt;= min &lt;= max &lt;= 0.5.</p></li>
+Should have 0&lt;= hue &lt;= 0.5 or -0.5 &lt;= min &lt;= max &lt;= 0.5.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.FiveCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">FiveCrop</code><span class="sig-paren">(</span><em class="sig-param">size</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#FiveCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.FiveCrop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image into four corners and the central crop.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">FiveCrop</code><span class="sig-paren">(</span><em>size</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#FiveCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.FiveCrop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image into four corners and the central crop</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform returns a tuple of images and there may be a mismatch in the number of
+<p class="first admonition-title">Note</p>
+<p class="last">This transform returns a tuple of images and there may be a mismatch in the number of
 inputs and targets your Dataset returns. See below for an example of how to deal with
 this.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an <code class="docutils literal notranslate"><span class="pre">int</span></code>
-instead of sequence like (h, w), a square crop of size (size, size) is made.
-If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p>
-</dd>
-</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an <code class="docutils literal notranslate"><span class="pre">int</span></code>
+instead of sequence like (h, w), a square crop of size (size, size) is made.</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Example</p>
-<div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">Compose</span><span class="p">([</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">Compose</span><span class="p">([</span>
 <span class="gp">&gt;&gt;&gt; </span>   <span class="n">FiveCrop</span><span class="p">(</span><span class="n">size</span><span class="p">),</span> <span class="c1"># this is a list of PIL Images</span>
 <span class="gp">&gt;&gt;&gt; </span>   <span class="n">Lambda</span><span class="p">(</span><span class="k">lambda</span> <span class="n">crops</span><span class="p">:</span> <span class="n">torch</span><span class="o">.</span><span class="n">stack</span><span class="p">([</span><span class="n">ToTensor</span><span class="p">()(</span><span class="n">crop</span><span class="p">)</span> <span class="k">for</span> <span class="n">crop</span> <span class="ow">in</span> <span class="n">crops</span><span class="p">]))</span> <span class="c1"># returns a 4D tensor</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="p">])</span>
@@ -439,359 +381,356 @@ If provided a tuple or list of length 1, it will be interpreted as (size[0], siz
 
 <dl class="class">
 <dt id="torchvision.transforms.Grayscale">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Grayscale</code><span class="sig-paren">(</span><em class="sig-param">num_output_channels=1</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Grayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Grayscale" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Grayscale</code><span class="sig-paren">(</span><em>num_output_channels=1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Grayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Grayscale" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert image to grayscale.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>num_output_channels</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – (1 or 3) number of channels desired for output image</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><dl class="simple">
-<dt>Grayscale version of the input.</dt><dd><ul class="simple">
-<li><p>If <code class="docutils literal notranslate"><span class="pre">num_output_channels</span> <span class="pre">==</span> <span class="pre">1</span></code> : returned image is single channel</p></li>
-<li><p>If <code class="docutils literal notranslate"><span class="pre">num_output_channels</span> <span class="pre">==</span> <span class="pre">3</span></code> : returned image is 3 channel with r == g == b</p></li>
-</ul>
-</dd>
-</dl>
-</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>num_output_channels</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – (1 or 3) number of channels desired for output image</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Grayscale version of the input.
+- If num_output_channels == 1 : returned image is single channel
+- If num_output_channels == 3 : returned image is 3 channel with r == g == b</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.Pad">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Pad</code><span class="sig-paren">(</span><em class="sig-param">padding</em>, <em class="sig-param">fill=0</em>, <em class="sig-param">padding_mode='constant'</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Pad"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Pad" title="Permalink to this definition">¶</a></dt>
-<dd><p>Pad the given image on all sides with the given “pad” value.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – Padding on each border. If a single int is provided this
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Pad</code><span class="sig-paren">(</span><em>padding</em>, <em>fill=0</em>, <em>padding_mode='constant'</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Pad"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Pad" title="Permalink to this definition">¶</a></dt>
+<dd><p>Pad the given PIL Image on all sides with the given “pad” value.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Padding on each border. If a single int is provided this
 is used to pad all borders. If tuple of length 2 is provided this is the padding
 on left/right and top/bottom respectively. If a tuple of length 4 is provided
-this is the padding for the left, top, right and bottom borders respectively.
-In torchscript mode padding as single int is not supported, use a tuple or
-list of length 1: <code class="docutils literal notranslate"><span class="pre">[padding,</span> <span class="pre">]</span></code>.</p></li>
-<li><p><strong>fill</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Pixel fill value for constant fill. Default is 0. If a tuple of
+this is the padding for the left, top, right and bottom borders
+respectively.</li>
+<li><strong>fill</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Pixel fill value for constant fill. Default is 0. If a tuple of
 length 3, it is used to fill R, G, B channels respectively.
-This value is only used when the padding_mode is constant</p></li>
-<li><p><strong>padding_mode</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – <p>Type of padding. Should be: constant, edge, reflect or symmetric.
-Default is constant. Mode symmetric is not yet supported for Tensor inputs.</p>
+This value is only used when the padding_mode is constant</li>
+<li><strong>padding_mode</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – <p>Type of padding. Should be: constant, edge, reflect or symmetric.
+Default is constant.</p>
 <ul>
-<li><p>constant: pads with a constant value, this value is specified with fill</p></li>
-<li><p>edge: pads with the last value at the edge of the image</p></li>
-<li><p>reflect: pads with reflection of image without repeating the last value on the edge</p>
-<blockquote>
-<div><p>For example, padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
-will result in [3, 2, 1, 2, 3, 4, 3, 2]</p>
-</div></blockquote>
+<li>constant: pads with a constant value, this value is specified with fill</li>
+<li>edge: pads with the last value at the edge of the image</li>
+<li>reflect: pads with reflection of image without repeating the last value on the edge<blockquote>
+<div>For example, padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+will result in [3, 2, 1, 2, 3, 4, 3, 2]</div></blockquote>
 </li>
-<li><p>symmetric: pads with reflection of image repeating the last value on the edge</p>
-<blockquote>
-<div><p>For example, padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
-will result in [2, 1, 1, 2, 3, 4, 4, 3]</p>
-</div></blockquote>
+<li>symmetric: pads with reflection of image repeating the last value on the edge<blockquote>
+<div>For example, padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+will result in [2, 1, 1, 2, 3, 4, 4, 3]</div></blockquote>
 </li>
 </ul>
-</p></li>
+</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomAffine">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomAffine</code><span class="sig-paren">(</span><em class="sig-param">degrees</em>, <em class="sig-param">translate=None</em>, <em class="sig-param">scale=None</em>, <em class="sig-param">shear=None</em>, <em class="sig-param">resample=False</em>, <em class="sig-param">fillcolor=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomAffine"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomAffine" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomAffine</code><span class="sig-paren">(</span><em>degrees</em>, <em>translate=None</em>, <em>scale=None</em>, <em>shear=None</em>, <em>resample=False</em>, <em>fillcolor=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomAffine"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomAffine" title="Permalink to this definition">¶</a></dt>
 <dd><p>Random affine transformation of the image keeping center invariant</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>degrees</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Range of degrees to select from.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>degrees</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Range of degrees to select from.
 If degrees is a number instead of sequence like (min, max), the range of degrees
-will be (-degrees, +degrees). Set to 0 to deactivate rotations.</p></li>
-<li><p><strong>translate</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – tuple of maximum absolute fraction for horizontal
+will be (-degrees, +degrees). Set to 0 to deactivate rotations.</li>
+<li><strong>translate</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – tuple of maximum absolute fraction for horizontal
 and vertical translations. For example translate=(a, b), then horizontal shift
 is randomly sampled in the range -img_width * a &lt; dx &lt; img_width * a and vertical shift is
-randomly sampled in the range -img_height * b &lt; dy &lt; img_height * b. Will not translate by default.</p></li>
-<li><p><strong>scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – scaling factor interval, e.g (a, b), then scale is
-randomly sampled from the range a &lt;= scale &lt;= b. Will keep original scale by default.</p></li>
-<li><p><strong>shear</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Range of degrees to select from.
+randomly sampled in the range -img_height * b &lt; dy &lt; img_height * b. Will not translate by default.</li>
+<li><strong>scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – scaling factor interval, e.g (a, b), then scale is
+randomly sampled from the range a &lt;= scale &lt;= b. Will keep original scale by default.</li>
+<li><strong>shear</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Range of degrees to select from.
 If shear is a number, a shear parallel to the x axis in the range (-shear, +shear)
 will be apllied. Else if shear is a tuple or list of 2 values a shear parallel to the x axis in the
 range (shear[0], shear[1]) will be applied. Else if shear is a tuple or list of 4 values,
 a x-axis shear in (shear[0], shear[1]) and y-axis shear in (shear[2], shear[3]) will be applied.
-Will not apply shear by default</p></li>
-<li><p><strong>resample</strong> (<em>{PIL.Image.NEAREST</em><em>, </em><em>PIL.Image.BILINEAR</em><em>, </em><em>PIL.Image.BICUBIC}</em><em>, </em><em>optional</em>) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
-If omitted, or if the image has mode “1” or “P”, it is set to PIL.Image.NEAREST.</p></li>
-<li><p><strong>fillcolor</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Optional fill color (Tuple for RGB Image And int for grayscale) for the area
-outside the transform in the output image.(Pillow&gt;=5.0.0)</p></li>
+Will not apply shear by default</li>
+<li><strong>resample</strong> (<em>{PIL.Image.NEAREST</em><em>, </em><em>PIL.Image.BILINEAR</em><em>, </em><em>PIL.Image.BICUBIC}</em><em>, </em><em>optional</em>) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
+If omitted, or if the image has mode “1” or “P”, it is set to PIL.Image.NEAREST.</li>
+<li><strong>fillcolor</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Optional fill color (Tuple for RGB Image And int for grayscale) for the area
+outside the transform in the output image.(Pillow&gt;=5.0.0)</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomApply">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomApply</code><span class="sig-paren">(</span><em class="sig-param">transforms</em>, <em class="sig-param">p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomApply"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomApply" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomApply</code><span class="sig-paren">(</span><em>transforms</em>, <em>p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomApply"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomApply" title="Permalink to this definition">¶</a></dt>
 <dd><p>Apply randomly a list of transformations with a given probability</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>transforms</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – list of transformations</p></li>
-<li><p><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>transforms</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – list of transformations</li>
+<li><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomChoice">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomChoice</code><span class="sig-paren">(</span><em class="sig-param">transforms</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomChoice"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomChoice" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomChoice</code><span class="sig-paren">(</span><em>transforms</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomChoice"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomChoice" title="Permalink to this definition">¶</a></dt>
 <dd><p>Apply single transformation randomly picked from a list</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomCrop</code><span class="sig-paren">(</span><em class="sig-param">size</em>, <em class="sig-param">padding=None</em>, <em class="sig-param">pad_if_needed=False</em>, <em class="sig-param">fill=0</em>, <em class="sig-param">padding_mode='constant'</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomCrop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image at a random location.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomCrop</code><span class="sig-paren">(</span><em>size</em>, <em>padding=None</em>, <em>pad_if_needed=False</em>, <em>fill=0</em>, <em>padding_mode='constant'</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomCrop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image at a random location.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
 int instead of sequence like (h, w), a square crop (size, size) is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p></li>
-<li><p><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>sequence</em><em>, </em><em>optional</em>) – Optional padding on each border
-of the image. Default is None. If a single int is provided this
-is used to pad all borders. If tuple of length 2 is provided this is the padding
-on left/right and top/bottom respectively. If a tuple of length 4 is provided
-this is the padding for the left, top, right and bottom borders respectively.
-In torchscript mode padding as single int is not supported, use a tuple or
-list of length 1: <code class="docutils literal notranslate"><span class="pre">[padding,</span> <span class="pre">]</span></code>.</p></li>
-<li><p><strong>pad_if_needed</strong> (<em>boolean</em>) – It will pad the image if smaller than the
+made.</li>
+<li><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>sequence</em><em>, </em><em>optional</em>) – Optional padding on each border
+of the image. Default is None, i.e no padding. If a sequence of length
+4 is provided, it is used to pad left, top, right, bottom borders
+respectively. If a sequence of length 2 is provided, it is used to
+pad left/right, top/bottom borders, respectively.</li>
+<li><strong>pad_if_needed</strong> (<em>boolean</em>) – It will pad the image if smaller than the
 desired size to avoid raising an exception. Since cropping is done
-after padding, the padding seems to be done at a random offset.</p></li>
-<li><p><strong>fill</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Pixel fill value for constant fill. Default is 0. If a tuple of
+after padding, the padding seems to be done at a random offset.</li>
+<li><strong>fill</strong> – Pixel fill value for constant fill. Default is 0. If a tuple of
 length 3, it is used to fill R, G, B channels respectively.
-This value is only used when the padding_mode is constant</p></li>
-<li><p><strong>padding_mode</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a>) – <p>Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.
-Mode symmetric is not yet supported for Tensor inputs.</p>
-<blockquote>
-<div><ul>
-<li><p>constant: pads with a constant value, this value is specified with fill</p></li>
-<li><p>edge: pads with the last value on the edge of the image</p></li>
-<li><p>reflect: pads with reflection of image (without repeating the last value on the edge)</p>
-<blockquote>
-<div><p>padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
-will result in [3, 2, 1, 2, 3, 4, 3, 2]</p>
-</div></blockquote>
+This value is only used when the padding_mode is constant</li>
+<li><strong>padding_mode</strong> – <p>Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.</p>
+<ul>
+<li>constant: pads with a constant value, this value is specified with fill</li>
+<li>edge: pads with the last value on the edge of the image</li>
+<li>reflect: pads with reflection of image (without repeating the last value on the edge)<blockquote>
+<div>padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+will result in [3, 2, 1, 2, 3, 4, 3, 2]</div></blockquote>
 </li>
-<li><p>symmetric: pads with reflection of image (repeating the last value on the edge)</p>
-<blockquote>
-<div><p>padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
-will result in [2, 1, 1, 2, 3, 4, 4, 3]</p>
-</div></blockquote>
+<li>symmetric: pads with reflection of image (repeating the last value on the edge)<blockquote>
+<div>padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+will result in [2, 1, 1, 2, 3, 4, 4, 3]</div></blockquote>
 </li>
 </ul>
-</div></blockquote>
-</p></li>
+</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomGrayscale">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomGrayscale</code><span class="sig-paren">(</span><em class="sig-param">p=0.1</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomGrayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomGrayscale" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomGrayscale</code><span class="sig-paren">(</span><em>p=0.1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomGrayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomGrayscale" title="Permalink to this definition">¶</a></dt>
 <dd><p>Randomly convert image to grayscale with a probability of p (default 0.1).</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability that image should be converted to grayscale.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Grayscale version of the input image with probability p and unchanged
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability that image should be converted to grayscale.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Grayscale version of the input image with probability p and unchanged
 with probability (1-p).
 - If input image is 1 channel: grayscale version is 1 channel
-- If input image is 3 channel: grayscale version is 3 channel with r == g == b</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
+- If input image is 3 channel: grayscale version is 3 channel with r == g == b</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomHorizontalFlip">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomHorizontalFlip</code><span class="sig-paren">(</span><em class="sig-param">p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomHorizontalFlip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomHorizontalFlip" title="Permalink to this definition">¶</a></dt>
-<dd><p>Horizontally flip the given image randomly with a given probability.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being flipped. Default value is 0.5</p>
-</dd>
-</dl>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomHorizontalFlip</code><span class="sig-paren">(</span><em>p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomHorizontalFlip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomHorizontalFlip" title="Permalink to this definition">¶</a></dt>
+<dd><p>Horizontally flip the given PIL Image randomly with a given probability.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being flipped. Default value is 0.5</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomOrder">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomOrder</code><span class="sig-paren">(</span><em class="sig-param">transforms</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomOrder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomOrder" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomOrder</code><span class="sig-paren">(</span><em>transforms</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomOrder"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomOrder" title="Permalink to this definition">¶</a></dt>
 <dd><p>Apply a list of transformations in a random order</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomPerspective">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomPerspective</code><span class="sig-paren">(</span><em class="sig-param">distortion_scale=0.5</em>, <em class="sig-param">p=0.5</em>, <em class="sig-param">interpolation=3</em>, <em class="sig-param">fill=0</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomPerspective"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomPerspective" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomPerspective</code><span class="sig-paren">(</span><em>distortion_scale=0.5</em>, <em>p=0.5</em>, <em>interpolation=3</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomPerspective"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomPerspective" title="Permalink to this definition">¶</a></dt>
 <dd><p>Performs Perspective transformation of the given PIL Image randomly with a given probability.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>interpolation</strong> – Default- Image.BICUBIC</p></li>
-<li><p><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being perspectively transformed. Default value is 0.5</p></li>
-<li><p><strong>distortion_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – it controls the degree of distortion and ranges from 0 to 1. Default value is 0.5.</p></li>
-<li><p><strong>fill</strong> (<em>3-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – RGB pixel fill value for area outside the rotated image.
-If int, it is used for all channels respectively. Default value is 0.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>interpolation</strong> – Default- Image.BICUBIC</li>
+<li><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being perspectively transformed. Default value is 0.5</li>
+<li><strong>distortion_scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – it controls the degree of distortion and ranges from 0 to 1. Default value is 0.5.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomResizedCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomResizedCrop</code><span class="sig-paren">(</span><em class="sig-param">size</em>, <em class="sig-param">scale=(0.08</em>, <em class="sig-param">1.0)</em>, <em class="sig-param">ratio=(0.75</em>, <em class="sig-param">1.3333333333333333)</em>, <em class="sig-param">interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomResizedCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomResizedCrop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image to random size and aspect ratio.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomResizedCrop</code><span class="sig-paren">(</span><em>size</em>, <em>scale=(0.08</em>, <em>1.0)</em>, <em>ratio=(0.75</em>, <em>1.3333333333333333)</em>, <em>interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomResizedCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomResizedCrop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image to random size and aspect ratio.</p>
 <p>A crop of random size (default: of 0.08 to 1.0) of the original size and a random
 aspect ratio (default: of 3/4 to 4/3) of the original aspect ratio is made. This crop
 is finally resized to given size.
 This is popularly used to train the Inception networks.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>size</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><em>sequence</em>) – expected output size of each edge. If size is an
-int instead of sequence like (h, w), a square output size <code class="docutils literal notranslate"><span class="pre">(size,</span> <span class="pre">size)</span></code> is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p></li>
-<li><p><strong>scale</strong> (<em>tuple of python:float</em>) – range of size of the origin size cropped</p></li>
-<li><p><strong>ratio</strong> (<em>tuple of python:float</em>) – range of aspect ratio of the origin aspect ratio cropped.</p></li>
-<li><p><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired interpolation enum defined by <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a>.
-Default is <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>. If input is Tensor, only <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>, <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>
-and <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code> are supported.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>size</strong> – expected output size of each edge</li>
+<li><strong>scale</strong> – range of size of the origin size cropped</li>
+<li><strong>ratio</strong> – range of aspect ratio of the origin aspect ratio cropped</li>
+<li><strong>interpolation</strong> – Default: PIL.Image.BILINEAR</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomRotation">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomRotation</code><span class="sig-paren">(</span><em class="sig-param">degrees</em>, <em class="sig-param">resample=False</em>, <em class="sig-param">expand=False</em>, <em class="sig-param">center=None</em>, <em class="sig-param">fill=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomRotation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomRotation" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomRotation</code><span class="sig-paren">(</span><em>degrees</em>, <em>resample=False</em>, <em>expand=False</em>, <em>center=None</em>, <em>fill=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomRotation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomRotation" title="Permalink to this definition">¶</a></dt>
 <dd><p>Rotate the image by angle.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>degrees</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Range of degrees to select from.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>degrees</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Range of degrees to select from.
 If degrees is a number instead of sequence like (min, max), the range of degrees
-will be (-degrees, +degrees).</p></li>
-<li><p><strong>resample</strong> (<em>{PIL.Image.NEAREST</em><em>, </em><em>PIL.Image.BILINEAR</em><em>, </em><em>PIL.Image.BICUBIC}</em><em>, </em><em>optional</em>) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
-If omitted, or if the image has mode “1” or “P”, it is set to PIL.Image.NEAREST.</p></li>
-<li><p><strong>expand</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – Optional expansion flag.
+will be (-degrees, +degrees).</li>
+<li><strong>resample</strong> (<em>{PIL.Image.NEAREST</em><em>, </em><em>PIL.Image.BILINEAR</em><em>, </em><em>PIL.Image.BICUBIC}</em><em>, </em><em>optional</em>) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
+If omitted, or if the image has mode “1” or “P”, it is set to PIL.Image.NEAREST.</li>
+<li><strong>expand</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – Optional expansion flag.
 If true, expands the output to make it large enough to hold the entire rotated image.
 If false or omitted, make the output image the same size as the input image.
-Note that the expand flag assumes rotation around the center and no translation.</p></li>
-<li><p><strong>center</strong> (<em>2-tuple</em><em>, </em><em>optional</em>) – Optional center of rotation.
+Note that the expand flag assumes rotation around the center and no translation.</li>
+<li><strong>center</strong> (<em>2-tuple</em><em>, </em><em>optional</em>) – Optional center of rotation.
 Origin is the upper left corner.
-Default is the center of the image.</p></li>
-<li><p><strong>fill</strong> (<em>n-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – Pixel fill value for area outside the rotated
-image. If int or float, the value is used for all bands respectively.
-Defaults to 0 for all bands. This option is only available for <code class="docutils literal notranslate"><span class="pre">pillow&gt;=5.2.0</span></code>.</p></li>
+Default is the center of the image.</li>
+<li><strong>fill</strong> (<em>3-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – RGB pixel fill value for area outside the rotated image.
+If int, it is used for all channels respectively.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomSizedCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomSizedCrop</code><span class="sig-paren">(</span><em class="sig-param">*args</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomSizedCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomSizedCrop" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomSizedCrop</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomSizedCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomSizedCrop" title="Permalink to this definition">¶</a></dt>
 <dd><p>Note: This transform is deprecated in favor of RandomResizedCrop.</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomVerticalFlip">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomVerticalFlip</code><span class="sig-paren">(</span><em class="sig-param">p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomVerticalFlip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomVerticalFlip" title="Permalink to this definition">¶</a></dt>
-<dd><p>Vertically flip the given image randomly with a given probability.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being flipped. Default value is 0.5</p>
-</dd>
-</dl>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomVerticalFlip</code><span class="sig-paren">(</span><em>p=0.5</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomVerticalFlip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomVerticalFlip" title="Permalink to this definition">¶</a></dt>
+<dd><p>Vertically flip the given PIL Image randomly with a given probability.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>p</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – probability of the image being flipped. Default value is 0.5</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.Resize">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Resize</code><span class="sig-paren">(</span><em class="sig-param">size</em>, <em class="sig-param">interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Resize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Resize" title="Permalink to this definition">¶</a></dt>
-<dd><p>Resize the input image to the given size.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. If size is a sequence like
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Resize</code><span class="sig-paren">(</span><em>size</em>, <em>interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Resize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Resize" title="Permalink to this definition">¶</a></dt>
+<dd><p>Resize the input PIL Image to the given size.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. If size is a sequence like
 (h, w), output size will be matched to this. If size is an int,
 smaller edge of the image will be matched to this number.
 i.e, if height &gt; width, then image will be rescaled to
-(size * height / width, size).
-In torchscript mode padding as single int is not supported, use a tuple or
-list of length 1: <code class="docutils literal notranslate"><span class="pre">[size,</span> <span class="pre">]</span></code>.</p></li>
-<li><p><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation enum defined by <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a>.
-Default is <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>. If input is Tensor, only <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>, <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>
-and <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code> are supported.</p></li>
+(size * height / width, size)</li>
+<li><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation. Default is
+<code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code></li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.Scale">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Scale</code><span class="sig-paren">(</span><em class="sig-param">*args</em>, <em class="sig-param">**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Scale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Scale" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Scale</code><span class="sig-paren">(</span><em>*args</em>, <em>**kwargs</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Scale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Scale" title="Permalink to this definition">¶</a></dt>
 <dd><p>Note: This transform is deprecated in favor of Resize.</p>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.TenCrop">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">TenCrop</code><span class="sig-paren">(</span><em class="sig-param">size</em>, <em class="sig-param">vertical_flip=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#TenCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.TenCrop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image into four corners and the central crop plus the flipped version of
-these (horizontal flipping is used by default).
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">TenCrop</code><span class="sig-paren">(</span><em>size</em>, <em>vertical_flip=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#TenCrop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.TenCrop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image into four corners and the central crop plus the flipped version of
+these (horizontal flipping is used by default)</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform returns a tuple of images and there may be a mismatch in the number of
+<p class="first admonition-title">Note</p>
+<p class="last">This transform returns a tuple of images and there may be a mismatch in the number of
 inputs and targets your Dataset returns. See below for an example of how to deal with
 this.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
 int instead of sequence like (h, w), a square crop (size, size) is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p></li>
-<li><p><strong>vertical_flip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – Use vertical flipping instead of horizontal</p></li>
+made.</li>
+<li><strong>vertical_flip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – Use vertical flipping instead of horizontal</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Example</p>
-<div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">Compose</span><span class="p">([</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">Compose</span><span class="p">([</span>
 <span class="gp">&gt;&gt;&gt; </span>   <span class="n">TenCrop</span><span class="p">(</span><span class="n">size</span><span class="p">),</span> <span class="c1"># this is a list of PIL Images</span>
 <span class="gp">&gt;&gt;&gt; </span>   <span class="n">Lambda</span><span class="p">(</span><span class="k">lambda</span> <span class="n">crops</span><span class="p">:</span> <span class="n">torch</span><span class="o">.</span><span class="n">stack</span><span class="p">([</span><span class="n">ToTensor</span><span class="p">()(</span><span class="n">crop</span><span class="p">)</span> <span class="k">for</span> <span class="n">crop</span> <span class="ow">in</span> <span class="n">crops</span><span class="p">]))</span> <span class="c1"># returns a 4D tensor</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="p">])</span>
@@ -809,96 +748,112 @@ made. If provided a tuple or list of length 1, it will be interpreted as (size[0
 <h2>Transforms on torch.*Tensor<a class="headerlink" href="#transforms-on-torch-tensor" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.transforms.LinearTransformation">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">LinearTransformation</code><span class="sig-paren">(</span><em class="sig-param">transformation_matrix</em>, <em class="sig-param">mean_vector</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#LinearTransformation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.LinearTransformation" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">LinearTransformation</code><span class="sig-paren">(</span><em>transformation_matrix</em>, <em>mean_vector</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#LinearTransformation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.LinearTransformation" title="Permalink to this definition">¶</a></dt>
 <dd><p>Transform a tensor image with a square transformation matrix and a mean_vector computed
 offline.
 Given transformation_matrix and mean_vector, will flatten the torch.*Tensor and
 subtract mean_vector from it which is then followed by computing the dot
 product with the transformation matrix and then reshaping the tensor to its
 original shape.</p>
-<dl class="simple">
-<dt>Applications:</dt><dd><p>whitening transformation: Suppose X is a column vector zero-centered data.
+<dl class="docutils">
+<dt>Applications:</dt>
+<dd>whitening transformation: Suppose X is a column vector zero-centered data.
 Then compute the data covariance matrix [D x D] with torch.mm(X.t(), X),
-perform SVD on this matrix and pass it as transformation_matrix.</p>
-</dd>
+perform SVD on this matrix and pass it as transformation_matrix.</dd>
 </dl>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>transformation_matrix</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – tensor [D x D], D = C x H x W</p></li>
-<li><p><strong>mean_vector</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – tensor [D], D = C x H x W</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>transformation_matrix</strong> (<em>Tensor</em>) – tensor [D x D], D = C x H x W</li>
+<li><strong>mean_vector</strong> (<em>Tensor</em>) – tensor [D], D = C x H x W</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.Normalize">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Normalize</code><span class="sig-paren">(</span><em class="sig-param">mean</em>, <em class="sig-param">std</em>, <em class="sig-param">inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Normalize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Normalize" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Normalize</code><span class="sig-paren">(</span><em>mean</em>, <em>std</em>, <em>inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Normalize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Normalize" title="Permalink to this definition">¶</a></dt>
 <dd><p>Normalize a tensor image with mean and standard deviation.
-Given mean: <code class="docutils literal notranslate"><span class="pre">(mean[1],...,mean[n])</span></code> and std: <code class="docutils literal notranslate"><span class="pre">(std[1],..,std[n])</span></code> for <code class="docutils literal notranslate"><span class="pre">n</span></code>
-channels, this transform will normalize each channel of the input
-<code class="docutils literal notranslate"><span class="pre">torch.*Tensor</span></code> i.e.,
-<code class="docutils literal notranslate"><span class="pre">output[channel]</span> <span class="pre">=</span> <span class="pre">(input[channel]</span> <span class="pre">-</span> <span class="pre">mean[channel])</span> <span class="pre">/</span> <span class="pre">std[channel]</span></code></p>
+Given mean: <code class="docutils literal notranslate"><span class="pre">(M1,...,Mn)</span></code> and std: <code class="docutils literal notranslate"><span class="pre">(S1,..,Sn)</span></code> for <code class="docutils literal notranslate"><span class="pre">n</span></code> channels, this transform
+will normalize each channel of the input <code class="docutils literal notranslate"><span class="pre">torch.*Tensor</span></code> i.e.
+<code class="docutils literal notranslate"><span class="pre">input[channel]</span> <span class="pre">=</span> <span class="pre">(input[channel]</span> <span class="pre">-</span> <span class="pre">mean[channel])</span> <span class="pre">/</span> <span class="pre">std[channel]</span></code></p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform acts out of place, i.e., it does not mutate the input tensor.</p>
+<p class="first admonition-title">Note</p>
+<p class="last">This transform acts out of place, i.e., it does not mutates the input tensor.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>mean</strong> (<em>sequence</em>) – Sequence of means for each channel.</p></li>
-<li><p><strong>std</strong> (<em>sequence</em>) – Sequence of standard deviations for each channel.</p></li>
-<li><p><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – Bool to make this operation in-place.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>mean</strong> (<em>sequence</em>) – Sequence of means for each channel.</li>
+<li><strong>std</strong> (<em>sequence</em>) – Sequence of standard deviations for each channel.</li>
+<li><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – Bool to make this operation in-place.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.transforms.Normalize.__call__">
-<code class="sig-name descname">__call__</code><span class="sig-paren">(</span><em class="sig-param">tensor</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Normalize.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Normalize.__call__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>tensor</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Tensor image of size (C, H, W) to be normalized.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Normalized Tensor image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+<code class="descname">__call__</code><span class="sig-paren">(</span><em>tensor</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Normalize.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Normalize.__call__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>tensor</strong> (<em>Tensor</em>) – Tensor image of size (C, H, W) to be normalized.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Normalized Tensor image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">Tensor</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.RandomErasing">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">RandomErasing</code><span class="sig-paren">(</span><em class="sig-param">p=0.5</em>, <em class="sig-param">scale=(0.02</em>, <em class="sig-param">0.33)</em>, <em class="sig-param">ratio=(0.3</em>, <em class="sig-param">3.3)</em>, <em class="sig-param">value=0</em>, <em class="sig-param">inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#RandomErasing"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomErasing" title="Permalink to this definition">¶</a></dt>
-<dd><p>Randomly selects a rectangle region in an image and erases its pixels.
-‘Random Erasing Data Augmentation’ by Zhong et al. See <a class="reference external" href="https://arxiv.org/pdf/1708.04896.pdf">https://arxiv.org/pdf/1708.04896.pdf</a></p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>p</strong> – probability that the random erasing operation will be performed.</p></li>
-<li><p><strong>scale</strong> – range of proportion of erased area against input image.</p></li>
-<li><p><strong>ratio</strong> – range of aspect ratio of erased area.</p></li>
-<li><p><strong>value</strong> – erasing value. Default is 0. If a single int, it is used to
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">RandomErasing</code><span class="sig-paren">(</span><em>p=0.5</em>, <em>scale=(0.02</em>, <em>0.33)</em>, <em>ratio=(0.3</em>, <em>3.3)</em>, <em>value=0</em>, <em>inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#RandomErasing"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.RandomErasing" title="Permalink to this definition">¶</a></dt>
+<dd><dl class="docutils">
+<dt>Randomly selects a rectangle region in an image and erases its pixels.</dt>
+<dd>‘Random Erasing Data Augmentation’ by Zhong et al.
+See <a class="reference external" href="https://arxiv.org/pdf/1708.04896.pdf">https://arxiv.org/pdf/1708.04896.pdf</a></dd>
+</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>p</strong> – probability that the random erasing operation will be performed.</li>
+<li><strong>scale</strong> – range of proportion of erased area against input image.</li>
+<li><strong>ratio</strong> – range of aspect ratio of erased area.</li>
+<li><strong>value</strong> – erasing value. Default is 0. If a single int, it is used to
 erase all pixels. If a tuple of length 3, it is used to erase
 R, G, B channels respectively.
-If a str of ‘random’, erasing each pixel with random values.</p></li>
-<li><p><strong>inplace</strong> – boolean to make this transform inplace. Default set to False.</p></li>
+If a str of ‘random’, erasing each pixel with random values.</li>
+<li><strong>inplace</strong> – boolean to make this transform inplace. Default set to False.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Erased Image.</p>
-</dd>
-</dl>
-<dl>
-<dt># Examples:</dt><dd><div class="doctest highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">transforms</span><span class="o">.</span><span class="n">Compose</span><span class="p">([</span>
-<span class="gp">&gt;&gt;&gt; </span>  <span class="n">transforms</span><span class="o">.</span><span class="n">RandomHorizontalFlip</span><span class="p">(),</span>
-<span class="gp">&gt;&gt;&gt; </span>  <span class="n">transforms</span><span class="o">.</span><span class="n">ToTensor</span><span class="p">(),</span>
-<span class="gp">&gt;&gt;&gt; </span>  <span class="n">transforms</span><span class="o">.</span><span class="n">Normalize</span><span class="p">((</span><span class="mf">0.485</span><span class="p">,</span> <span class="mf">0.456</span><span class="p">,</span> <span class="mf">0.406</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.229</span><span class="p">,</span> <span class="mf">0.224</span><span class="p">,</span> <span class="mf">0.225</span><span class="p">)),</span>
-<span class="gp">&gt;&gt;&gt; </span>  <span class="n">transforms</span><span class="o">.</span><span class="n">RandomErasing</span><span class="p">(),</span>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">Erased Image.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<dl class="docutils">
+<dt># Examples:</dt>
+<dd><div class="first last highlight-default notranslate"><div class="highlight"><pre><span></span><span class="gp">&gt;&gt;&gt; </span><span class="n">transform</span> <span class="o">=</span> <span class="n">transforms</span><span class="o">.</span><span class="n">Compose</span><span class="p">([</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">RandomHorizontalFlip</span><span class="p">(),</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">ToTensor</span><span class="p">(),</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">Normalize</span><span class="p">((</span><span class="mf">0.485</span><span class="p">,</span> <span class="mf">0.456</span><span class="p">,</span> <span class="mf">0.406</span><span class="p">),</span> <span class="p">(</span><span class="mf">0.229</span><span class="p">,</span> <span class="mf">0.224</span><span class="p">,</span> <span class="mf">0.225</span><span class="p">)),</span>
+<span class="gp">&gt;&gt;&gt; </span><span class="n">transforms</span><span class="o">.</span><span class="n">RandomErasing</span><span class="p">(),</span>
 <span class="gp">&gt;&gt;&gt; </span><span class="p">])</span>
 </pre></div>
 </div>
@@ -911,47 +866,51 @@ If a str of ‘random’, erasing each pixel with random values.</p></li>
 <h2>Conversion Transforms<a class="headerlink" href="#conversion-transforms" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.transforms.ToPILImage">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">ToPILImage</code><span class="sig-paren">(</span><em class="sig-param">mode=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#ToPILImage"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToPILImage" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">ToPILImage</code><span class="sig-paren">(</span><em>mode=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#ToPILImage"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToPILImage" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert a tensor or an ndarray to PIL Image.</p>
 <p>Converts a torch.*Tensor of shape C x H x W or a numpy ndarray of shape
 H x W x C to a PIL Image while preserving the value range.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>mode</strong> (<a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#concept-modes">PIL.Image mode</a>) – <p>color space and pixel depth of input data (optional).
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>mode</strong> (<a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#concept-modes">PIL.Image mode</a>) – <p>color space and pixel depth of input data (optional).
 If <code class="docutils literal notranslate"><span class="pre">mode</span></code> is <code class="docutils literal notranslate"><span class="pre">None</span></code> (default) there are some assumptions made about the input data:</p>
 <blockquote>
 <div><ul class="simple">
-<li><p>If the input has 4 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">RGBA</span></code>.</p></li>
-<li><p>If the input has 3 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">RGB</span></code>.</p></li>
-<li><p>If the input has 2 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">LA</span></code>.</p></li>
-<li><p>If the input has 1 channel, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is determined by the data type (i.e <code class="docutils literal notranslate"><span class="pre">int</span></code>, <code class="docutils literal notranslate"><span class="pre">float</span></code>,
-<code class="docutils literal notranslate"><span class="pre">short</span></code>).</p></li>
+<li>If the input has 4 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">RGBA</span></code>.</li>
+<li>If the input has 3 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">RGB</span></code>.</li>
+<li>If the input has 2 channels, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is assumed to be <code class="docutils literal notranslate"><span class="pre">LA</span></code>.</li>
+<li>If the input has 1 channel, the <code class="docutils literal notranslate"><span class="pre">mode</span></code> is determined by the data type (i.e <code class="docutils literal notranslate"><span class="pre">int</span></code>, <code class="docutils literal notranslate"><span class="pre">float</span></code>,
+<code class="docutils literal notranslate"><span class="pre">short</span></code>).</li>
 </ul>
 </div></blockquote>
-</p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <dl class="method">
 <dt id="torchvision.transforms.ToPILImage.__call__">
-<code class="sig-name descname">__call__</code><span class="sig-paren">(</span><em class="sig-param">pic</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#ToPILImage.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToPILImage.__call__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>pic</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to PIL Image.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Image converted to PIL Image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
+<code class="descname">__call__</code><span class="sig-paren">(</span><em>pic</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#ToPILImage.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToPILImage.__call__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>pic</strong> (<em>Tensor</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to PIL Image.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Image converted to PIL Image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
 
 <dl class="class">
 <dt id="torchvision.transforms.ToTensor">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">ToTensor</code><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#ToTensor"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToTensor" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">ToTensor</code><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#ToTensor"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToTensor" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert a <code class="docutils literal notranslate"><span class="pre">PIL</span> <span class="pre">Image</span></code> or <code class="docutils literal notranslate"><span class="pre">numpy.ndarray</span></code> to tensor.</p>
 <p>Converts a PIL Image or numpy.ndarray (H x W x C) in the range
 [0, 255] to a torch.FloatTensor of shape (C x H x W) in the range [0.0, 1.0]
@@ -960,18 +919,19 @@ or if the numpy.ndarray has dtype = np.uint8</p>
 <p>In the other cases, tensors are returned without scaling.</p>
 <dl class="method">
 <dt id="torchvision.transforms.ToTensor.__call__">
-<code class="sig-name descname">__call__</code><span class="sig-paren">(</span><em class="sig-param">pic</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#ToTensor.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToTensor.__call__" title="Permalink to this definition">¶</a></dt>
-<dd><dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>pic</strong> (<em>PIL Image</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to tensor.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Converted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+<code class="descname">__call__</code><span class="sig-paren">(</span><em>pic</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#ToTensor.__call__"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.ToTensor.__call__" title="Permalink to this definition">¶</a></dt>
+<dd><table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>pic</strong> (<em>PIL Image</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to tensor.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Converted image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">Tensor</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </dd></dl>
@@ -981,13 +941,16 @@ or if the numpy.ndarray has dtype = np.uint8</p>
 <h2>Generic Transforms<a class="headerlink" href="#generic-transforms" title="Permalink to this headline">¶</a></h2>
 <dl class="class">
 <dt id="torchvision.transforms.Lambda">
-<em class="property">class </em><code class="sig-prename descclassname">torchvision.transforms.</code><code class="sig-name descname">Lambda</code><span class="sig-paren">(</span><em class="sig-param">lambd</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/transforms.html#Lambda"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Lambda" title="Permalink to this definition">¶</a></dt>
+<em class="property">class </em><code class="descclassname">torchvision.transforms.</code><code class="descname">Lambda</code><span class="sig-paren">(</span><em>lambd</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/transforms.html#Lambda"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.Lambda" title="Permalink to this definition">¶</a></dt>
 <dd><p>Apply a user-defined lambda as a transform.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>lambd</strong> (<em>function</em>) – Lambda/function to be used for transform.</p>
-</dd>
-</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>lambd</strong> (<em>function</em>) – Lambda/function to be used for transform.</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -999,7 +962,7 @@ generator for their parameters.
 That means you have to specify/generate all parameters, but you can reuse the functional transform.</p>
 <p>Example:
 you can apply a functional transform with the same parameters to multiple images like this:</p>
-<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.transforms.functional</span> <span class="k">as</span> <span class="nn">TF</span>
+<div class="code python highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.transforms.functional</span> <span class="k">as</span> <span class="nn">TF</span>
 <span class="kn">import</span> <span class="nn">random</span>
 
 <span class="k">def</span> <span class="nf">my_segmentation_transforms</span><span class="p">(</span><span class="n">image</span><span class="p">,</span> <span class="n">segmentation</span><span class="p">):</span>
@@ -1013,16 +976,16 @@ you can apply a functional transform with the same parameters to multiple images
 </div>
 <p>Example:
 you can use a functional transform to build transform classes with custom behavior:</p>
-<div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.transforms.functional</span> <span class="k">as</span> <span class="nn">TF</span>
+<div class="code python highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">import</span> <span class="nn">torchvision.transforms.functional</span> <span class="k">as</span> <span class="nn">TF</span>
 <span class="kn">import</span> <span class="nn">random</span>
 
 <span class="k">class</span> <span class="nc">MyRotationTransform</span><span class="p">:</span>
     <span class="sd">&quot;&quot;&quot;Rotate by one of the given angles.&quot;&quot;&quot;</span>
 
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">angles</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">angles</span><span class="p">):</span>
         <span class="bp">self</span><span class="o">.</span><span class="n">angles</span> <span class="o">=</span> <span class="n">angles</span>
 
-    <span class="k">def</span> <span class="fm">__call__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">x</span><span class="p">):</span>
+    <span class="k">def</span> <span class="nf">__call__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">x</span><span class="p">):</span>
         <span class="n">angle</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="n">choice</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">angles</span><span class="p">)</span>
         <span class="k">return</span> <span class="n">TF</span><span class="o">.</span><span class="n">rotate</span><span class="p">(</span><span class="n">x</span><span class="p">,</span> <span class="n">angle</span><span class="p">)</span>
 
@@ -1031,82 +994,85 @@ you can use a functional transform to build transform classes with custom behavi
 </div>
 <span class="target" id="module-torchvision.transforms.functional"></span><dl class="function">
 <dt id="torchvision.transforms.functional.adjust_brightness">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">adjust_brightness</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">brightness_factor: float</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#adjust_brightness"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_brightness" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">adjust_brightness</code><span class="sig-paren">(</span><em>img</em>, <em>brightness_factor</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#adjust_brightness"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_brightness" title="Permalink to this definition">¶</a></dt>
 <dd><p>Adjust brightness of an Image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be adjusted.</p></li>
-<li><p><strong>brightness_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the brightness. Can be
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</li>
+<li><strong>brightness_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the brightness. Can be
 any non negative number. 0 gives a black image, 1 gives the
-original image while 2 increases the brightness by a factor of 2.</p></li>
+original image while 2 increases the brightness by a factor of 2.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Brightness adjusted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Brightness adjusted image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.adjust_contrast">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">adjust_contrast</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">contrast_factor: float</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#adjust_contrast"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_contrast" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">adjust_contrast</code><span class="sig-paren">(</span><em>img</em>, <em>contrast_factor</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#adjust_contrast"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_contrast" title="Permalink to this definition">¶</a></dt>
 <dd><p>Adjust contrast of an Image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be adjusted.</p></li>
-<li><p><strong>contrast_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the contrast. Can be any
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</li>
+<li><strong>contrast_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the contrast. Can be any
 non negative number. 0 gives a solid gray image, 1 gives the
-original image while 2 increases the contrast by a factor of 2.</p></li>
+original image while 2 increases the contrast by a factor of 2.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Contrast adjusted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Contrast adjusted image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.adjust_gamma">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">adjust_gamma</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">gamma: float</em>, <em class="sig-param">gain: float = 1</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#adjust_gamma"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_gamma" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">adjust_gamma</code><span class="sig-paren">(</span><em>img</em>, <em>gamma</em>, <em>gain=1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#adjust_gamma"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_gamma" title="Permalink to this definition">¶</a></dt>
 <dd><p>Perform gamma correction on an image.</p>
 <p>Also known as Power Law Transform. Intensities in RGB mode are adjusted
 based on the following equation:</p>
-<div class="math">
-<span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><msub><mi>I</mi><mtext>out</mtext></msub><mo>=</mo><mn>2</mn><mn>5</mn><mn>5</mn><mo>×</mo><mtext>gain</mtext><mo>×</mo><msup><mrow><mo fence="true">(</mo><mfrac><mrow><msub><mi>I</mi><mtext>in</mtext></msub></mrow><mrow><mn>2</mn><mn>5</mn><mn>5</mn></mrow></mfrac><mo fence="true">)</mo></mrow><mi>γ</mi></msup></mrow><annotation encoding="application/x-tex">I_{\text{out}} = 255 \times \text{gain} \times \left(\frac{I_{\text{in}}}{255}\right)^{\gamma}
-
-</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:1.5042920000000002em;"></span><span class="strut bottom" style="height:2.4543220000000003em;vertical-align:-0.95003em;"></span><span class="base"><span class="mord"><span class="mord mathit" style="margin-right:0.07847em;">I</span><span class="msupsub"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:0.2805559999999999em;"><span style="top:-2.5500000000000003em;margin-left:-0.07847em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord text mtight"><span class="mord mathrm mtight">out</span></span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height:0.15em;"></span></span></span></span></span><span class="mrel">=</span><span class="mord mathrm">2</span><span class="mord mathrm">5</span><span class="mord mathrm">5</span><span class="mbin">×</span><span class="mord text"><span class="mord mathrm">gain</span></span><span class="mbin">×</span><span class="minner"><span class="minner"><span class="mopen delimcenter" style="top:0em;"><span class="delimsizing size3">(</span></span><span class="mord"><span class="mopen nulldelimiter"></span><span class="mfrac"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:1.36033em;"><span style="top:-2.314em;"><span class="pstrut" style="height:3em;"></span><span class="mord"><span class="mord mathrm">2</span><span class="mord mathrm">5</span><span class="mord mathrm">5</span></span></span><span style="top:-3.23em;"><span class="pstrut" style="height:3em;"></span><span class="frac-line" style="border-bottom-width:0.04em;"></span></span><span style="top:-3.677em;"><span class="pstrut" style="height:3em;"></span><span class="mord"><span class="mord"><span class="mord mathit" style="margin-right:0.07847em;">I</span><span class="msupsub"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:0.31750199999999995em;"><span style="top:-2.5500000000000003em;margin-left:-0.07847em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord text mtight"><span class="mord mathrm mtight">in</span></span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height:0.15em;"></span></span></span></span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height:0.686em;"></span></span></span></span><span class="mclose nulldelimiter"></span></span><span class="mclose delimcenter" style="top:0em;"><span class="delimsizing size3">)</span></span></span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:1.5042920000000002em;"><span style="top:-3.9029000000000007em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mathit mtight" style="margin-right:0.05556em;">γ</span></span></span></span></span></span></span></span></span></span></span></span></span>
-</div><p>See <a class="reference external" href="https://en.wikipedia.org/wiki/Gamma_correction">Gamma Correction</a> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – PIL Image to be adjusted.</p></li>
-<li><p><strong>gamma</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – Non negative real number, same as <span class="math"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>γ</mi></mrow><annotation encoding="application/x-tex">\gamma</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:0.43056em;"></span><span class="strut bottom" style="height:0.625em;vertical-align:-0.19444em;"></span><span class="base"><span class="mord mathit" style="margin-right:0.05556em;">γ</span></span></span></span>
-</span> in the equation.
+<div class="math notranslate nohighlight">
+\[I_{\text{out}} = 255 \times \text{gain} \times \left(\frac{I_{\text{in}}}{255}\right)^{\gamma}\]</div>
+<p>See <a class="reference external" href="https://en.wikipedia.org/wiki/Gamma_correction">Gamma Correction</a> for more details.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</li>
+<li><strong>gamma</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – Non negative real number, same as <span class="math notranslate nohighlight">\(\gamma\)</span> in the equation.
 gamma larger than 1 make the shadows darker,
-while gamma smaller than 1 make dark regions lighter.</p></li>
-<li><p><strong>gain</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – The constant multiplier.</p></li>
+while gamma smaller than 1 make dark regions lighter.</li>
+<li><strong>gain</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – The constant multiplier.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Gamma correction adjusted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.adjust_hue">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">adjust_hue</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">hue_factor: float</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#adjust_hue"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_hue" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">adjust_hue</code><span class="sig-paren">(</span><em>img</em>, <em>hue_factor</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#adjust_hue"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_hue" title="Permalink to this definition">¶</a></dt>
 <dd><p>Adjust hue of an image.</p>
 <p>The image hue is adjusted by converting the image to HSV and
 cyclically shifting the intensities in the hue channel (H).
@@ -1114,564 +1080,529 @@ The image is then converted back to original image mode.</p>
 <p><cite>hue_factor</cite> is the amount of shift in H channel and must be in the
 interval <cite>[-0.5, 0.5]</cite>.</p>
 <p>See <a class="reference external" href="https://en.wikipedia.org/wiki/Hue">Hue</a> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</p></li>
-<li><p><strong>hue_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to shift the hue channel. Should be in
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</li>
+<li><strong>hue_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to shift the hue channel. Should be in
 [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
 HSV space in positive and negative direction respectively.
 0 means no shift. Therefore, both -0.5 and 0.5 will give an image
-with complementary colors while 0 gives the original image.</p></li>
+with complementary colors while 0 gives the original image.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Hue adjusted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Hue adjusted image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.adjust_saturation">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">adjust_saturation</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">saturation_factor: float</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#adjust_saturation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_saturation" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">adjust_saturation</code><span class="sig-paren">(</span><em>img</em>, <em>saturation_factor</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#adjust_saturation"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.adjust_saturation" title="Permalink to this definition">¶</a></dt>
 <dd><p>Adjust color saturation of an image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be adjusted.</p></li>
-<li><p><strong>saturation_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the saturation. 0 will
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be adjusted.</li>
+<li><strong>saturation_factor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – How much to adjust the saturation. 0 will
 give a black and white image, 1 will give the original image while
-2 will enhance the saturation by a factor of 2.</p></li>
+2 will enhance the saturation by a factor of 2.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Saturation adjusted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Saturation adjusted image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.affine">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">affine</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, angle: float, translate: List[int], scale: float, shear: List[float], resample: int = 0, fillcolor: Optional[int] = None</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#affine"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.affine" title="Permalink to this definition">¶</a></dt>
-<dd><p>Apply affine transformation on the image keeping image center invariant.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – image to be rotated.</p></li>
-<li><p><strong>angle</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – rotation angle in degrees between -180 and 180, clockwise direction.</p></li>
-<li><p><strong>translate</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em> or </em><em>tuple of python:integers</em>) – horizontal and vertical translations (post-rotation translation)</p></li>
-<li><p><strong>scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – overall scale</p></li>
-<li><p><strong>shear</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – shear angle value in degrees between -180 to 180, clockwise direction.
-If a tuple of list is specified, the first value corresponds to a shear parallel to the x axis, while
-the second value corresponds to a shear parallel to the y axis.</p></li>
-<li><p><strong>resample</strong> (<code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code>, optional) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
-If omitted, or if the image is PIL Image and has mode “1” or “P”, it is set to <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>.
-If input is Tensor, only <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code> and <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code> are supported.</p></li>
-<li><p><strong>fillcolor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Optional fill color for the area outside the transform in the output image. (Pillow&gt;=5.0.0)</p></li>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">affine</code><span class="sig-paren">(</span><em>img</em>, <em>angle</em>, <em>translate</em>, <em>scale</em>, <em>shear</em>, <em>resample=0</em>, <em>fillcolor=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#affine"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.affine" title="Permalink to this definition">¶</a></dt>
+<dd><p>Apply affine transformation on the image keeping image center invariant</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be rotated.</li>
+<li><strong>angle</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – rotation angle in degrees between -180 and 180, clockwise direction.</li>
+<li><strong>translate</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a><em> or </em><em>tuple of python:integers</em>) – horizontal and vertical translations (post-rotation translation)</li>
+<li><strong>scale</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – overall scale</li>
+<li><strong>shear</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – shear angle value in degrees between -180 to 180, clockwise direction.</li>
+<li><strong>a tuple of list is specified, the first value corresponds to a shear parallel to the x axis, while</strong> (<em>If</em>) – </li>
+<li><strong>second value corresponds to a shear parallel to the y axis.</strong> (<em>the</em>) – </li>
+<li><strong>resample</strong> (<code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code>, optional) – An optional resampling filter.
+See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
+If omitted, or if the image has mode “1” or “P”, it is set to <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>.</li>
+<li><strong>fillcolor</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Optional fill color for the area outside the transform in the output image. (Pillow&gt;=5.0.0)</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Transformed image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.center_crop">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">center_crop</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, output_size: List[int]</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#center_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.center_crop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crops the given image at the center.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be cropped.</p></li>
-<li><p><strong>output_size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – (height, width) of the crop box. If int or sequence with single int
-it is used for both directions.</p></li>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">center_crop</code><span class="sig-paren">(</span><em>img</em>, <em>output_size</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#center_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.center_crop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image and resize it to desired size.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – Image to be cropped. (0,0) denotes the top left corner of the image.</li>
+<li><strong>output_size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – (height, width) of the crop box. If int,
+it is used for both directions</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Cropped image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
-</dd></dl>
-
-<dl class="function">
-<dt id="torchvision.transforms.functional.convert_image_dtype">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">convert_image_dtype</code><span class="sig-paren">(</span><em class="sig-param">image: torch.Tensor</em>, <em class="sig-param">dtype: torch.dtype = torch.float32</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#convert_image_dtype"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.convert_image_dtype" title="Permalink to this definition">¶</a></dt>
-<dd><p>Convert a tensor image to the given <code class="docutils literal notranslate"><span class="pre">dtype</span></code> and scale the values accordingly</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>image</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>torch.Tensor</em></a>) – Image to be converted</p></li>
-<li><p><strong>dtype</strong> (<em>torch.dpython:type</em>) – Desired data type of the output</p></li>
-</ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Converted image</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>(<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">torch.Tensor</a>)</p>
-</dd>
-</dl>
-<div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>When converting from a smaller to a larger integer <code class="docutils literal notranslate"><span class="pre">dtype</span></code> the maximum values are <strong>not</strong> mapped exactly.
-If converted back and forth, this mismatch has no effect.</p>
-</div>
-<dl class="field-list simple">
-<dt class="field-odd">Raises</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/exceptions.html#RuntimeError" title="(in Python v3.8)"><strong>RuntimeError</strong></a> – When trying to cast <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.float32</span></code> to <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.int32</span></code> or <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.int64</span></code> as
-    well as for trying to cast <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.float64</span></code> to <code class="xref py py-class docutils literal notranslate"><span class="pre">torch.int64</span></code>. These conversions might lead to
-    overflow errors since the floating point <code class="docutils literal notranslate"><span class="pre">dtype</span></code> cannot store consecutive integers over the whole range
-    of the integer <code class="docutils literal notranslate"><span class="pre">dtype</span></code>.</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Cropped image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.crop">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">crop</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">top: int</em>, <em class="sig-param">left: int</em>, <em class="sig-param">height: int</em>, <em class="sig-param">width: int</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.crop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image at specified location and output size.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading
-dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be cropped. (0,0) denotes the top left corner of the image.</p></li>
-<li><p><strong>top</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Vertical component of the top left corner of the crop box.</p></li>
-<li><p><strong>left</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Horizontal component of the top left corner of the crop box.</p></li>
-<li><p><strong>height</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Height of the crop box.</p></li>
-<li><p><strong>width</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Width of the crop box.</p></li>
-</ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Cropped image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">crop</code><span class="sig-paren">(</span><em>img</em>, <em>top</em>, <em>left</em>, <em>height</em>, <em>width</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.crop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image.
+:param img: Image to be cropped. (0,0) denotes the top left corner of the image.
+:type img: PIL Image
+:param top: Vertical component of the top left corner of the crop box.
+:type top: int
+:param left: Horizontal component of the top left corner of the crop box.
+:type left: int
+:param height: Height of the crop box.
+:type height: int
+:param width: Width of the crop box.
+:type width: int</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Cropped image.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.erase">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">erase</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em>, <em class="sig-param">i: int</em>, <em class="sig-param">j: int</em>, <em class="sig-param">h: int</em>, <em class="sig-param">w: int</em>, <em class="sig-param">v: torch.Tensor</em>, <em class="sig-param">inplace: bool = False</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#erase"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.erase" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">erase</code><span class="sig-paren">(</span><em>img</em>, <em>i</em>, <em>j</em>, <em>h</em>, <em>w</em>, <em>v</em>, <em>inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#erase"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.erase" title="Permalink to this definition">¶</a></dt>
 <dd><p>Erase the input Tensor Image with given value.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>Tensor Image</em>) – Tensor image of size (C, H, W) to be erased</p></li>
-<li><p><strong>i</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – i in (i,j) i.e coordinates of the upper left corner.</p></li>
-<li><p><strong>j</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – j in (i,j) i.e coordinates of the upper left corner.</p></li>
-<li><p><strong>h</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Height of the erased region.</p></li>
-<li><p><strong>w</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Width of the erased region.</p></li>
-<li><p><strong>v</strong> – Erasing value.</p></li>
-<li><p><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – For in-place operations. By default is set False.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>Tensor Image</em>) – Tensor image of size (C, H, W) to be erased</li>
+<li><strong>i</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – i in (i,j) i.e coordinates of the upper left corner.</li>
+<li><strong>j</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – j in (i,j) i.e coordinates of the upper left corner.</li>
+<li><strong>h</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Height of the erased region.</li>
+<li><strong>w</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Width of the erased region.</li>
+<li><strong>v</strong> – Erasing value.</li>
+<li><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – For in-place operations. By default is set False.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Erased image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>Tensor Image</p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Erased image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">Tensor Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.five_crop">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">five_crop</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, size: List[int]</em><span class="sig-paren">)</span> &#x2192; Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#five_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.five_crop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image into four corners and the central crop.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">five_crop</code><span class="sig-paren">(</span><em>img</em>, <em>size</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#five_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.five_crop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image into four corners and the central crop.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform returns a tuple of images and there may be a
+<p class="first admonition-title">Note</p>
+<p class="last">This transform returns a tuple of images and there may be a
 mismatch in the number of inputs and targets your <code class="docutils literal notranslate"><span class="pre">Dataset</span></code> returns.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be cropped.</p></li>
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
 int instead of sequence like (h, w), a square crop (size, size) is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p></li>
-</ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><dl class="simple">
-<dt>tuple (tl, tr, bl, br, center)</dt><dd><p>Corresponding top left, top right, bottom left, bottom right and center crop.</p>
-</dd>
+made.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><dl class="docutils">
+<dt>tuple (tl, tr, bl, br, center)</dt>
+<dd>Corresponding top left, top right, bottom left, bottom right and center crop.</dd>
 </dl>
-</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.hflip">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">hflip</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#hflip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.hflip" title="Permalink to this definition">¶</a></dt>
-<dd><p>Horizontally flip the given PIL Image or Tensor.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be flipped. If img
-is a Tensor, it is expected to be in […, H, W] format,
-where … means it can have an arbitrary number of trailing
-dimensions.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Horizontally flipped image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">hflip</code><span class="sig-paren">(</span><em>img</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#hflip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.hflip" title="Permalink to this definition">¶</a></dt>
+<dd><p>Horizontally flip the given PIL Image.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>img</strong> (<em>PIL Image</em>) – Image to be flipped.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Horizontall flipped image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.normalize">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">normalize</code><span class="sig-paren">(</span><em class="sig-param">tensor</em>, <em class="sig-param">mean</em>, <em class="sig-param">std</em>, <em class="sig-param">inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#normalize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.normalize" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">normalize</code><span class="sig-paren">(</span><em>tensor</em>, <em>mean</em>, <em>std</em>, <em>inplace=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#normalize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.normalize" title="Permalink to this definition">¶</a></dt>
 <dd><p>Normalize a tensor image with mean and standard deviation.</p>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform acts out of place by default, i.e., it does not mutates the input tensor.</p>
+<p class="first admonition-title">Note</p>
+<p class="last">This transform acts out of place by default, i.e., it does not mutates the input tensor.</p>
 </div>
 <p>See <a class="reference internal" href="#torchvision.transforms.Normalize" title="torchvision.transforms.Normalize"><code class="xref py py-class docutils literal notranslate"><span class="pre">Normalize</span></code></a> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>tensor</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Tensor image of size (C, H, W) to be normalized.</p></li>
-<li><p><strong>mean</strong> (<em>sequence</em>) – Sequence of means for each channel.</p></li>
-<li><p><strong>std</strong> (<em>sequence</em>) – Sequence of standard deviations for each channel.</p></li>
-<li><p><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – Bool to make this operation inplace.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>tensor</strong> (<em>Tensor</em>) – Tensor image of size (C, H, W) to be normalized.</li>
+<li><strong>mean</strong> (<em>sequence</em>) – Sequence of means for each channel.</li>
+<li><strong>std</strong> (<em>sequence</em>) – Sequence of standard deviations for each channel.</li>
+<li><strong>inplace</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>,</em><em>optional</em>) – Bool to make this operation inplace.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Normalized Tensor image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Normalized Tensor image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">Tensor</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.pad">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">pad</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, padding: List[int], fill: int = 0, padding_mode: str = 'constant'</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#pad"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.pad" title="Permalink to this definition">¶</a></dt>
-<dd><p>Pad the given image on all sides with the given “pad” value.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be padded.</p></li>
-<li><p><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – Padding on each border. If a single int is provided this
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">pad</code><span class="sig-paren">(</span><em>img</em>, <em>padding</em>, <em>fill=0</em>, <em>padding_mode='constant'</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#pad"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.pad" title="Permalink to this definition">¶</a></dt>
+<dd><p>Pad the given PIL Image on all sides with specified padding mode and fill value.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – Image to be padded.</li>
+<li><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Padding on each border. If a single int is provided this
 is used to pad all borders. If tuple of length 2 is provided this is the padding
 on left/right and top/bottom respectively. If a tuple of length 4 is provided
-this is the padding for the left, top, right and bottom borders respectively.
-In torchscript mode padding as single int is not supported, use a tuple or
-list of length 1: <code class="docutils literal notranslate"><span class="pre">[padding,</span> <span class="pre">]</span></code>.</p></li>
-<li><p><strong>fill</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.8)"><em>str</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a>) – Pixel fill value for constant fill. Default is 0. If a tuple of
+this is the padding for the left, top, right and bottom borders
+respectively.</li>
+<li><strong>fill</strong> – Pixel fill value for constant fill. Default is 0. If a tuple of
 length 3, it is used to fill R, G, B channels respectively.
-This value is only used when the padding_mode is constant. Only int value is supported for Tensors.</p></li>
-<li><p><strong>padding_mode</strong> – <p>Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.
-Mode symmetric is not yet supported for Tensor inputs.</p>
+This value is only used when the padding_mode is constant</li>
+<li><strong>padding_mode</strong> – <p>Type of padding. Should be: constant, edge, reflect or symmetric. Default is constant.</p>
 <ul>
-<li><p>constant: pads with a constant value, this value is specified with fill</p></li>
-<li><p>edge: pads with the last value on the edge of the image</p></li>
-<li><p>reflect: pads with reflection of image (without repeating the last value on the edge)</p>
-<blockquote>
-<div><p>padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
-will result in [3, 2, 1, 2, 3, 4, 3, 2]</p>
-</div></blockquote>
+<li>constant: pads with a constant value, this value is specified with fill</li>
+<li>edge: pads with the last value on the edge of the image</li>
+<li>reflect: pads with reflection of image (without repeating the last value on the edge)<blockquote>
+<div>padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+will result in [3, 2, 1, 2, 3, 4, 3, 2]</div></blockquote>
 </li>
-<li><p>symmetric: pads with reflection of image (repeating the last value on the edge)</p>
-<blockquote>
-<div><p>padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
-will result in [2, 1, 1, 2, 3, 4, 4, 3]</p>
-</div></blockquote>
+<li>symmetric: pads with reflection of image (repeating the last value on the edge)<blockquote>
+<div>padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+will result in [2, 1, 1, 2, 3, 4, 4, 3]</div></blockquote>
 </li>
 </ul>
-</p></li>
+</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Padded image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Padded image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.perspective">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">perspective</code><span class="sig-paren">(</span><em class="sig-param">img</em>, <em class="sig-param">startpoints</em>, <em class="sig-param">endpoints</em>, <em class="sig-param">interpolation=3</em>, <em class="sig-param">fill=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#perspective"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.perspective" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">perspective</code><span class="sig-paren">(</span><em>img</em>, <em>startpoints</em>, <em>endpoints</em>, <em>interpolation=3</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#perspective"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.perspective" title="Permalink to this definition">¶</a></dt>
 <dd><p>Perform perspective transform of the given PIL Image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em>) – Image to be transformed.</p></li>
-<li><p><strong>startpoints</strong> – List containing [top-left, top-right, bottom-right, bottom-left] of the original image</p></li>
-<li><p><strong>endpoints</strong> – List containing [top-left, top-right, bottom-right, bottom-left] of the transformed image</p></li>
-<li><p><strong>interpolation</strong> – Default- Image.BICUBIC</p></li>
-<li><p><strong>fill</strong> (<em>n-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – Pixel fill value for area outside the rotated
-image. If int or float, the value is used for all bands respectively.
-This option is only available for <code class="docutils literal notranslate"><span class="pre">pillow&gt;=5.0.0</span></code>.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – Image to be transformed.</li>
+<li><strong>startpoints</strong> – List containing [top-left, top-right, bottom-right, bottom-left] of the orignal image</li>
+<li><strong>endpoints</strong> – List containing [top-left, top-right, bottom-right, bottom-left] of the transformed image</li>
+<li><strong>interpolation</strong> – Default- Image.BICUBIC</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Perspectively transformed Image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
-</dd></dl>
-
-<dl class="function">
-<dt id="torchvision.transforms.functional.pil_to_tensor">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">pil_to_tensor</code><span class="sig-paren">(</span><em class="sig-param">pic</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#pil_to_tensor"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.pil_to_tensor" title="Permalink to this definition">¶</a></dt>
-<dd><p>Convert a <code class="docutils literal notranslate"><span class="pre">PIL</span> <span class="pre">Image</span></code> to a tensor of the same type.</p>
-<p>See <code class="docutils literal notranslate"><span class="pre">AsTensor</span></code> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>pic</strong> (<em>PIL Image</em>) – Image to be converted to tensor.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Converted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Perspectively transformed Image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.resize">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">resize</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, size: List[int], interpolation: int = 2</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#resize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.resize" title="Permalink to this definition">¶</a></dt>
-<dd><p>Resize the input image to the given size.
-The image can be a PIL Image or a torch Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be resized.</p></li>
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. If size is a sequence like
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">resize</code><span class="sig-paren">(</span><em>img</em>, <em>size</em>, <em>interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#resize"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.resize" title="Permalink to this definition">¶</a></dt>
+<dd><p>Resize the input PIL Image to the given size.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – Image to be resized.</li>
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. If size is a sequence like
 (h, w), the output size will be matched to this. If size is an int,
-the smaller edge of the image will be matched to this number maintaining
+the smaller edge of the image will be matched to this number maintaing
 the aspect ratio. i.e, if height &gt; width, then image will be rescaled to
-<span class="math"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mrow><mo fence="true">(</mo><mtext>size</mtext><mo>×</mo><mfrac><mrow><mtext>height</mtext></mrow><mrow><mtext>width</mtext></mrow></mfrac><mo separator="true">,</mo><mtext>size</mtext><mo fence="true">)</mo></mrow></mrow><annotation encoding="application/x-tex">\left(\text{size} \times \frac{\text{height}}{\text{width}}, \text{size}\right)</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:1.15em;"></span><span class="strut bottom" style="height:1.80002em;vertical-align:-0.65002em;"></span><span class="base"><span class="minner"><span class="mopen delimcenter" style="top:0em;"><span class="delimsizing size2">(</span></span><span class="mord text"><span class="mord mathrm">size</span></span><span class="mbin">×</span><span class="mord"><span class="mopen nulldelimiter"></span><span class="mfrac"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:0.9322159999999999em;"><span style="top:-2.6550000000000002em;"><span class="pstrut" style="height:3em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord text mtight"><span class="mord mathrm mtight">width</span></span></span></span></span><span style="top:-3.23em;"><span class="pstrut" style="height:3em;"></span><span class="frac-line" style="border-bottom-width:0.04em;"></span></span><span style="top:-3.446108em;"><span class="pstrut" style="height:3em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord text mtight"><span class="mord mathrm mtight">height</span></span></span></span></span></span><span class="vlist-s">​</span></span><span class="vlist-r"><span class="vlist" style="height:0.345em;"></span></span></span></span><span class="mclose nulldelimiter"></span></span><span class="mpunct">,</span><span class="mord text"><span class="mord mathrm">size</span></span><span class="mclose delimcenter" style="top:0em;"><span class="delimsizing size2">)</span></span></span></span></span></span>
-</span>.
-In torchscript mode padding as single int is not supported, use a tuple or
-list of length 1: <code class="docutils literal notranslate"><span class="pre">[size,</span> <span class="pre">]</span></code>.</p></li>
-<li><p><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation enum defined by <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a>.
-Default is <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>. If input is Tensor, only <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>, <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>
-and <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code> are supported.</p></li>
+<span class="math notranslate nohighlight">\(\left(\text{size} \times \frac{\text{height}}{\text{width}}, \text{size}\right)\)</span></li>
+<li><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation. Default is
+<code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code></li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Resized image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Resized image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.resized_crop">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">resized_crop</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, top: int, left: int, height: int, width: int, size: List[int], interpolation: int = 2</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#resized_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.resized_crop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Crop the given image and resize it to desired size.
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">resized_crop</code><span class="sig-paren">(</span><em>img</em>, <em>top</em>, <em>left</em>, <em>height</em>, <em>width</em>, <em>size</em>, <em>interpolation=2</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#resized_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.resized_crop" title="Permalink to this definition">¶</a></dt>
+<dd><p>Crop the given PIL Image and resize it to desired size.</p>
 <p>Notably used in <a class="reference internal" href="#torchvision.transforms.RandomResizedCrop" title="torchvision.transforms.RandomResizedCrop"><code class="xref py py-class docutils literal notranslate"><span class="pre">RandomResizedCrop</span></code></a>.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be cropped. (0,0) denotes the top left corner of the image.</p></li>
-<li><p><strong>top</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Vertical component of the top left corner of the crop box.</p></li>
-<li><p><strong>left</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Horizontal component of the top left corner of the crop box.</p></li>
-<li><p><strong>height</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Height of the crop box.</p></li>
-<li><p><strong>width</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Width of the crop box.</p></li>
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. Same semantics as <code class="docutils literal notranslate"><span class="pre">resize</span></code>.</p></li>
-<li><p><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation enum defined by <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a>.
-Default is <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>. If input is Tensor, only <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>, <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>
-and <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code> are supported.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – Image to be cropped. (0,0) denotes the top left corner of the image.</li>
+<li><strong>top</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Vertical component of the top left corner of the crop box.</li>
+<li><strong>left</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Horizontal component of the top left corner of the crop box.</li>
+<li><strong>height</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Height of the crop box.</li>
+<li><strong>width</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Width of the crop box.</li>
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size. Same semantics as <code class="docutils literal notranslate"><span class="pre">resize</span></code>.</li>
+<li><strong>interpolation</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Desired interpolation. Default is
+<code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code>.</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Cropped image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image or <a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first">Cropped image.</p>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last">PIL Image</p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.rotate">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">rotate</code><span class="sig-paren">(</span><em class="sig-param">img</em>, <em class="sig-param">angle</em>, <em class="sig-param">resample=False</em>, <em class="sig-param">expand=False</em>, <em class="sig-param">center=None</em>, <em class="sig-param">fill=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#rotate"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.rotate" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">rotate</code><span class="sig-paren">(</span><em>img</em>, <em>angle</em>, <em>resample=False</em>, <em>expand=False</em>, <em>center=None</em>, <em>fill=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#rotate"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.rotate" title="Permalink to this definition">¶</a></dt>
 <dd><p>Rotate the image by angle.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be rotated.</p></li>
-<li><p><strong>angle</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – In degrees degrees counter clockwise order.</p></li>
-<li><p><strong>resample</strong> (<code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code>, optional) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
-If omitted, or if the image has mode “1” or “P”, it is set to <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>.</p></li>
-<li><p><strong>expand</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – Optional expansion flag.
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>img</strong> (<em>PIL Image</em>) – PIL Image to be rotated.</li>
+<li><strong>angle</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – In degrees degrees counter clockwise order.</li>
+<li><strong>resample</strong> (<code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BILINEAR</span></code> or <code class="docutils literal notranslate"><span class="pre">PIL.Image.BICUBIC</span></code>, optional) – An optional resampling filter. See <a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters">filters</a> for more information.
+If omitted, or if the image has mode “1” or “P”, it is set to <code class="docutils literal notranslate"><span class="pre">PIL.Image.NEAREST</span></code>.</li>
+<li><strong>expand</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – Optional expansion flag.
 If true, expands the output image to make it large enough to hold the entire rotated image.
 If false or omitted, make the output image the same size as the input image.
-Note that the expand flag assumes rotation around the center and no translation.</p></li>
-<li><p><strong>center</strong> (<em>2-tuple</em><em>, </em><em>optional</em>) – Optional center of rotation.
+Note that the expand flag assumes rotation around the center and no translation.</li>
+<li><strong>center</strong> (<em>2-tuple</em><em>, </em><em>optional</em>) – Optional center of rotation.
 Origin is the upper left corner.
-Default is the center of the image.</p></li>
-<li><p><strong>fill</strong> (<em>n-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a>) – Pixel fill value for area outside the rotated
-image. If int or float, the value is used for all bands respectively.
-Defaults to 0 for all bands. This option is only available for <code class="docutils literal notranslate"><span class="pre">pillow&gt;=5.2.0</span></code>.</p></li>
+Default is the center of the image.</li>
+<li><strong>fill</strong> (<em>3-tuple</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – RGB pixel fill value for area outside the rotated image.
+If int, it is used for all channels respectively.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.ten_crop">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">ten_crop</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor, size: List[int], vertical_flip: bool = False</em><span class="sig-paren">)</span> &#x2192; List[torch.Tensor]<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#ten_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.ten_crop" title="Permalink to this definition">¶</a></dt>
-<dd><p>Generate ten cropped images from the given image.
-Crop the given image into four corners and the central crop plus the
-flipped version of these (horizontal flipping is used by default).
-The image can be a PIL Image or a Tensor, in which case it is expected
-to have […, H, W] shape, where … means an arbitrary number of leading dimensions</p>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">ten_crop</code><span class="sig-paren">(</span><em>img</em>, <em>size</em>, <em>vertical_flip=False</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#ten_crop"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.ten_crop" title="Permalink to this definition">¶</a></dt>
+<dd><dl class="docutils">
+<dt>Crop the given PIL Image into four corners and the central crop plus the</dt>
+<dd>flipped version of these (horizontal flipping is used by default).</dd>
+</dl>
 <div class="admonition note">
-<p class="admonition-title">Note</p>
-<p>This transform returns a tuple of images and there may be a
+<p class="first admonition-title">Note</p>
+<p class="last">This transform returns a tuple of images and there may be a
 mismatch in the number of inputs and targets your <code class="docutils literal notranslate"><span class="pre">Dataset</span></code> returns.</p>
 </div>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be cropped.</p></li>
-<li><p><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>size</strong> (<em>sequence</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a>) – Desired output size of the crop. If size is an
 int instead of sequence like (h, w), a square crop (size, size) is
-made. If provided a tuple or list of length 1, it will be interpreted as (size[0], size[0]).</p></li>
-<li><p><strong>vertical_flip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – Use vertical flipping instead of horizontal</p></li>
+made.</li>
+<li><strong>vertical_flip</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a>) – Use vertical flipping instead of horizontal</li>
 </ul>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><dl class="simple">
-<dt>tuple (tl, tr, bl, br, center, tl_flip, tr_flip, bl_flip, br_flip, center_flip)</dt><dd><p>Corresponding top left, top right, bottom left, bottom right and
-center crop and same for the flipped image.</p>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first"><dl class="docutils">
+<dt>tuple (tl, tr, bl, br, center, tl_flip, tr_flip, bl_flip, br_flip, center_flip)</dt>
+<dd><p class="first last">Corresponding top left, top right, bottom left, bottom right and center crop
+and same for the flipped image.</p>
 </dd>
 </dl>
 </p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
-</dd>
-</dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last"><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)">tuple</a></p>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.to_grayscale">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">to_grayscale</code><span class="sig-paren">(</span><em class="sig-param">img</em>, <em class="sig-param">num_output_channels=1</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#to_grayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_grayscale" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">to_grayscale</code><span class="sig-paren">(</span><em>img</em>, <em>num_output_channels=1</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#to_grayscale"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_grayscale" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert image to grayscale version of image.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>img</strong> (<em>PIL Image</em>) – Image to be converted to grayscale.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p><dl>
-<dt>Grayscale version of the image.</dt><dd><p>if num_output_channels = 1 : returned image is single channel</p>
-<p>if num_output_channels = 3 : returned image is 3 channel with r = g = b</p>
-</dd>
-</dl>
-</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>img</strong> (<em>PIL Image</em>) – Image to be converted to grayscale.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><dl class="docutils">
+<dt>Grayscale version of the image.</dt>
+<dd>if num_output_channels = 1 : returned image is single channel<p class="last">if num_output_channels = 3 : returned image is 3 channel with r = g = b</p>
 </dd>
 </dl>
+</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.to_pil_image">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">to_pil_image</code><span class="sig-paren">(</span><em class="sig-param">pic</em>, <em class="sig-param">mode=None</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#to_pil_image"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_pil_image" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">to_pil_image</code><span class="sig-paren">(</span><em>pic</em>, <em>mode=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#to_pil_image"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_pil_image" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert a tensor or an ndarray to PIL Image.</p>
 <p>See <a class="reference internal" href="#torchvision.transforms.ToPILImage" title="torchvision.transforms.ToPILImage"><code class="xref py py-class docutils literal notranslate"><span class="pre">ToPILImage</span></code></a> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>pic</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to PIL Image.</p></li>
-<li><p><strong>mode</strong> (<a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#concept-modes">PIL.Image mode</a>) – color space and pixel depth of input data (optional).</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>pic</strong> (<em>Tensor</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to PIL Image.</li>
+<li><strong>mode</strong> (<a class="reference external" href="https://pillow.readthedocs.io/en/latest/handbook/concepts.html#concept-modes">PIL.Image mode</a>) – color space and pixel depth of input data (optional).</li>
 </ul>
-</dd>
-</dl>
-<dl class="field-list simple">
-<dt class="field-odd">Returns</dt>
-<dd class="field-odd"><p>Image converted to PIL Image.</p>
-</dd>
-<dt class="field-even">Return type</dt>
-<dd class="field-even"><p>PIL Image</p>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">Image converted to PIL Image.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.to_tensor">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">to_tensor</code><span class="sig-paren">(</span><em class="sig-param">pic</em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/torchvision/transforms/functional.html#to_tensor"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_tensor" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">to_tensor</code><span class="sig-paren">(</span><em>pic</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#to_tensor"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.to_tensor" title="Permalink to this definition">¶</a></dt>
 <dd><p>Convert a <code class="docutils literal notranslate"><span class="pre">PIL</span> <span class="pre">Image</span></code> or <code class="docutils literal notranslate"><span class="pre">numpy.ndarray</span></code> to tensor.</p>
 <p>See <code class="docutils literal notranslate"><span class="pre">ToTensor</span></code> for more details.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>pic</strong> (<em>PIL Image</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to tensor.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Converted image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor">Tensor</a></p>
-</dd>
-</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>pic</strong> (<em>PIL Image</em><em> or </em><a class="reference external" href="https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html#numpy.ndarray" title="(in NumPy v1.19)"><em>numpy.ndarray</em></a>) – Image to be converted to tensor.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Converted image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">Tensor</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.transforms.functional.vflip">
-<code class="sig-prename descclassname">torchvision.transforms.functional.</code><code class="sig-name descname">vflip</code><span class="sig-paren">(</span><em class="sig-param">img: torch.Tensor</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/transforms/functional.html#vflip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.vflip" title="Permalink to this definition">¶</a></dt>
-<dd><p>Vertically flip the given PIL Image or torch Tensor.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><p><strong>img</strong> (<em>PIL Image</em><em> or </em><a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a>) – Image to be flipped. If img
-is a Tensor, it is expected to be in […, H, W] format,
-where … means it can have an arbitrary number of trailing
-dimensions.</p>
-</dd>
-<dt class="field-even">Returns</dt>
-<dd class="field-even"><p>Vertically flipped image.</p>
-</dd>
-<dt class="field-odd">Return type</dt>
-<dd class="field-odd"><p>PIL Image</p>
-</dd>
-</dl>
+<code class="descclassname">torchvision.transforms.functional.</code><code class="descname">vflip</code><span class="sig-paren">(</span><em>img</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/transforms/functional.html#vflip"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.transforms.functional.vflip" title="Permalink to this definition">¶</a></dt>
+<dd><p>Vertically flip the given PIL Image.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>img</strong> (<em>PIL Image</em>) – Image to be flipped.</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body">Vertically flipped image.</td>
+</tr>
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body">PIL Image</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -1685,10 +1616,10 @@ dimensions.</p>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="utils.html" class="btn btn-neutral float-right" title="torchvision.utils" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="utils.html" class="btn btn-neutral float-right" title="torchvision.utils" accesskey="n" rel="next">Next <img src="_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="ops.html" class="btn btn-neutral" title="torchvision.ops" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="ops.html" class="btn btn-neutral" title="torchvision.ops" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -1701,7 +1632,7 @@ dimensions.</p>
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -1742,50 +1673,35 @@ dimensions.</p>
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -1891,7 +1807,7 @@ dimensions.</p>
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -1958,7 +1874,7 @@ dimensions.</p>
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {

--- a/docs/stable/torchvision/utils.html
+++ b/docs/stable/torchvision/utils.html
@@ -6,17 +6,26 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', 'UA-90545585-1']);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+    </script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>torchvision.utils &mdash; PyTorch 1.6.0 documentation</title>
+  <title>torchvision.utils &mdash; Torchvision master documentation</title>
   
 
   
   
   
-  
-    <link rel="canonical" href="https://pytorch.org/docs/stable/torchvision/utils.html"/>
   
 
   
@@ -27,28 +36,23 @@
 
   
 
-  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
-  <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-    <link rel="index" title="Index" href="../genindex.html" />
-    <link rel="search" title="Search" href="../search.html" />
-    <link rel="next" title="PyTorch Contribution Guide" href="../community/contribution_guide.html" />
+  <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
+  <!-- <link rel="stylesheet" href="_static/pygments.css" type="text/css" /> -->
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
     <link rel="prev" title="torchvision.transforms" href="transforms.html" /> 
 
   
-  <script src="../_static/js/modernizr.min.js"></script>
+  <script src="_static/js/modernizr.min.js"></script>
 
   <!-- Preload the theme fonts -->
 
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<link rel="preload" href="../_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-book.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-Medium.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/FreightSans/freight-sans-medium-italic.woff2" as="font" type="font/woff2" crossorigin="anonymous">
+<link rel="preload" href="_static/fonts/IBMPlexMono/IBMPlexMono-SemiBold.woff2" as="font" type="font/woff2" crossorigin="anonymous">
 
 <!-- Preload the katex fonts -->
 
@@ -159,7 +163,7 @@
               
               
                 <div class="version">
-                  <a href='http://pytorch.org/docs/versions.html'>1.6.0 &#x25BC</a>
+                  master (0.5.0 )
                 </div>
               
             
@@ -171,7 +175,7 @@
 
 
 <div role="search">
-  <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
+  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
     <input type="text" name="q" placeholder="Search Docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
@@ -182,91 +186,23 @@
           </div>
 
           
-
-
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">Automatic Mixed Precision examples</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/broadcasting.html">Broadcasting semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cpu_threading_torchscript_inference.html">CPU threading and TorchScript inference</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/cuda.html">CUDA semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/ddp.html">Distributed Data Parallel</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/extending.html">Extending PyTorch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/faq.html">Frequently Asked Questions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/large_scale_deployments.html">Features for large-scale deployments</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/multiprocessing.html">Multiprocessing best practices</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/randomness.html">Reproducibility</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.functional.html">torch.nn.functional</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensors.html">torch.Tensor</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_attributes.html">Tensor Attributes</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensor_view.html">Tensor Views</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../autograd.html">torch.autograd</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cuda.html">torch.cuda</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../amp.html">torch.cuda.amp</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributed.html">torch.distributed</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../distributions.html">torch.distributions</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../futures.html">torch.futures</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../hub.html">torch.hub</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../complex_numbers.html">Complex Numbers</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../bottleneck.html">torch.utils.bottleneck</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../tensorboard.html">torch.utils.tensorboard</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../type_info.html">Type Info</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../named_tensor.html">Named Tensors</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../__config__.html">torch.__config__</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+              <p class="caption"><span class="caption-text">Package Reference</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio">torchaudio</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text">torchtext</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html">torchvision</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/elastic/">TorchElastic</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://pytorch.org/serve">TorchServe</a></li>
-<li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul>
-<li class="toctree-l1"><a class="reference internal" href="../community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="datasets.html">torchvision.datasets</a></li>
+<li class="toctree-l1"><a class="reference internal" href="io.html">torchvision.io</a></li>
+<li class="toctree-l1"><a class="reference internal" href="models.html">torchvision.models</a></li>
+<li class="toctree-l1"><a class="reference internal" href="ops.html">torchvision.ops</a></li>
+<li class="toctree-l1"><a class="reference internal" href="transforms.html">torchvision.transforms</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">torchvision.utils</a></li>
 </ul>
 
             
           
-
         </div>
       </div>
     </nav>
@@ -295,7 +231,7 @@
   <ul class="pytorch-breadcrumbs">
     
       <li>
-        <a href="../index.html">
+        <a href="index.html">
           
             Docs
           
@@ -303,15 +239,13 @@
       </li>
 
         
-          <li><a href="index.html">torchvision</a> &gt;</li>
-        
       <li>torchvision.utils</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/torchvision/utils.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="_sources/utils.rst.txt" rel="nofollow"><img src="_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -341,47 +275,55 @@
 <h1>torchvision.utils<a class="headerlink" href="#torchvision-utils" title="Permalink to this headline">¶</a></h1>
 <dl class="function">
 <dt id="torchvision.utils.make_grid">
-<code class="sig-prename descclassname">torchvision.utils.</code><code class="sig-name descname">make_grid</code><span class="sig-paren">(</span><em class="sig-param">tensor: Union[torch.Tensor, List[torch.Tensor]], nrow: int = 8, padding: int = 2, normalize: bool = False, range: Optional[Tuple[int, int]] = None, scale_each: bool = False, pad_value: int = 0</em><span class="sig-paren">)</span> &#x2192; torch.Tensor<a class="reference internal" href="../_modules/torchvision/utils.html#make_grid"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.utils.make_grid" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.utils.</code><code class="descname">make_grid</code><span class="sig-paren">(</span><em>tensor</em>, <em>nrow=8</em>, <em>padding=2</em>, <em>normalize=False</em>, <em>range=None</em>, <em>scale_each=False</em>, <em>pad_value=0</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/utils.html#make_grid"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.utils.make_grid" title="Permalink to this definition">¶</a></dt>
 <dd><p>Make a grid of images.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>tensor</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – 4D mini-batch Tensor of shape (B x C x H x W)
-or a list of images all of the same size.</p></li>
-<li><p><strong>nrow</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Number of images displayed in each row of the grid.
-The final grid size is <code class="docutils literal notranslate"><span class="pre">(B</span> <span class="pre">/</span> <span class="pre">nrow,</span> <span class="pre">nrow)</span></code>. Default: <code class="docutils literal notranslate"><span class="pre">8</span></code>.</p></li>
-<li><p><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – amount of padding. Default: <code class="docutils literal notranslate"><span class="pre">2</span></code>.</p></li>
-<li><p><strong>normalize</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, shift the image to the range (0, 1),
-by the min and max values specified by <code class="xref py py-attr docutils literal notranslate"><span class="pre">range</span></code>. Default: <code class="docutils literal notranslate"><span class="pre">False</span></code>.</p></li>
-<li><p><strong>range</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – tuple (min, max) where min and max are numbers,
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>tensor</strong> (<em>Tensor</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – 4D mini-batch Tensor of shape (B x C x H x W)
+or a list of images all of the same size.</li>
+<li><strong>nrow</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – Number of images displayed in each row of the grid.
+The final grid size is <code class="docutils literal notranslate"><span class="pre">(B</span> <span class="pre">/</span> <span class="pre">nrow,</span> <span class="pre">nrow)</span></code>. Default: <code class="docutils literal notranslate"><span class="pre">8</span></code>.</li>
+<li><strong>padding</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#int" title="(in Python v3.8)"><em>int</em></a><em>, </em><em>optional</em>) – amount of padding. Default: <code class="docutils literal notranslate"><span class="pre">2</span></code>.</li>
+<li><strong>normalize</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If True, shift the image to the range (0, 1),
+by the min and max values specified by <code class="xref py py-attr docutils literal notranslate"><span class="pre">range</span></code>. Default: <code class="docutils literal notranslate"><span class="pre">False</span></code>.</li>
+<li><strong>range</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#tuple" title="(in Python v3.8)"><em>tuple</em></a><em>, </em><em>optional</em>) – tuple (min, max) where min and max are numbers,
 then these numbers are used to normalize the image. By default, min and max
-are computed from the tensor.</p></li>
-<li><p><strong>scale_each</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, scale each image in the batch of
-images separately rather than the (min, max) over all images. Default: <code class="docutils literal notranslate"><span class="pre">False</span></code>.</p></li>
-<li><p><strong>pad_value</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em>, </em><em>optional</em>) – Value for the padded pixels. Default: <code class="docutils literal notranslate"><span class="pre">0</span></code>.</p></li>
+are computed from the tensor.</li>
+<li><strong>scale_each</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#bool" title="(in Python v3.8)"><em>bool</em></a><em>, </em><em>optional</em>) – If <code class="docutils literal notranslate"><span class="pre">True</span></code>, scale each image in the batch of
+images separately rather than the (min, max) over all images. Default: <code class="docutils literal notranslate"><span class="pre">False</span></code>.</li>
+<li><strong>pad_value</strong> (<a class="reference external" href="https://docs.python.org/3/library/functions.html#float" title="(in Python v3.8)"><em>float</em></a><em>, </em><em>optional</em>) – Value for the padded pixels. Default: <code class="docutils literal notranslate"><span class="pre">0</span></code>.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 <p class="rubric">Example</p>
 <p>See this notebook <a class="reference external" href="https://gist.github.com/anonymous/bf16430f7750c023141c562f3e9f2a91">here</a></p>
 </dd></dl>
 
 <dl class="function">
 <dt id="torchvision.utils.save_image">
-<code class="sig-prename descclassname">torchvision.utils.</code><code class="sig-name descname">save_image</code><span class="sig-paren">(</span><em class="sig-param">tensor: Union[torch.Tensor, List[torch.Tensor]], fp: Union[str, pathlib.Path, BinaryIO], nrow: int = 8, padding: int = 2, normalize: bool = False, range: Optional[Tuple[int, int]] = None, scale_each: bool = False, pad_value: int = 0, format: Optional[str] = None</em><span class="sig-paren">)</span> &#x2192; None<a class="reference internal" href="../_modules/torchvision/utils.html#save_image"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.utils.save_image" title="Permalink to this definition">¶</a></dt>
+<code class="descclassname">torchvision.utils.</code><code class="descname">save_image</code><span class="sig-paren">(</span><em>tensor</em>, <em>fp</em>, <em>nrow=8</em>, <em>padding=2</em>, <em>normalize=False</em>, <em>range=None</em>, <em>scale_each=False</em>, <em>pad_value=0</em>, <em>format=None</em><span class="sig-paren">)</span><a class="reference internal" href="_modules/torchvision/utils.html#save_image"><span class="viewcode-link">[source]</span></a><a class="headerlink" href="#torchvision.utils.save_image" title="Permalink to this definition">¶</a></dt>
 <dd><p>Save a given Tensor into an image file.</p>
-<dl class="field-list simple">
-<dt class="field-odd">Parameters</dt>
-<dd class="field-odd"><ul class="simple">
-<li><p><strong>tensor</strong> (<a class="reference internal" href="../tensors.html#torch.Tensor" title="torch.Tensor"><em>Tensor</em></a><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – Image to be saved. If given a mini-batch tensor,
-saves the tensor as a grid of images by calling <code class="docutils literal notranslate"><span class="pre">make_grid</span></code>.</p></li>
-<li><p><strong>fp</strong> (<em>string</em><em> or </em><em>file object</em>) – A filename or a file object</p></li>
-<li><p><strong>format</strong> (<em>Optional</em>) – If omitted, the format to use is determined from the filename extension.
-If a file object was used instead of a filename, this parameter should always be used.</p></li>
-<li><p><strong>**kwargs</strong> – Other arguments are documented in <code class="docutils literal notranslate"><span class="pre">make_grid</span></code>.</p></li>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first last simple">
+<li><strong>tensor</strong> (<em>Tensor</em><em> or </em><a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#list" title="(in Python v3.8)"><em>list</em></a>) – Image to be saved. If given a mini-batch tensor,
+saves the tensor as a grid of images by calling <code class="docutils literal notranslate"><span class="pre">make_grid</span></code>.</li>
+<li><strong>- A filename</strong> (<em>fp</em>) – </li>
+<li><strong>format</strong> (<em>Optional</em>) – If omitted, the format to use is determined from the filename extension.
+If a file object was used instead of a filename, this parameter should always be used.</li>
+<li><strong>**kwargs</strong> – Other arguments are documented in <code class="docutils literal notranslate"><span class="pre">make_grid</span></code>.</li>
 </ul>
-</dd>
-</dl>
+</td>
+</tr>
+</tbody>
+</table>
 </dd></dl>
 
 </div>
@@ -394,10 +336,8 @@ If a file object was used instead of a filename, this parameter should always be
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="../community/contribution_guide.html" class="btn btn-neutral float-right" title="PyTorch Contribution Guide" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
       
-      
-        <a href="transforms.html" class="btn btn-neutral" title="torchvision.transforms" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="transforms.html" class="btn btn-neutral" title="torchvision.transforms" accesskey="p" rel="prev"><img src="_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -410,7 +350,7 @@ If a file object was used instead of a filename, this parameter should always be
 
   <div role="contentinfo">
     <p>
-        &copy; Copyright 2019, Torch Contributors.
+        &copy; Copyright 2017, Torch Contributors.
 
     </p>
   </div>
@@ -444,50 +384,35 @@ If a file object was used instead of a filename, this parameter should always be
   
 
      
-       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
-         <script src="../_static/jquery.js"></script>
-         <script src="../_static/underscore.js"></script>
-         <script src="../_static/doctools.js"></script>
-         <script src="../_static/language_data.js"></script>
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'./',
+               VERSION:'master',
+               LANGUAGE:'None',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'.html',
+               HAS_SOURCE:  true,
+               SOURCELINK_SUFFIX: '.txt'
+           };
+       </script>
+         <script type="text/javascript" src="_static/jquery.js"></script>
+         <script type="text/javascript" src="_static/underscore.js"></script>
+         <script type="text/javascript" src="_static/doctools.js"></script>
+         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
      
 
   
 
-  <script type="text/javascript" src="../_static/js/vendor/popper.min.js"></script>
-  <script type="text/javascript" src="../_static/js/vendor/bootstrap.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/popper.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
-  <script type="text/javascript" src="../_static/js/theme.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
-  </script>
- 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-90545585-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-117752657-2"></script>
-
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag(){dataLayer.push(arguments);}
-
-  gtag('js', new Date());
-  gtag('config', 'UA-117752657-2');
-</script>
-
-<img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>
-
+  </script> 
 
   <!-- Begin Footer -->
 
@@ -593,7 +518,7 @@ If a file object was used instead of a filename, this parameter should always be
   <div class="cookie-banner-wrapper">
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
-    <img class="close-button" src="../_static/images/pytorch-x.svg">
+    <img class="close-button" src="_static/images/pytorch-x.svg">
   </div>
 </div>
 
@@ -660,7 +585,7 @@ If a file object was used instead of a filename, this parameter should always be
 
   <!-- End Mobile Menu -->
 
-  <script type="text/javascript" src="../_static/js/vendor/anchor.min.js"></script>
+  <script type="text/javascript" src="_static/js/vendor/anchor.min.js"></script>
 
   <script type="text/javascript">
     $(document).ready(function() {


### PR DESCRIPTION
For Pytorch 1.6 release, vision docs were built off of master. Rebuilt docs from a release/0.7.

