### PR TITLE
Update SageMaker URL

### DIFF
--- a/_includes/quick_start_cloud_options.html
+++ b/_includes/quick_start_cloud_options.html
@@ -18,7 +18,7 @@
 
       <ul>
         <li><a href="https://aws.amazon.com/pytorch/">PyTorch on AWS</a></li>
-        <li><a href="https://sagemaker.readthedocs.io/en/stable/using_pytorch.html">Amazon SageMaker</a></li>
+        <li><a href="https://aws.amazon.com/sagemaker">Amazon SageMaker</a></li>
         <li><a href="https://docs.aws.amazon.com/deep-learning-containers/latest/devguide/deep-learning-containers-ec2-tutorials-training.html#deep-learning-containers-ec2-tutorials-training-pytorch">AWS Deep Learning Containers</a></li>
         <li><a href="https://docs.aws.amazon.com/dlami/latest/devguide/tutorial-pytorch.html">AWS Deep Learning AMIs</a></li>
       </ul>


### PR DESCRIPTION
This PR updates the Amazon SageMaker URL in the Get Started Cloud Partners dropdown