### PR TITLE
add docs/1.8.0/torchvision redirect pages

### DIFF
--- a/docs/1.8.0/torchvision/datasets.html
+++ b/docs/1.8.0/torchvision/datasets.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/datasets.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/datasets.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/datasets.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/datasets.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/index.html
+++ b/docs/1.8.0/torchvision/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/index.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/index.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/index.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/index.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/io.html
+++ b/docs/1.8.0/torchvision/io.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/io.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/io.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/io.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/io.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/models.html
+++ b/docs/1.8.0/torchvision/models.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/models.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/models.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/models.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/models.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/ops.html
+++ b/docs/1.8.0/torchvision/ops.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/ops.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/ops.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/ops.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/ops.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/transforms.html
+++ b/docs/1.8.0/torchvision/transforms.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/transforms.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/transforms.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/transforms.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/transforms.html'</script>
+</body>
+</html>

--- a/docs/1.8.0/torchvision/utils.html
+++ b/docs/1.8.0/torchvision/utils.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <link rel="canonical" href="https://pytorch.org/vision/stable/utils.html/>
+  <meta http-equiv="refresh" content="0;url=https://pytorch.org/vision/stable/utils.html" />
+</head>
+<body>
+  <h1>Redirecting...</h1>
+  <a href="https://pytorch.org/vision/stable/utils.html">Click here if you are not redirected.<a>
+  <script>location='https://pytorch.org/vision/stable/utils.html'</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #599, #603

The torchvision domain documentation is now served from

https://pytorch.org/vision/

not

https://pytorch.org/docs/1.7.1/torchvision/

As time goes on these pages will be replaced in search results so hopefully by the next release this will not be needed.