### PR TITLE
Update Github ids for Ecosystem star count

### DIFF
--- a/_ecosystem/pennylane
+++ b/_ecosystem/pennylane
@@ -7,6 +7,6 @@ order: 12
 summary-home: PennyLane is a library for quantum ML, automatic differentiation, and optimization of hybrid quantum-classical computations.
 featured-home: false
 redirect_to: https://pennylane.ai/
-github-id: XanaduAI/PennyLane
+github-id: PennyLaneAI/pennylane
 date-added: 7/14/19
 ---

--- a/_ecosystem/trains
+++ b/_ecosystem/trains
@@ -5,6 +5,6 @@ summary: Allegro Trains is a full system ML / DL experiment manager, versioning 
 link: https://github.com/allegroai/trains/
 summary-home: Allegro Trains is a full system ML / DL experiment manager, versioning and ML-Ops solution.
 featured-home: false
-github-id: allegroai/trains
+github-id: allegroai/clearml
 date-added: 6/17/20
 ---


### PR DESCRIPTION
This PR updates the GitHub id's for PennyLane and Allegro Trains