### PR TITLE
Blog Image Zoom

### DIFF
--- a/_includes/blog_modal.html
+++ b/_includes/blog_modal.html
@@ -1,0 +1,18 @@
+<img class="blog-image" data-toggle="modal" data-target="#{{ include.target }}" src="{{ site.baseurl }}/assets/images/{{ include.image }}" width="100%">
+
+<div class="container">
+  <div class="modal fade" id="{{ include.target }}" role="dialog">
+    <div class="blog-modal modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-body">
+          <img data-toggle="modal" data-target="#{{ include.target }}" src="{{ site.baseurl }}/assets/images/{{ include.image }}" width="100%">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/js-image-zoom/js-image-zoom.min.js"></script>

--- a/_layouts/blog_detail.html
+++ b/_layouts/blog_detail.html
@@ -41,7 +41,6 @@
 
 <!--    {% include similar_posts_module.html %} -->
     {% include footer.html %}
-
 </body>
 
 </html>

--- a/_posts/2020-07-28-accelerating-training-on-nvidia-gpus-with-pytorch-automatic-mixed-precision.md
+++ b/_posts/2020-07-28-accelerating-training-on-nvidia-gpus-with-pytorch-automatic-mixed-precision.md
@@ -9,7 +9,7 @@ Most deep learning frameworks, including PyTorch, train with 32-bit floating poi
 * Shorter training time;
 * Lower memory requirements, enabling larger batch sizes, larger models, or larger inputs.
 
