### PR TITLE
.circleci: Bump python -> python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: yarn install --cache-folder ~/.cache/yarn
       - run:
           name: Notedown Install
-          command: sudo apt update && sudo apt install python-pip && sudo -H pip install notedown pyyaml -Iv nbformat==4.4.0
+          command: sudo apt update && sudo apt install python3-pip && sudo -H pip3 install notedown pyyaml -Iv nbformat==4.4.0
       - save_cache:
           key: pytorch-yarn-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
There were issues since one of our dependencies stopped supporting
python 2.7.X ([CircleCI Logs](https://app.circleci.com/pipelines/github/pytorch/pytorch.github.io/18814/workflows/2a084f39-9bcc-4b31-9059-3b318dc82827/jobs/18432)):

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/dist-packages/pip/commands/install.py", line 353, in run
    wb.build(autobuilding=True)
  File "/usr/lib/python2.7/dist-packages/pip/wheel.py", line 749, in build
    self.requirement_set.prepare_files(self.finder)
  File "/usr/lib/python2.7/dist-packages/pip/req/req_set.py", line 380, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "/usr/lib/python2.7/dist-packages/pip/req/req_set.py", line 666, in _prepare_file
    check_dist_requires_python(dist)
  File "/usr/lib/python2.7/dist-packages/pip/utils/packaging.py", line 57, in check_dist_requires_python
    '.'.join(map(str, sys.version_info[:3])),)
UnsupportedPythonVersion: pyrsistent requires Python '>=3.5' but the running Python is 2.7.13
```

This should get us in line.

EDIT: I just realized, there's no actual way for me to test this without merging into `site`

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>