### PR TITLE
add 1.7.0 to the version selector

### DIFF
--- a/docs/versions.html
+++ b/docs/versions.html
@@ -21,6 +21,9 @@
           <a class="reference internal" href="master/">master (unstable)</a>
         </li>
         <li class="toctree-l1">
+          <a class="reference internal" href="1.7.0/">v1.7.0 (pre-release)</a>
+        </li>
+        <li class="toctree-l1">
           <a class="reference internal" href="stable/">v1.6.0 (stable release)</a>
         </li>
         <li class="toctree-l1">


### PR DESCRIPTION
The 1.7.0 version of the docs was built off commit 43404c4, which is the v1.7.0-rc1 tag. This PR adds a link to the version selector for the as-yet-unreleased documentation.