-In order to streamline the user experience of training in mixed precision for researchers and practitioners, NVIDIA developed [Apex](https://developer.nvidia.com/blog/apex-pytorch-easy-mixed-precision-training/) in 2018, which is a lightweight PyTorch extension with [Automatic Mixed Precision](https://developer.nvidia.com/automatic-mixed-precision) (AMP) feature. This feature enables automatic conversion of certain GPU operations from FP32 precision to mixed precision, thus improving performance while maintaining accuracy. 
+In order to streamline the user experience of training in mixed precision for researchers and practitioners, NVIDIA developed [Apex](https://developer.nvidia.com/blog/apex-pytorch-easy-mixed-precision-training/) in 2018, which is a lightweight PyTorch extension with [Automatic Mixed Precision](https://developer.nvidia.com/automatic-mixed-precision) (AMP) feature. This feature enables automatic conversion of certain GPU operations from FP32 precision to mixed precision, thus improving performance while maintaining accuracy.
 
 For the PyTorch 1.6 release, developers at NVIDIA and Facebook moved mixed precision functionality into PyTorch core as the AMP package, [torch.cuda.amp](https://pytorch.org/docs/stable/amp.html). `torch.cuda.amp` is more flexible and intuitive compared to `apex.amp`. Some of `apex.amp`'s known pain points that `torch.cuda.amp` has been able to fix:
 
@@ -22,7 +22,7 @@ For the PyTorch 1.6 release, developers at NVIDIA and Facebook moved mixed preci
 * torch.cuda.amp.autocast() has no effect outside regions where it's enabled, so it should serve cases that formerly struggled with multiple calls to [apex.amp.initialize()](https://github.com/NVIDIA/apex/issues/439) (including [cross-validation)](https://github.com/NVIDIA/apex/issues/392#issuecomment-610038073) without difficulty. Multiple convergence runs in the same script should each use a fresh [GradScaler instance](https://github.com/NVIDIA/apex/issues/439#issuecomment-610028282), but GradScalers are lightweight and self-contained so that's not a problem.
 * Sparse gradient support
 
-With AMP being added to PyTorch core, we have started the process of deprecating `apex.amp.` We have moved `apex.amp` to maintenance mode and will support customers using `apex.amp.` However, we highly encourage `apex.amp` customers to transition to using `torch.cuda.amp` from PyTorch Core.  
+With AMP being added to PyTorch core, we have started the process of deprecating `apex.amp.` We have moved `apex.amp` to maintenance mode and will support customers using `apex.amp.` However, we highly encourage `apex.amp` customers to transition to using `torch.cuda.amp` from PyTorch Core.
 
 # Example Walkthrough
 Please see official docs for usage:
@@ -32,33 +32,33 @@ Please see official docs for usage:
 Example:
 
 ```python
-import torch 
-# Creates once at the beginning of training 
-scaler = torch.cuda.amp.GradScaler() 
- 
-for data, label in data_iter: 
-   optimizer.zero_grad() 
-   # Casts operations to mixed precision 
-   with torch.cuda.amp.autocast(): 
-      loss = model(data) 
- 
-   # Scales the loss, and calls backward() 
-   # to create scaled gradients 
-   scaler.scale(loss).backward() 
- 
-   # Unscales gradients and calls 
-   # or skips optimizer.step() 
-   scaler.step(optimizer) 
- 
-   # Updates the scale for next iteration 
-   scaler.update() 
+import torch
+# Creates once at the beginning of training
+scaler = torch.cuda.amp.GradScaler()
+
+for data, label in data_iter:
+   optimizer.zero_grad()
+   # Casts operations to mixed precision
+   with torch.cuda.amp.autocast():
+      loss = model(data)
+
+   # Scales the loss, and calls backward()
+   # to create scaled gradients
+   scaler.scale(loss).backward()
+
+   # Unscales gradients and calls
+   # or skips optimizer.step()
+   scaler.step(optimizer)
+
+   # Updates the scale for next iteration
+   scaler.update()
 ```
 
 # Performance Benchmarks
 In this section, we discuss the accuracy and performance of mixed precision training with AMP on the latest NVIDIA GPU A100 and also previous generation V100 GPU. The mixed precision performance is compared to FP32 performance, when running Deep Learning workloads in the [NVIDIA pytorch:20.06-py3 container](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch?ncid=partn-52193#cid=ngc01_partn_en-us) from NGC.
 
 ## Accuracy: AMP (FP16), FP32
-The advantage of using AMP for Deep Learning training is that the models converge to the similar final accuracy while providing improved training performance. To illustrate this point, for [Resnet 50 v1.5 training](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Classification/ConvNets/resnet50v1.5#training-accuracy-nvidia-dgx-a100-8x-a100-40gb), we see the following accuracy results where higher is better. Please note that the below accuracy numbers are sample numbers that are subject to run to run variance of up to 0.4%. Accuracy numbers for other models including BERT, Transformer, ResNeXt-101, Mask-RCNN, DLRM can be found at  [NVIDIA Deep Learning Examples Github](https://github.com/NVIDIA/DeepLearningExamples). 
+The advantage of using AMP for Deep Learning training is that the models converge to the similar final accuracy while providing improved training performance. To illustrate this point, for [Resnet 50 v1.5 training](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Classification/ConvNets/resnet50v1.5#training-accuracy-nvidia-dgx-a100-8x-a100-40gb), we see the following accuracy results where higher is better. Please note that the below accuracy numbers are sample numbers that are subject to run to run variance of up to 0.4%. Accuracy numbers for other models including BERT, Transformer, ResNeXt-101, Mask-RCNN, DLRM can be found at  [NVIDIA Deep Learning Examples Github](https://github.com/NVIDIA/DeepLearningExamples).
 
 Training accuracy: NVIDIA DGX A100 (8x A100 40GB)
 
@@ -78,7 +78,7 @@ Training accuracy: NVIDIA DGX A100 (8x A100 40GB)
 </table>
 
 Training accuracy: NVIDIA DGX-1 (8x V100 16GB)
-	
+
  <table width="460" border="0" cellspacing="5" cellpadding="5">
   <tbody>
     <tr>
@@ -104,13 +104,13 @@ Training accuracy: NVIDIA DGX-1 (8x V100 16GB)
   </tbody>
 </table>
 
-## Speedup Performance: 
+## Speedup Performance:
 
 ### FP16 on NVIDIA V100 vs. FP32 on V100
 AMP with FP16 is the most performant option for DL training on the V100. In Table 1, we can observe that for various models, AMP on V100 provides a speedup of 1.5x to 5.5x over FP32 on V100 while converging to the same final accuracy.
 
 <div class="text-center">
-  <img src="{{ site.url }}/assets/images/nvidiafp32onv100.jpg" width="100%">
+  <img src="{{ site.baseurl }}/assets/images/nvidiafp32onv100.jpg" width="100%">
 </div>
 *Figure 2. Performance of mixed precision training on NVIDIA 8xV100 vs. FP32 training on 8xV100 GPU. Bars represent the speedup factor of V100 AMP over V100 FP32. The higher the better.*
 
@@ -119,13 +119,9 @@ AMP with FP16 is the most performant option for DL training on the V100. In Tabl
 AMP with FP16 remains the most performant option for DL training on the A100. In Figure 3, we can observe that for various models, AMP on A100 provides a speedup of 1.3x to 2.5x over AMP on V100 while converging to the same final accuracy.
 
 <div class="text-center">
-  <img src="{{ site.url }}/assets/images/nvidiafp16onv100.png" width="100%">
+  <img src="{{ site.baseurl }}/assets/images/nvidiafp16onv100.png" width="100%">
 </div>
 *Figure 3. Performance of mixed precision training on NVIDIA 8xA100 vs. 8xV100 GPU. Bars represent the speedup factor of A100 over V100. The higher the better.*
 
 # Call to action
-AMP provides a healthy speedup for Deep Learning training workloads on Nvidia Tensor Core GPUs, especially on the latest Ampere generation A100 GPUs.  You can start experimenting with AMP enabled models and model scripts for A100, V100, T4 and other GPUs available at NVIDIA deep learning [examples](https://github.com/NVIDIA/DeepLearningExamples). NVIDIA PyTorch with native AMP support is available from the [PyTorch NGC container](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch?ncid=partn-52193#cid=ngc01_partn_en-us) version 20.06. We highly encourage existing `apex.amp` customers to transition to using `torch.cuda.amp` from PyTorch Core available in the latest [PyTorch 1.6 release](https://pytorch.org/blog/pytorch-1.6-released/). 
-
-	
-	
-    
+AMP provides a healthy speedup for Deep Learning training workloads on Nvidia Tensor Core GPUs, especially on the latest Ampere generation A100 GPUs.  You can start experimenting with AMP enabled models and model scripts for A100, V100, T4 and other GPUs available at NVIDIA deep learning [examples](https://github.com/NVIDIA/DeepLearningExamples). NVIDIA PyTorch with native AMP support is available from the [PyTorch NGC container](https://ngc.nvidia.com/catalog/containers/nvidia:pytorch?ncid=partn-52193#cid=ngc01_partn_en-us) version 20.06. We highly encourage existing `apex.amp` customers to transition to using `torch.cuda.amp` from PyTorch Core available in the latest [PyTorch 1.6 release](https://pytorch.org/blog/pytorch-1.6-released/).

--- a/_posts/2020-08-11-efficient-pytorch-io-library-for-large-datasets-many-files-many-gpus.md
+++ b/_posts/2020-08-11-efficient-pytorch-io-library-for-large-datasets-many-files-many-gpus.md
@@ -20,7 +20,7 @@ However, working with the large amount of data sets presents a number of challen
 * **Shuffling and Augmentation:** training data needs to be shuffled and augmented prior to training.
 * **Scalability:** users often want to develop and test on small datasets and then rapidly scale up to large datasets.
 
-Traditional local and network file systems, and even object storage servers, are not designed for these kinds of applications. [The WebDataset I/O library](https://github.com/tmbdev/webdataset) for PyTorch, together with the optional [AIStore server](https://github.com/NVIDIA/aistore) and [Tensorcom](https://github.com/NVlabs/tensorcom) RDMA libraries, provide an efficient, simple, and standards-based solution to all these problems. The library is simple enough for day-to-day use, is based on mature open source standards, and is easy to migrate to from existing file-based datasets. 
+Traditional local and network file systems, and even object storage servers, are not designed for these kinds of applications. [The WebDataset I/O library](https://github.com/tmbdev/webdataset) for PyTorch, together with the optional [AIStore server](https://github.com/NVIDIA/aistore) and [Tensorcom](https://github.com/NVlabs/tensorcom) RDMA libraries, provide an efficient, simple, and standards-based solution to all these problems. The library is simple enough for day-to-day use, is based on mature open source standards, and is easy to migrate to from existing file-based datasets.
 
 Using WebDataset is simple and requires little effort, and it will let you scale up the same code from running local experiments to using hundreds of GPUs on clusters or in the cloud with linearly scalable performance. Even on small problems and on your desktop, it can speed up I/O tenfold and simplifies data management and processing of large datasets. The rest of this blog post tells you how to get started with WebDataset and how it works.
 
@@ -38,7 +38,7 @@ The WebDataset library is a complete solution for working with large datasets an
 
 ## Benefits
 
-The use of sharded, sequentially readable formats is essential for very large datasets. In addition, it has benefits in many other environments. WebDataset provides a solution that scales well from small problems on a desktop machine to very large deep learning problems in clusters or in the cloud. The following table summarizes some of the benefits in different environments. 
+The use of sharded, sequentially readable formats is essential for very large datasets. In addition, it has benefits in many other environments. WebDataset provides a solution that scales well from small problems on a desktop machine to very large deep learning problems in clusters or in the cloud. The following table summarizes some of the benefits in different environments.
 
   {:.table.table-striped.table-bordered}
  | Environment  | Benefits of WebDataset |
@@ -122,7 +122,7 @@ for inputs, targets in loader:
   ```
 
 This code is nearly identical to the file-based I/O pipeline found in the PyTorch Imagenet example: it creates a preprocessing/augmentation pipeline, instantiates a dataset using that pipeline and a data source location, and then constructs a DataLoader instance from the dataset.
- 
+
  WebDataset uses a fluent API for a configuration that internally builds up a processing pipeline. Without any added processing stages, In this example, WebDataset is used with the PyTorch DataLoader class, which replicates DataSet instances across multiple threads and performs both parallel I/O and parallel data augmentation.
 
 WebDataset instances themselves just iterate through each training sample as a dictionary:
@@ -154,6 +154,3 @@ For a general introduction to how we handle large scale training with WebDataset
 * [Bigdata 2019 Paper with Benchmarks](https://arxiv.org/abs/2001.01858)
 
 Check out [the library](https://github.com/tmbdev/webdataset) and provide your feedback for [RFC 38419](https://github.com/pytorch/pytorch/issues/38419).
-
-
-

--- a/_sass/blog.scss
+++ b/_sass/blog.scss
@@ -48,6 +48,23 @@
     }
   }
 
+  .zoom-in {
+    cursor: zoom-in;
+  }
+
+  .zoomed {
+    cursor: zoom-out;
+    img {
+      margin: auto !important;
+      position: absolute;
+      top: 0;
+      left:0;
+      right:0;
+      bottom: 0;
+      max-width: 98%;
+    }
+  }
+
   .nav-logo {
     background-image: url($baseurl + "/assets/images/logo-dark.svg");
   }
@@ -228,6 +245,22 @@
     color: $orange;
     width: rem(120px);
     text-align: center;
+  }
+
+  .blog-modal {
+    max-width: 75%;
+    top: 5rem;
+    &:hover {
+      cursor: zoom-out;
+    }
+    @media (max-width: 575px) {
+      max-width: 100%;
+      top: 10rem;
+    }
+  }
+
+  .blog-image {
+    cursor: zoom-in;
   }
 
   @media (max-width: 1067px) {


### PR DESCRIPTION
## This PR adds the ability to zoom in on Blog images. 

#### Image without zoom
```
<div class="text-center">
  <img src="{{ site.url }}/assets/images/example-image.png" width="100%">
</div>
```
#### Image with zoom
```
<div class="text-center">
  {% include blog_modal.html image="example-image.png" target="image-1" %}
</div>
```

To add an image with Zoom you need to add the `include` in place of the `<img>` tag. The include needs the image and target attributes to work properly.

- image: Name of the image

- target: Can be anything to identify image but must be unique