### PR TITLE
Fix hyperlink for build from source

### DIFF
--- a/_get_started/installation/windows.md
+++ b/_get_started/installation/windows.md
@@ -129,6 +129,6 @@ For the majority of PyTorch users, installing from a pre-built binary via a pack
 1. Install [Anaconda](#anaconda)
 2. Install [CUDA](https://developer.nvidia.com/cuda-downloads), if your machine has a [CUDA-enabled GPU](https://developer.nvidia.com/cuda-gpus).
 3. If you want to build on Windows, Visual Studio with MSVC toolset, and NVTX are also needed. The exact requirements of those dependencies could be found out [here](https://github.com/pytorch/pytorch#from-source).
-4. Follow the steps described here: https://github.com/pytorch/pytorch#from-source
+4. Follow the steps described here: [https://github.com/pytorch/pytorch#from-source](https://github.com/pytorch/pytorch#from-source)
 
 You can verify the installation as described [above](#windows-verification).


### PR DESCRIPTION
It renders correctly as a hyperlink when viewed on GitHub but not on https://pytorch.org/get-started/locally/#supported-windows-distributions