### PR TITLE
Fix for main navigation menu active states

### DIFF
--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -25,9 +25,7 @@
       <a href="{{ site.external_urls.tutorials }}">Tutorials</a>
     </li>
 
-    {% assign docs = "resources, features, hub" | split: ", " %}
-
-    <li class="main-menu-item {% if docs contains current[1] %}active{% endif %}">
+    <li class="main-menu-item">
       <div id="docsDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
         <a class="doc-option {% if current[1] == {{ site.baseurl }} %}with-down-white-arrow{% else %}with-down-arrow{% endif %}">
           Docs

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -106,6 +106,17 @@
         text-align: center;
       }
 
+      .resources-dropdown:after {
+        content: "•";
+        bottom: -24px;
+        color: $orange;
+        font-size: rem(22px);
+        left: -27px;
+        position: absolute;
+        right: 0;
+        text-align: center;
+      }
+
       a {
         color: $orange;
       }


### PR DESCRIPTION
This PR addresses two issues:

**1) Double active menu state**

<img width="1320" alt="Screen Shot 2021-03-11 at 1 59 02 PM" src="https://user-images.githubusercontent.com/213593/110852036-da4f0000-827f-11eb-8e4b-b9d1d2a400aa.png">

Highlighted states for the 'Docs' menu item should not be present in the Jekyll site and have been removed.

**2) Orange bullet for 'Resources' menu active state**

<img width="1293" alt="Screen Shot 2021-03-11 at 3 39 53 PM" src="https://user-images.githubusercontent.com/213593/110852200-0cf8f880-8280-11eb-9b49-5d8aba2d34f3.png">

An orange bullet has been added to the 'Resources' menu active state to be consistent with other top-level navigation items. 

This bullet is not present on 'Docs' and 'Tutorials' items. This will need to be updated in the docs codebase.
