### PR TITLE
Fixed typo - replaced 'customer' with 'custom'

### DIFF
--- a/_posts/2021-3-4-pytorch-1.8-new-library-releases.md
+++ b/_posts/2021-3-4-pytorch-1.8-new-library-releases.md
@@ -17,7 +17,7 @@ Please note that, starting in PyTorch 1.6, features are classified as Stable, Be
 
 # TorchVision 0.9.0
 ### [Stable] TorchVision Mobile: Operators, Android Binaries, and Tutorial
-We are excited to announce the first on-device support and binaries for a PyTorch domain library. We have seen significant appetite in both research and industry for on-device vision support to allow low latency, privacy friendly, and resource efficient mobile vision experiences. You can follow this [new tutorial](https://github.com/pytorch/android-demo-app/tree/master/D2Go) to build your own Android object detection app using TorchVision operators, D2Go, or your own customer operators and model.
+We are excited to announce the first on-device support and binaries for a PyTorch domain library. We have seen significant appetite in both research and industry for on-device vision support to allow low latency, privacy friendly, and resource efficient mobile vision experiences. You can follow this [new tutorial](https://github.com/pytorch/android-demo-app/tree/master/D2Go) to build your own Android object detection app using TorchVision operators, D2Go, or your own custom operators and model.
 
 <div class="text-center">
   <img src="{{ site.url }}/assets/images/tochvisionmobile.png" width="30%">


### PR DESCRIPTION
There's a small typo in the post.

> or your own customer operators and model 

should instead be 

> or your own custom operators and model