### PR TITLE
Change "name" to "project name" on ecosystem join form

### DIFF
--- a/_includes/ecosystem_form.html
+++ b/_includes/ecosystem_form.html
@@ -4,7 +4,7 @@
       <h3>Project Overview</h3>
 
       <div class="mc-field-group">
-        <label for="mce-MMERGE10">Name: <span class="asterisk">*</span></label>
+        <label for="mce-MMERGE10">Project Name: <span class="asterisk">*</span></label>
         <input type="text" value="" name="MMERGE10" class="required" id="mce-MMERGE10" required>
       </div>
 
@@ -56,7 +56,7 @@
         <label for="mce-MMERGE8">How is continuous integration provided today? <span class="asterisk">*</span></label>
         <textarea type="text" value="" name="MMERGE8" class="required large-input" id="mce-MMERGE8" required></textarea>
       </div>
-      
+
       <div class="mc-field-group">
         <label for="mce-MMERGE8">Does the project support TorchScript today for production usage? <span class="asterisk">*</span></label>
         <textarea type="text" value="" name="MMERGE8" class="required large-input" id="mce-MMERGE8" required></textarea>


### PR DESCRIPTION
This PR changes "Name" to "Project Name" under Project Overview on the Ecosystem Join form