### PR TITLE
Add torchaudio to default linux install guide

### DIFF
--- a/assets/quick-start-module.js
+++ b/assets/quick-start-module.js
@@ -240,7 +240,7 @@ function commandMessage(key) {
       "pip install torch==1.7.0+cu101 torchvision==0.8.1+cu101 torchaudio==0.7.0 -f https://download.pytorch.org/whl/torch_stable.html",
 
     "stable,pip,linux,cuda10.2,python":
-      "pip install torch torchvision",
+      "pip install torch torchvision torchaudio",
 
     "stable,pip,linux,cuda11.0,python":
       "pip install torch==1.7.0+cu110 torchvision==0.8.1+cu110 torchaudio===0.7.0 -f https://download.pytorch.org/whl/torch_stable.html",


### PR DESCRIPTION
I noticed `torchaudio` is missing in the cuda 10.2 linux install. Not sure if it's intentional or not.