### PR TITLE
Homepage updates

### DIFF
--- a/_includes/quick_start_module.html
+++ b/_includes/quick_start_module.html
@@ -3,8 +3,7 @@
     <div class="row">
       <div class="col-md-8 start-locally-col">
 
-        <h3>Quick Start
-          <br />Locally</h3>
+        <h3>Install PyTorch</h3>
 
         {% include quick_start_local.html %}
 

--- a/_includes/quick_start_module.html
+++ b/_includes/quick_start_module.html
@@ -8,7 +8,9 @@
 
         {% include quick_start_local.html %}
 
-        <br/><a href="{{ site.baseurl }}/get-started/previous-versions">Previous versions of PyTorch</a>
+        <a href="{{ site.baseurl }}/get-started/previous-versions" class="btn btn-lg with-right-arrow btn-white prev-versions-btn">
+          Previous versions of PyTorch
+        </a>
       </div>
 
       <div class="col-md-3 offset-md-1 cloud-options-col">

--- a/_sass/homepage.scss
+++ b/_sass/homepage.scss
@@ -353,6 +353,7 @@
   white-space: nowrap;
   margin: auto;
   width: 80%;
+  font-size: rem(18px);
   @include desktop {
     padding-top: 3px;
   }
@@ -368,7 +369,7 @@
     &:hover {
       color: $orange;
     }
-  }  
+  }
 }
 
 .no-banner {

--- a/_sass/quick-start-module.scss
+++ b/_sass/quick-start-module.scss
@@ -52,6 +52,10 @@
       font-size: 80% !important;
       background-color: #ffffff !important;
     }
+
+    .prev-versions-btn {
+      margin-top: 30px;
+    }
   }
 
   .cloud-options-col {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ display-news-banner: true
     <p class="lead">An open source machine learning framework that accelerates the path from research prototyping to production deployment.</p>
 
     <a href="{{ site.baseurl }}/get-started" class="btn btn-lg with-right-arrow" data-cta="get-started">
-      Get Started
+      Install
     </a>
   </div>
 </div>


### PR DESCRIPTION
This PR makes the following updates:

- Updates the copy of the button in the homepage hero
- Within the Quickstart module the "Previous Version of PyTorch" text has been changed into a button
- The news banner font-size has been increased
- The heading of the Quickstart module has been changed to say Install PyTorch

Preview link: https://5f68f1460ac7f800c498d25e--shiftlab-pytorch-github-io.netlify.app/