### PR TITLE
Add meta no-index tags to 1.4.0 docs

### DIFF
--- a/docs/1.4.0/__config__.html
+++ b/docs/1.4.0/__config__.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/index.html
+++ b/docs/1.4.0/_modules/index.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch.html
+++ b/docs/1.4.0/_modules/torch.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/__config__.html
+++ b/docs/1.4.0/_modules/torch/__config__.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/_jit_internal.html
+++ b/docs/1.4.0/_modules/torch/_jit_internal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/_tensor_str.html
+++ b/docs/1.4.0/_modules/torch/_tensor_str.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/_utils.html
+++ b/docs/1.4.0/_modules/torch/_utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd.html
+++ b/docs/1.4.0/_modules/torch/autograd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd/anomaly_mode.html
+++ b/docs/1.4.0/_modules/torch/autograd/anomaly_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd/function.html
+++ b/docs/1.4.0/_modules/torch/autograd/function.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd/grad_mode.html
+++ b/docs/1.4.0/_modules/torch/autograd/grad_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd/gradcheck.html
+++ b/docs/1.4.0/_modules/torch/autograd/gradcheck.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/autograd/profiler.html
+++ b/docs/1.4.0/_modules/torch/autograd/profiler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda.html
+++ b/docs/1.4.0/_modules/torch/cuda.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda/comm.html
+++ b/docs/1.4.0/_modules/torch/cuda/comm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda/memory.html
+++ b/docs/1.4.0/_modules/torch/cuda/memory.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda/nvtx.html
+++ b/docs/1.4.0/_modules/torch/cuda/nvtx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda/random.html
+++ b/docs/1.4.0/_modules/torch/cuda/random.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/cuda/streams.html
+++ b/docs/1.4.0/_modules/torch/cuda/streams.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed.html
+++ b/docs/1.4.0/_modules/torch/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed/autograd.html
+++ b/docs/1.4.0/_modules/torch/distributed/autograd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed/distributed_c10d.html
+++ b/docs/1.4.0/_modules/torch/distributed/distributed_c10d.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed/optim/optimizer.html
+++ b/docs/1.4.0/_modules/torch/distributed/optim/optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed/rpc.html
+++ b/docs/1.4.0/_modules/torch/distributed/rpc.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributed/rpc/api.html
+++ b/docs/1.4.0/_modules/torch/distributed/rpc/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/bernoulli.html
+++ b/docs/1.4.0/_modules/torch/distributions/bernoulli.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/beta.html
+++ b/docs/1.4.0/_modules/torch/distributions/beta.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/binomial.html
+++ b/docs/1.4.0/_modules/torch/distributions/binomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/categorical.html
+++ b/docs/1.4.0/_modules/torch/distributions/categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/cauchy.html
+++ b/docs/1.4.0/_modules/torch/distributions/cauchy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/chi2.html
+++ b/docs/1.4.0/_modules/torch/distributions/chi2.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/constraint_registry.html
+++ b/docs/1.4.0/_modules/torch/distributions/constraint_registry.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/constraints.html
+++ b/docs/1.4.0/_modules/torch/distributions/constraints.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/dirichlet.html
+++ b/docs/1.4.0/_modules/torch/distributions/dirichlet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/distribution.html
+++ b/docs/1.4.0/_modules/torch/distributions/distribution.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/exp_family.html
+++ b/docs/1.4.0/_modules/torch/distributions/exp_family.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/exponential.html
+++ b/docs/1.4.0/_modules/torch/distributions/exponential.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/1.4.0/_modules/torch/distributions/fishersnedecor.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/gamma.html
+++ b/docs/1.4.0/_modules/torch/distributions/gamma.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/geometric.html
+++ b/docs/1.4.0/_modules/torch/distributions/geometric.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/gumbel.html
+++ b/docs/1.4.0/_modules/torch/distributions/gumbel.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/half_cauchy.html
+++ b/docs/1.4.0/_modules/torch/distributions/half_cauchy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/half_normal.html
+++ b/docs/1.4.0/_modules/torch/distributions/half_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/independent.html
+++ b/docs/1.4.0/_modules/torch/distributions/independent.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/kl.html
+++ b/docs/1.4.0/_modules/torch/distributions/kl.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/laplace.html
+++ b/docs/1.4.0/_modules/torch/distributions/laplace.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/log_normal.html
+++ b/docs/1.4.0/_modules/torch/distributions/log_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/lowrank_multivariate_normal.html
+++ b/docs/1.4.0/_modules/torch/distributions/lowrank_multivariate_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/multinomial.html
+++ b/docs/1.4.0/_modules/torch/distributions/multinomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/1.4.0/_modules/torch/distributions/multivariate_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/negative_binomial.html
+++ b/docs/1.4.0/_modules/torch/distributions/negative_binomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/normal.html
+++ b/docs/1.4.0/_modules/torch/distributions/normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/1.4.0/_modules/torch/distributions/one_hot_categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/pareto.html
+++ b/docs/1.4.0/_modules/torch/distributions/pareto.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/poisson.html
+++ b/docs/1.4.0/_modules/torch/distributions/poisson.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/1.4.0/_modules/torch/distributions/relaxed_bernoulli.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/1.4.0/_modules/torch/distributions/relaxed_categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/studentT.html
+++ b/docs/1.4.0/_modules/torch/distributions/studentT.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/1.4.0/_modules/torch/distributions/transformed_distribution.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/transforms.html
+++ b/docs/1.4.0/_modules/torch/distributions/transforms.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/uniform.html
+++ b/docs/1.4.0/_modules/torch/distributions/uniform.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/distributions/weibull.html
+++ b/docs/1.4.0/_modules/torch/distributions/weibull.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/functional.html
+++ b/docs/1.4.0/_modules/torch/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/hub.html
+++ b/docs/1.4.0/_modules/torch/hub.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/jit.html
+++ b/docs/1.4.0/_modules/torch/jit.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/multiprocessing.html
+++ b/docs/1.4.0/_modules/torch/multiprocessing.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/multiprocessing/spawn.html
+++ b/docs/1.4.0/_modules/torch/multiprocessing/spawn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/functional.html
+++ b/docs/1.4.0/_modules/torch/nn/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/init.html
+++ b/docs/1.4.0/_modules/torch/nn/init.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/intrinsic/modules/fused.html
+++ b/docs/1.4.0/_modules/torch/nn/intrinsic/modules/fused.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/intrinsic/qat/modules/conv_fused.html
+++ b/docs/1.4.0/_modules/torch/nn/intrinsic/qat/modules/conv_fused.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/intrinsic/qat/modules/linear_relu.html
+++ b/docs/1.4.0/_modules/torch/nn/intrinsic/qat/modules/linear_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/intrinsic/quantized/modules/conv_relu.html
+++ b/docs/1.4.0/_modules/torch/nn/intrinsic/quantized/modules/conv_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/intrinsic/quantized/modules/linear_relu.html
+++ b/docs/1.4.0/_modules/torch/nn/intrinsic/quantized/modules/linear_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/activation.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/activation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/adaptive.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/adaptive.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/batchnorm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/container.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/container.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/conv.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/distance.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/distance.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/dropout.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/dropout.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/flatten.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/flatten.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/fold.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/fold.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/instancenorm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/linear.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/loss.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/loss.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/module.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/module.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/normalization.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/normalization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/padding.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/padding.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/pixelshuffle.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/pooling.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/pooling.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/rnn.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/sparse.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/sparse.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/transformer.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/transformer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/modules/upsampling.html
+++ b/docs/1.4.0/_modules/torch/nn/modules/upsampling.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/1.4.0/_modules/torch/nn/parallel/data_parallel.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/parallel/distributed.html
+++ b/docs/1.4.0/_modules/torch/nn/parallel/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/parameter.html
+++ b/docs/1.4.0/_modules/torch/nn/parameter.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/qat/modules/conv.html
+++ b/docs/1.4.0/_modules/torch/nn/qat/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/qat/modules/linear.html
+++ b/docs/1.4.0/_modules/torch/nn/qat/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/dynamic/modules/linear.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/dynamic/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/dynamic/modules/rnn.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/dynamic/modules/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/functional.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/modules.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/modules.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/modules/activation.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/modules/activation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/modules/conv.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/modules/functional_modules.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/modules/functional_modules.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/quantized/modules/linear.html
+++ b/docs/1.4.0/_modules/torch/nn/quantized/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/clip_grad.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/convert_parameters.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/convert_parameters.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/prune.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/prune.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/rnn.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/spectral_norm.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/spectral_norm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/1.4.0/_modules/torch/nn/utils/weight_norm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/onnx.html
+++ b/docs/1.4.0/_modules/torch/onnx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/onnx/operators.html
+++ b/docs/1.4.0/_modules/torch/onnx/operators.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/adadelta.html
+++ b/docs/1.4.0/_modules/torch/optim/adadelta.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/adagrad.html
+++ b/docs/1.4.0/_modules/torch/optim/adagrad.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/adam.html
+++ b/docs/1.4.0/_modules/torch/optim/adam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/adamax.html
+++ b/docs/1.4.0/_modules/torch/optim/adamax.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/adamw.html
+++ b/docs/1.4.0/_modules/torch/optim/adamw.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/asgd.html
+++ b/docs/1.4.0/_modules/torch/optim/asgd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/lbfgs.html
+++ b/docs/1.4.0/_modules/torch/optim/lbfgs.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/lr_scheduler.html
+++ b/docs/1.4.0/_modules/torch/optim/lr_scheduler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/optimizer.html
+++ b/docs/1.4.0/_modules/torch/optim/optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/rmsprop.html
+++ b/docs/1.4.0/_modules/torch/optim/rmsprop.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/rprop.html
+++ b/docs/1.4.0/_modules/torch/optim/rprop.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/sgd.html
+++ b/docs/1.4.0/_modules/torch/optim/sgd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/optim/sparse_adam.html
+++ b/docs/1.4.0/_modules/torch/optim/sparse_adam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization.html
+++ b/docs/1.4.0/_modules/torch/quantization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/fake_quantize.html
+++ b/docs/1.4.0/_modules/torch/quantization/fake_quantize.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/fuse_modules.html
+++ b/docs/1.4.0/_modules/torch/quantization/fuse_modules.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/observer.html
+++ b/docs/1.4.0/_modules/torch/quantization/observer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/qconfig.html
+++ b/docs/1.4.0/_modules/torch/quantization/qconfig.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/quantize.html
+++ b/docs/1.4.0/_modules/torch/quantization/quantize.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quantization/stubs.html
+++ b/docs/1.4.0/_modules/torch/quantization/stubs.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/quasirandom.html
+++ b/docs/1.4.0/_modules/torch/quasirandom.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/random.html
+++ b/docs/1.4.0/_modules/torch/random.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/serialization.html
+++ b/docs/1.4.0/_modules/torch/serialization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/sparse.html
+++ b/docs/1.4.0/_modules/torch/sparse.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/storage.html
+++ b/docs/1.4.0/_modules/torch/storage.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/tensor.html
+++ b/docs/1.4.0/_modules/torch/tensor.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/checkpoint.html
+++ b/docs/1.4.0/_modules/torch/utils/checkpoint.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/cpp_extension.html
+++ b/docs/1.4.0/_modules/torch/utils/cpp_extension.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/data/_utils/worker.html
+++ b/docs/1.4.0/_modules/torch/utils/data/_utils/worker.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/data/dataloader.html
+++ b/docs/1.4.0/_modules/torch/utils/data/dataloader.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/data/dataset.html
+++ b/docs/1.4.0/_modules/torch/utils/data/dataset.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/data/distributed.html
+++ b/docs/1.4.0/_modules/torch/utils/data/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/data/sampler.html
+++ b/docs/1.4.0/_modules/torch/utils/data/sampler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torch/utils/tensorboard/writer.html
+++ b/docs/1.4.0/_modules/torch/utils/tensorboard/writer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision.html
+++ b/docs/1.4.0/_modules/torchvision.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/cifar.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/cifar.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/cityscapes.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/cityscapes.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/coco.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/coco.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/fakedata.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/fakedata.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/flickr.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/flickr.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/folder.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/folder.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/hmdb51.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/hmdb51.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/imagenet.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/imagenet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/kinetics.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/kinetics.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/lsun.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/lsun.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/mnist.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/mnist.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/phototour.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/phototour.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/sbd.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/sbd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/sbu.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/sbu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/stl10.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/stl10.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/svhn.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/svhn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/ucf101.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/ucf101.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/usps.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/usps.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/datasets/voc.html
+++ b/docs/1.4.0/_modules/torchvision/datasets/voc.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/io/video.html
+++ b/docs/1.4.0/_modules/torchvision/io/video.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/alexnet.html
+++ b/docs/1.4.0/_modules/torchvision/models/alexnet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/densenet.html
+++ b/docs/1.4.0/_modules/torchvision/models/densenet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/detection/faster_rcnn.html
+++ b/docs/1.4.0/_modules/torchvision/models/detection/faster_rcnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/detection/keypoint_rcnn.html
+++ b/docs/1.4.0/_modules/torchvision/models/detection/keypoint_rcnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/detection/mask_rcnn.html
+++ b/docs/1.4.0/_modules/torchvision/models/detection/mask_rcnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/googlenet.html
+++ b/docs/1.4.0/_modules/torchvision/models/googlenet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/inception.html
+++ b/docs/1.4.0/_modules/torchvision/models/inception.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/mnasnet.html
+++ b/docs/1.4.0/_modules/torchvision/models/mnasnet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/mobilenet.html
+++ b/docs/1.4.0/_modules/torchvision/models/mobilenet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/resnet.html
+++ b/docs/1.4.0/_modules/torchvision/models/resnet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/segmentation/segmentation.html
+++ b/docs/1.4.0/_modules/torchvision/models/segmentation/segmentation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/shufflenetv2.html
+++ b/docs/1.4.0/_modules/torchvision/models/shufflenetv2.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/squeezenet.html
+++ b/docs/1.4.0/_modules/torchvision/models/squeezenet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/vgg.html
+++ b/docs/1.4.0/_modules/torchvision/models/vgg.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/models/video/resnet.html
+++ b/docs/1.4.0/_modules/torchvision/models/video/resnet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/ops/boxes.html
+++ b/docs/1.4.0/_modules/torchvision/ops/boxes.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/ops/roi_align.html
+++ b/docs/1.4.0/_modules/torchvision/ops/roi_align.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/ops/roi_pool.html
+++ b/docs/1.4.0/_modules/torchvision/ops/roi_pool.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/transforms/functional.html
+++ b/docs/1.4.0/_modules/torchvision/transforms/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/transforms/transforms.html
+++ b/docs/1.4.0/_modules/torchvision/transforms/transforms.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/_modules/torchvision/utils.html
+++ b/docs/1.4.0/_modules/torchvision/utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/autograd.html
+++ b/docs/1.4.0/autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/bottleneck.html
+++ b/docs/1.4.0/bottleneck.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/checkpoint.html
+++ b/docs/1.4.0/checkpoint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/community/contribution_guide.html
+++ b/docs/1.4.0/community/contribution_guide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/community/governance.html
+++ b/docs/1.4.0/community/governance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/community/persons_of_interest.html
+++ b/docs/1.4.0/community/persons_of_interest.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cpp_extension.html
+++ b/docs/1.4.0/cpp_extension.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cuda.html
+++ b/docs/1.4.0/cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cuda_deterministic.html
+++ b/docs/1.4.0/cuda_deterministic.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cuda_deterministic_backward.html
+++ b/docs/1.4.0/cuda_deterministic_backward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cudnn_deterministic.html
+++ b/docs/1.4.0/cudnn_deterministic.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/cudnn_persistent_rnn.html
+++ b/docs/1.4.0/cudnn_persistent_rnn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/data.html
+++ b/docs/1.4.0/data.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/distributed.html
+++ b/docs/1.4.0/distributed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/distributions.html
+++ b/docs/1.4.0/distributions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/dlpack.html
+++ b/docs/1.4.0/dlpack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/genindex.html
+++ b/docs/1.4.0/genindex.html
@@ -6,6 +6,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/hub.html
+++ b/docs/1.4.0/hub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/index.html
+++ b/docs/1.4.0/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/jit.html
+++ b/docs/1.4.0/jit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/jit_builtin_functions.html
+++ b/docs/1.4.0/jit_builtin_functions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/model_zoo.html
+++ b/docs/1.4.0/model_zoo.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/multiprocessing.html
+++ b/docs/1.4.0/multiprocessing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/name_inference.html
+++ b/docs/1.4.0/name_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/named_tensor.html
+++ b/docs/1.4.0/named_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/nn.functional.html
+++ b/docs/1.4.0/nn.functional.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/nn.html
+++ b/docs/1.4.0/nn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/nn.init.html
+++ b/docs/1.4.0/nn.init.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/autograd.html
+++ b/docs/1.4.0/notes/autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/broadcasting.html
+++ b/docs/1.4.0/notes/broadcasting.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/cpu_threading_torchscript_inference.html
+++ b/docs/1.4.0/notes/cpu_threading_torchscript_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/cuda.html
+++ b/docs/1.4.0/notes/cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/distributed_autograd.html
+++ b/docs/1.4.0/notes/distributed_autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/extending.html
+++ b/docs/1.4.0/notes/extending.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/faq.html
+++ b/docs/1.4.0/notes/faq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/large_scale_deployments.html
+++ b/docs/1.4.0/notes/large_scale_deployments.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/multiprocessing.html
+++ b/docs/1.4.0/notes/multiprocessing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/randomness.html
+++ b/docs/1.4.0/notes/randomness.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/rref.html
+++ b/docs/1.4.0/notes/rref.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/serialization.html
+++ b/docs/1.4.0/notes/serialization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/notes/windows.html
+++ b/docs/1.4.0/notes/windows.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/onnx.html
+++ b/docs/1.4.0/onnx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/optim.html
+++ b/docs/1.4.0/optim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/py-modindex.html
+++ b/docs/1.4.0/py-modindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/quantization.html
+++ b/docs/1.4.0/quantization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/random.html
+++ b/docs/1.4.0/random.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/rpc.html
+++ b/docs/1.4.0/rpc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/search.html
+++ b/docs/1.4.0/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/sparse.html
+++ b/docs/1.4.0/sparse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/storage.html
+++ b/docs/1.4.0/storage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/tensor_attributes.html
+++ b/docs/1.4.0/tensor_attributes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/tensorboard.html
+++ b/docs/1.4.0/tensorboard.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/tensors.html
+++ b/docs/1.4.0/tensors.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torch.html
+++ b/docs/1.4.0/torch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/datasets.html
+++ b/docs/1.4.0/torchvision/datasets.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/index.html
+++ b/docs/1.4.0/torchvision/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/io.html
+++ b/docs/1.4.0/torchvision/io.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/models.html
+++ b/docs/1.4.0/torchvision/models.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/ops.html
+++ b/docs/1.4.0/torchvision/ops.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/transforms.html
+++ b/docs/1.4.0/torchvision/transforms.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/torchvision/utils.html
+++ b/docs/1.4.0/torchvision/utils.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/1.4.0/type_info.html
+++ b/docs/1.4.0/type_info.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This hides 1.4.0 docs from google search, among other things.

I ran the following command inside the docs/1.4.0 folder:
- `find . -name "*.html" -print0 | xargs -0 sed -i '/<head>/a \ \ <meta name="robots" content="noindex">'`
This command adds a meta robots noindex tag directly after the `<head>` begin tag.

Test Plan:
- viewed docs locally
- wait for site preview