### PR TITLE
Fix the TorchServe link in the website

### DIFF
--- a/_ecosystem/translate.md
+++ b/_ecosystem/translate.md
@@ -40,7 +40,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-   ![Here's an image](http://via.placeholder.com/1000x200/e44c2c/ffffff "Sample image")
+   ![Here's an image](https://via.placeholder.com/1000x200/e44c2c/ffffff "Sample image")
 
 5. #### Run this Command
 

--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -53,7 +53,7 @@
             <span class="dropdown-title docs-title">TorchElastic</span>
             <p></p>
           </a>
-          <a class="nav-dropdown-item" href="{{ site.baseurl }}serve">
+          <a class="nav-dropdown-item" href="{{ site.baseurl }}/serve">
             <span class="dropdown-title docs-title">TorchServe</span>
             <p></p>
           </a>

--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -73,7 +73,7 @@
           </li>
 
           <li class="{% if current[1] == 'serve' %}active{% endif %}">
-            <a href="{{ site.baseurl }}serve">TorchServe</a>
+            <a href="{{ site.baseurl }}/serve">TorchServe</a>
           </li>
 
           <li class="{% if current[1] == 'hub' %}active{% endif %}">

--- a/_style_guide/article.md
+++ b/_style_guide/article.md
@@ -55,7 +55,7 @@ This is body copy after an ordered list. Lorem ipsum dolor sit amet, consectetur
 
 ---
 
-![Here's an image](http://via.placeholder.com/1000x200/e44c2c/ffffff "Sample image")
+![Here's an image](https://via.placeholder.com/1000x200/e44c2c/ffffff "Sample image")
 
 ---
 


### PR DESCRIPTION
The link under "Docs" in the nav menu for TorchServe doesn't correctly use the site base URL. Hence it breaks when the nav item is accessed from the pages that's not the root. (e.g. https://pytorch.org/get-started/locally/serve). 

Originally reported in the TorchServe repo in [this Issue](https://github.com/pytorch/serve/issues/792)

Tested the fix by building the static site locally.

Before fix:
<img width="481" alt="Screen Shot 2020-12-01 at 1 37 21 AM" src="https://user-images.githubusercontent.com/70922646/100724392-ac504a80-3377-11eb-9d2e-ebe1383ddeee.png">

After fix:
<img width="504" alt="Screen Shot 2020-12-01 at 1 40 13 AM" src="https://user-images.githubusercontent.com/70922646/100724407-b1ad9500-3377-11eb-8433-034ba6c49f01.png">
