### PR TITLE
change version for 1.8.1 release, hide profiler.html

### DIFF
--- a/docs/1.8.1/__config__.html
+++ b/docs/1.8.1/__config__.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/_modules/index.html
+++ b/docs/1.8.1/_modules/index.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/_modules/torch.html
+++ b/docs/1.8.1/_modules/torch.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/_modules/typing.html
+++ b/docs/1.8.1/_modules/typing.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/amp.html
+++ b/docs/1.8.1/amp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/autograd.html
+++ b/docs/1.8.1/autograd.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/backends.html
+++ b/docs/1.8.1/backends.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/benchmark_utils.html
+++ b/docs/1.8.1/benchmark_utils.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/bottleneck.html
+++ b/docs/1.8.1/bottleneck.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/checkpoint.html
+++ b/docs/1.8.1/checkpoint.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/community/contribution_guide.html
+++ b/docs/1.8.1/community/contribution_guide.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/community/governance.html
+++ b/docs/1.8.1/community/governance.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/community/persons_of_interest.html
+++ b/docs/1.8.1/community/persons_of_interest.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/complex_numbers.html
+++ b/docs/1.8.1/complex_numbers.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/cpp_extension.html
+++ b/docs/1.8.1/cpp_extension.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/cpp_index.html
+++ b/docs/1.8.1/cpp_index.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/cuda.html
+++ b/docs/1.8.1/cuda.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/cudnn_persistent_rnn.html
+++ b/docs/1.8.1/cudnn_persistent_rnn.html
@@ -183,7 +183,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -252,7 +252,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/cudnn_rnn_determinism.html
+++ b/docs/1.8.1/cudnn_rnn_determinism.html
@@ -183,7 +183,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -252,7 +252,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/data.html
+++ b/docs/1.8.1/data.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/ddp_comm_hooks.html
+++ b/docs/1.8.1/ddp_comm_hooks.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/distributed.html
+++ b/docs/1.8.1/distributed.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/distributions.html
+++ b/docs/1.8.1/distributions.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/dlpack.html
+++ b/docs/1.8.1/dlpack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/fft.html
+++ b/docs/1.8.1/fft.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/futures.html
+++ b/docs/1.8.1/futures.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/fx.html
+++ b/docs/1.8.1/fx.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.Generator.html
+++ b/docs/1.8.1/generated/torch.Generator.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch._assert.html
+++ b/docs/1.8.1/generated/torch._assert.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.abs.html
+++ b/docs/1.8.1/generated/torch.abs.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.absolute.html
+++ b/docs/1.8.1/generated/torch.absolute.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.acos.html
+++ b/docs/1.8.1/generated/torch.acos.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.acosh.html
+++ b/docs/1.8.1/generated/torch.acosh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.add.html
+++ b/docs/1.8.1/generated/torch.add.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addbmm.html
+++ b/docs/1.8.1/generated/torch.addbmm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addcdiv.html
+++ b/docs/1.8.1/generated/torch.addcdiv.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addcmul.html
+++ b/docs/1.8.1/generated/torch.addcmul.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addmm.html
+++ b/docs/1.8.1/generated/torch.addmm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addmv.html
+++ b/docs/1.8.1/generated/torch.addmv.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.addr.html
+++ b/docs/1.8.1/generated/torch.addr.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.all.html
+++ b/docs/1.8.1/generated/torch.all.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.allclose.html
+++ b/docs/1.8.1/generated/torch.allclose.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.amax.html
+++ b/docs/1.8.1/generated/torch.amax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.amin.html
+++ b/docs/1.8.1/generated/torch.amin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.angle.html
+++ b/docs/1.8.1/generated/torch.angle.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.any.html
+++ b/docs/1.8.1/generated/torch.any.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arange.html
+++ b/docs/1.8.1/generated/torch.arange.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arccos.html
+++ b/docs/1.8.1/generated/torch.arccos.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arccosh.html
+++ b/docs/1.8.1/generated/torch.arccosh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arcsin.html
+++ b/docs/1.8.1/generated/torch.arcsin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arcsinh.html
+++ b/docs/1.8.1/generated/torch.arcsinh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arctan.html
+++ b/docs/1.8.1/generated/torch.arctan.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.arctanh.html
+++ b/docs/1.8.1/generated/torch.arctanh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.are_deterministic_algorithms_enabled.html
+++ b/docs/1.8.1/generated/torch.are_deterministic_algorithms_enabled.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.argmax.html
+++ b/docs/1.8.1/generated/torch.argmax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.argmin.html
+++ b/docs/1.8.1/generated/torch.argmin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.argsort.html
+++ b/docs/1.8.1/generated/torch.argsort.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.as_strided.html
+++ b/docs/1.8.1/generated/torch.as_strided.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.as_tensor.html
+++ b/docs/1.8.1/generated/torch.as_tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.asin.html
+++ b/docs/1.8.1/generated/torch.asin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.asinh.html
+++ b/docs/1.8.1/generated/torch.asinh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atan.html
+++ b/docs/1.8.1/generated/torch.atan.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atan2.html
+++ b/docs/1.8.1/generated/torch.atan2.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atanh.html
+++ b/docs/1.8.1/generated/torch.atanh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atleast_1d.html
+++ b/docs/1.8.1/generated/torch.atleast_1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atleast_2d.html
+++ b/docs/1.8.1/generated/torch.atleast_2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.atleast_3d.html
+++ b/docs/1.8.1/generated/torch.atleast_3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.baddbmm.html
+++ b/docs/1.8.1/generated/torch.baddbmm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bartlett_window.html
+++ b/docs/1.8.1/generated/torch.bartlett_window.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bernoulli.html
+++ b/docs/1.8.1/generated/torch.bernoulli.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bincount.html
+++ b/docs/1.8.1/generated/torch.bincount.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bitwise_and.html
+++ b/docs/1.8.1/generated/torch.bitwise_and.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bitwise_not.html
+++ b/docs/1.8.1/generated/torch.bitwise_not.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bitwise_or.html
+++ b/docs/1.8.1/generated/torch.bitwise_or.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bitwise_xor.html
+++ b/docs/1.8.1/generated/torch.bitwise_xor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.blackman_window.html
+++ b/docs/1.8.1/generated/torch.blackman_window.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.block_diag.html
+++ b/docs/1.8.1/generated/torch.block_diag.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bmm.html
+++ b/docs/1.8.1/generated/torch.bmm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.broadcast_shapes.html
+++ b/docs/1.8.1/generated/torch.broadcast_shapes.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.broadcast_tensors.html
+++ b/docs/1.8.1/generated/torch.broadcast_tensors.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.broadcast_to.html
+++ b/docs/1.8.1/generated/torch.broadcast_to.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.bucketize.html
+++ b/docs/1.8.1/generated/torch.bucketize.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.can_cast.html
+++ b/docs/1.8.1/generated/torch.can_cast.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cartesian_prod.html
+++ b/docs/1.8.1/generated/torch.cartesian_prod.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cat.html
+++ b/docs/1.8.1/generated/torch.cat.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cdist.html
+++ b/docs/1.8.1/generated/torch.cdist.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ceil.html
+++ b/docs/1.8.1/generated/torch.ceil.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.chain_matmul.html
+++ b/docs/1.8.1/generated/torch.chain_matmul.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cholesky.html
+++ b/docs/1.8.1/generated/torch.cholesky.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cholesky_inverse.html
+++ b/docs/1.8.1/generated/torch.cholesky_inverse.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cholesky_solve.html
+++ b/docs/1.8.1/generated/torch.cholesky_solve.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.chunk.html
+++ b/docs/1.8.1/generated/torch.chunk.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.clamp.html
+++ b/docs/1.8.1/generated/torch.clamp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.clip.html
+++ b/docs/1.8.1/generated/torch.clip.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.clone.html
+++ b/docs/1.8.1/generated/torch.clone.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.column_stack.html
+++ b/docs/1.8.1/generated/torch.column_stack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.combinations.html
+++ b/docs/1.8.1/generated/torch.combinations.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.compiled_with_cxx11_abi.html
+++ b/docs/1.8.1/generated/torch.compiled_with_cxx11_abi.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.complex.html
+++ b/docs/1.8.1/generated/torch.complex.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.conj.html
+++ b/docs/1.8.1/generated/torch.conj.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.copysign.html
+++ b/docs/1.8.1/generated/torch.copysign.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cos.html
+++ b/docs/1.8.1/generated/torch.cos.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cosh.html
+++ b/docs/1.8.1/generated/torch.cosh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.count_nonzero.html
+++ b/docs/1.8.1/generated/torch.count_nonzero.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cross.html
+++ b/docs/1.8.1/generated/torch.cross.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cummax.html
+++ b/docs/1.8.1/generated/torch.cummax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cummin.html
+++ b/docs/1.8.1/generated/torch.cummin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cumprod.html
+++ b/docs/1.8.1/generated/torch.cumprod.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.cumsum.html
+++ b/docs/1.8.1/generated/torch.cumsum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.deg2rad.html
+++ b/docs/1.8.1/generated/torch.deg2rad.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.dequantize.html
+++ b/docs/1.8.1/generated/torch.dequantize.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.det.html
+++ b/docs/1.8.1/generated/torch.det.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.diag.html
+++ b/docs/1.8.1/generated/torch.diag.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.diag_embed.html
+++ b/docs/1.8.1/generated/torch.diag_embed.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.diagflat.html
+++ b/docs/1.8.1/generated/torch.diagflat.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.diagonal.html
+++ b/docs/1.8.1/generated/torch.diagonal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.diff.html
+++ b/docs/1.8.1/generated/torch.diff.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.digamma.html
+++ b/docs/1.8.1/generated/torch.digamma.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.dist.html
+++ b/docs/1.8.1/generated/torch.dist.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.div.html
+++ b/docs/1.8.1/generated/torch.div.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.divide.html
+++ b/docs/1.8.1/generated/torch.divide.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.dot.html
+++ b/docs/1.8.1/generated/torch.dot.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.dstack.html
+++ b/docs/1.8.1/generated/torch.dstack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.eig.html
+++ b/docs/1.8.1/generated/torch.eig.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.einsum.html
+++ b/docs/1.8.1/generated/torch.einsum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.empty.html
+++ b/docs/1.8.1/generated/torch.empty.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.empty_like.html
+++ b/docs/1.8.1/generated/torch.empty_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.empty_strided.html
+++ b/docs/1.8.1/generated/torch.empty_strided.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.enable_grad.html
+++ b/docs/1.8.1/generated/torch.enable_grad.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.eq.html
+++ b/docs/1.8.1/generated/torch.eq.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.equal.html
+++ b/docs/1.8.1/generated/torch.equal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.erf.html
+++ b/docs/1.8.1/generated/torch.erf.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.erfc.html
+++ b/docs/1.8.1/generated/torch.erfc.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.erfinv.html
+++ b/docs/1.8.1/generated/torch.erfinv.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.exp.html
+++ b/docs/1.8.1/generated/torch.exp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.exp2.html
+++ b/docs/1.8.1/generated/torch.exp2.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.expm1.html
+++ b/docs/1.8.1/generated/torch.expm1.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.eye.html
+++ b/docs/1.8.1/generated/torch.eye.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fake_quantize_per_channel_affine.html
+++ b/docs/1.8.1/generated/torch.fake_quantize_per_channel_affine.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fake_quantize_per_tensor_affine.html
+++ b/docs/1.8.1/generated/torch.fake_quantize_per_tensor_affine.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fix.html
+++ b/docs/1.8.1/generated/torch.fix.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.flatten.html
+++ b/docs/1.8.1/generated/torch.flatten.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.flip.html
+++ b/docs/1.8.1/generated/torch.flip.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fliplr.html
+++ b/docs/1.8.1/generated/torch.fliplr.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.flipud.html
+++ b/docs/1.8.1/generated/torch.flipud.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.float_power.html
+++ b/docs/1.8.1/generated/torch.float_power.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.floor.html
+++ b/docs/1.8.1/generated/torch.floor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.floor_divide.html
+++ b/docs/1.8.1/generated/torch.floor_divide.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fmax.html
+++ b/docs/1.8.1/generated/torch.fmax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fmin.html
+++ b/docs/1.8.1/generated/torch.fmin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.fmod.html
+++ b/docs/1.8.1/generated/torch.fmod.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.frac.html
+++ b/docs/1.8.1/generated/torch.frac.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.from_numpy.html
+++ b/docs/1.8.1/generated/torch.from_numpy.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.full.html
+++ b/docs/1.8.1/generated/torch.full.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.full_like.html
+++ b/docs/1.8.1/generated/torch.full_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.gather.html
+++ b/docs/1.8.1/generated/torch.gather.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.gcd.html
+++ b/docs/1.8.1/generated/torch.gcd.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ge.html
+++ b/docs/1.8.1/generated/torch.ge.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.geqrf.html
+++ b/docs/1.8.1/generated/torch.geqrf.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ger.html
+++ b/docs/1.8.1/generated/torch.ger.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.get_default_dtype.html
+++ b/docs/1.8.1/generated/torch.get_default_dtype.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.get_num_interop_threads.html
+++ b/docs/1.8.1/generated/torch.get_num_interop_threads.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.get_num_threads.html
+++ b/docs/1.8.1/generated/torch.get_num_threads.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.get_rng_state.html
+++ b/docs/1.8.1/generated/torch.get_rng_state.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.greater.html
+++ b/docs/1.8.1/generated/torch.greater.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.greater_equal.html
+++ b/docs/1.8.1/generated/torch.greater_equal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.gt.html
+++ b/docs/1.8.1/generated/torch.gt.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.hamming_window.html
+++ b/docs/1.8.1/generated/torch.hamming_window.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.hann_window.html
+++ b/docs/1.8.1/generated/torch.hann_window.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.heaviside.html
+++ b/docs/1.8.1/generated/torch.heaviside.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.histc.html
+++ b/docs/1.8.1/generated/torch.histc.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.hstack.html
+++ b/docs/1.8.1/generated/torch.hstack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.hypot.html
+++ b/docs/1.8.1/generated/torch.hypot.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.i0.html
+++ b/docs/1.8.1/generated/torch.i0.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.igamma.html
+++ b/docs/1.8.1/generated/torch.igamma.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.igammac.html
+++ b/docs/1.8.1/generated/torch.igammac.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.imag.html
+++ b/docs/1.8.1/generated/torch.imag.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.index_select.html
+++ b/docs/1.8.1/generated/torch.index_select.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.initial_seed.html
+++ b/docs/1.8.1/generated/torch.initial_seed.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.inner.html
+++ b/docs/1.8.1/generated/torch.inner.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.inverse.html
+++ b/docs/1.8.1/generated/torch.inverse.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.is_complex.html
+++ b/docs/1.8.1/generated/torch.is_complex.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.is_floating_point.html
+++ b/docs/1.8.1/generated/torch.is_floating_point.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.is_nonzero.html
+++ b/docs/1.8.1/generated/torch.is_nonzero.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.is_storage.html
+++ b/docs/1.8.1/generated/torch.is_storage.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.is_tensor.html
+++ b/docs/1.8.1/generated/torch.is_tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isclose.html
+++ b/docs/1.8.1/generated/torch.isclose.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isfinite.html
+++ b/docs/1.8.1/generated/torch.isfinite.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isinf.html
+++ b/docs/1.8.1/generated/torch.isinf.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isnan.html
+++ b/docs/1.8.1/generated/torch.isnan.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isneginf.html
+++ b/docs/1.8.1/generated/torch.isneginf.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isposinf.html
+++ b/docs/1.8.1/generated/torch.isposinf.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.isreal.html
+++ b/docs/1.8.1/generated/torch.isreal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.istft.html
+++ b/docs/1.8.1/generated/torch.istft.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.ScriptFunction.html
+++ b/docs/1.8.1/generated/torch.jit.ScriptFunction.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.ScriptModule.html
+++ b/docs/1.8.1/generated/torch.jit.ScriptModule.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.fork.html
+++ b/docs/1.8.1/generated/torch.jit.fork.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.freeze.html
+++ b/docs/1.8.1/generated/torch.jit.freeze.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.ignore.html
+++ b/docs/1.8.1/generated/torch.jit.ignore.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.isinstance.html
+++ b/docs/1.8.1/generated/torch.jit.isinstance.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.load.html
+++ b/docs/1.8.1/generated/torch.jit.load.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.save.html
+++ b/docs/1.8.1/generated/torch.jit.save.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.script.html
+++ b/docs/1.8.1/generated/torch.jit.script.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.script_if_tracing.html
+++ b/docs/1.8.1/generated/torch.jit.script_if_tracing.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.trace.html
+++ b/docs/1.8.1/generated/torch.jit.trace.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.trace_module.html
+++ b/docs/1.8.1/generated/torch.jit.trace_module.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.unused.html
+++ b/docs/1.8.1/generated/torch.jit.unused.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.jit.wait.html
+++ b/docs/1.8.1/generated/torch.jit.wait.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.kaiser_window.html
+++ b/docs/1.8.1/generated/torch.kaiser_window.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.kron.html
+++ b/docs/1.8.1/generated/torch.kron.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.kthvalue.html
+++ b/docs/1.8.1/generated/torch.kthvalue.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lcm.html
+++ b/docs/1.8.1/generated/torch.lcm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ldexp.html
+++ b/docs/1.8.1/generated/torch.ldexp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.le.html
+++ b/docs/1.8.1/generated/torch.le.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lerp.html
+++ b/docs/1.8.1/generated/torch.lerp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.less.html
+++ b/docs/1.8.1/generated/torch.less.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.less_equal.html
+++ b/docs/1.8.1/generated/torch.less_equal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lgamma.html
+++ b/docs/1.8.1/generated/torch.lgamma.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.linspace.html
+++ b/docs/1.8.1/generated/torch.linspace.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.load.html
+++ b/docs/1.8.1/generated/torch.load.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lobpcg.html
+++ b/docs/1.8.1/generated/torch.lobpcg.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.log.html
+++ b/docs/1.8.1/generated/torch.log.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.log10.html
+++ b/docs/1.8.1/generated/torch.log10.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.log1p.html
+++ b/docs/1.8.1/generated/torch.log1p.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.log2.html
+++ b/docs/1.8.1/generated/torch.log2.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logaddexp.html
+++ b/docs/1.8.1/generated/torch.logaddexp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logaddexp2.html
+++ b/docs/1.8.1/generated/torch.logaddexp2.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logcumsumexp.html
+++ b/docs/1.8.1/generated/torch.logcumsumexp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logdet.html
+++ b/docs/1.8.1/generated/torch.logdet.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logical_and.html
+++ b/docs/1.8.1/generated/torch.logical_and.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logical_not.html
+++ b/docs/1.8.1/generated/torch.logical_not.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logical_or.html
+++ b/docs/1.8.1/generated/torch.logical_or.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logical_xor.html
+++ b/docs/1.8.1/generated/torch.logical_xor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logit.html
+++ b/docs/1.8.1/generated/torch.logit.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logspace.html
+++ b/docs/1.8.1/generated/torch.logspace.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.logsumexp.html
+++ b/docs/1.8.1/generated/torch.logsumexp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lstsq.html
+++ b/docs/1.8.1/generated/torch.lstsq.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lt.html
+++ b/docs/1.8.1/generated/torch.lt.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lu.html
+++ b/docs/1.8.1/generated/torch.lu.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lu_solve.html
+++ b/docs/1.8.1/generated/torch.lu_solve.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.lu_unpack.html
+++ b/docs/1.8.1/generated/torch.lu_unpack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.manual_seed.html
+++ b/docs/1.8.1/generated/torch.manual_seed.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.masked_select.html
+++ b/docs/1.8.1/generated/torch.masked_select.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.matmul.html
+++ b/docs/1.8.1/generated/torch.matmul.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.matrix_exp.html
+++ b/docs/1.8.1/generated/torch.matrix_exp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.matrix_power.html
+++ b/docs/1.8.1/generated/torch.matrix_power.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.matrix_rank.html
+++ b/docs/1.8.1/generated/torch.matrix_rank.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.max.html
+++ b/docs/1.8.1/generated/torch.max.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.maximum.html
+++ b/docs/1.8.1/generated/torch.maximum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mean.html
+++ b/docs/1.8.1/generated/torch.mean.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.median.html
+++ b/docs/1.8.1/generated/torch.median.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.meshgrid.html
+++ b/docs/1.8.1/generated/torch.meshgrid.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.min.html
+++ b/docs/1.8.1/generated/torch.min.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.minimum.html
+++ b/docs/1.8.1/generated/torch.minimum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mm.html
+++ b/docs/1.8.1/generated/torch.mm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mode.html
+++ b/docs/1.8.1/generated/torch.mode.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.moveaxis.html
+++ b/docs/1.8.1/generated/torch.moveaxis.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.movedim.html
+++ b/docs/1.8.1/generated/torch.movedim.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.msort.html
+++ b/docs/1.8.1/generated/torch.msort.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mul.html
+++ b/docs/1.8.1/generated/torch.mul.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.multinomial.html
+++ b/docs/1.8.1/generated/torch.multinomial.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.multiply.html
+++ b/docs/1.8.1/generated/torch.multiply.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mv.html
+++ b/docs/1.8.1/generated/torch.mv.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.mvlgamma.html
+++ b/docs/1.8.1/generated/torch.mvlgamma.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nan_to_num.html
+++ b/docs/1.8.1/generated/torch.nan_to_num.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nanmedian.html
+++ b/docs/1.8.1/generated/torch.nanmedian.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nanquantile.html
+++ b/docs/1.8.1/generated/torch.nanquantile.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nansum.html
+++ b/docs/1.8.1/generated/torch.nansum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.narrow.html
+++ b/docs/1.8.1/generated/torch.narrow.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ne.html
+++ b/docs/1.8.1/generated/torch.ne.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.neg.html
+++ b/docs/1.8.1/generated/torch.neg.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.negative.html
+++ b/docs/1.8.1/generated/torch.negative.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nextafter.html
+++ b/docs/1.8.1/generated/torch.nextafter.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool1d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool3d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveAvgPool3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveLogSoftmaxWithLoss.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveLogSoftmaxWithLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool1d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool3d.html
+++ b/docs/1.8.1/generated/torch.nn.AdaptiveMaxPool3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AlphaDropout.html
+++ b/docs/1.8.1/generated/torch.nn.AlphaDropout.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AvgPool1d.html
+++ b/docs/1.8.1/generated/torch.nn.AvgPool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AvgPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.AvgPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.AvgPool3d.html
+++ b/docs/1.8.1/generated/torch.nn.AvgPool3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.BCELoss.html
+++ b/docs/1.8.1/generated/torch.nn.BCELoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.BCEWithLogitsLoss.html
+++ b/docs/1.8.1/generated/torch.nn.BCEWithLogitsLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.BatchNorm1d.html
+++ b/docs/1.8.1/generated/torch.nn.BatchNorm1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.BatchNorm2d.html
+++ b/docs/1.8.1/generated/torch.nn.BatchNorm2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.BatchNorm3d.html
+++ b/docs/1.8.1/generated/torch.nn.BatchNorm3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Bilinear.html
+++ b/docs/1.8.1/generated/torch.nn.Bilinear.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.CELU.html
+++ b/docs/1.8.1/generated/torch.nn.CELU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.CTCLoss.html
+++ b/docs/1.8.1/generated/torch.nn.CTCLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ChannelShuffle.html
+++ b/docs/1.8.1/generated/torch.nn.ChannelShuffle.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConstantPad1d.html
+++ b/docs/1.8.1/generated/torch.nn.ConstantPad1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConstantPad2d.html
+++ b/docs/1.8.1/generated/torch.nn.ConstantPad2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConstantPad3d.html
+++ b/docs/1.8.1/generated/torch.nn.ConstantPad3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Conv1d.html
+++ b/docs/1.8.1/generated/torch.nn.Conv1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Conv2d.html
+++ b/docs/1.8.1/generated/torch.nn.Conv2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Conv3d.html
+++ b/docs/1.8.1/generated/torch.nn.Conv3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConvTranspose1d.html
+++ b/docs/1.8.1/generated/torch.nn.ConvTranspose1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConvTranspose2d.html
+++ b/docs/1.8.1/generated/torch.nn.ConvTranspose2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ConvTranspose3d.html
+++ b/docs/1.8.1/generated/torch.nn.ConvTranspose3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.CosineEmbeddingLoss.html
+++ b/docs/1.8.1/generated/torch.nn.CosineEmbeddingLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.CosineSimilarity.html
+++ b/docs/1.8.1/generated/torch.nn.CosineSimilarity.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.CrossEntropyLoss.html
+++ b/docs/1.8.1/generated/torch.nn.CrossEntropyLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.DataParallel.html
+++ b/docs/1.8.1/generated/torch.nn.DataParallel.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Dropout.html
+++ b/docs/1.8.1/generated/torch.nn.Dropout.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Dropout2d.html
+++ b/docs/1.8.1/generated/torch.nn.Dropout2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Dropout3d.html
+++ b/docs/1.8.1/generated/torch.nn.Dropout3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ELU.html
+++ b/docs/1.8.1/generated/torch.nn.ELU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Embedding.html
+++ b/docs/1.8.1/generated/torch.nn.Embedding.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.EmbeddingBag.html
+++ b/docs/1.8.1/generated/torch.nn.EmbeddingBag.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Flatten.html
+++ b/docs/1.8.1/generated/torch.nn.Flatten.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Fold.html
+++ b/docs/1.8.1/generated/torch.nn.Fold.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.FractionalMaxPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.FractionalMaxPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.GELU.html
+++ b/docs/1.8.1/generated/torch.nn.GELU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.GRU.html
+++ b/docs/1.8.1/generated/torch.nn.GRU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.GRUCell.html
+++ b/docs/1.8.1/generated/torch.nn.GRUCell.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.GaussianNLLLoss.html
+++ b/docs/1.8.1/generated/torch.nn.GaussianNLLLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.GroupNorm.html
+++ b/docs/1.8.1/generated/torch.nn.GroupNorm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Hardshrink.html
+++ b/docs/1.8.1/generated/torch.nn.Hardshrink.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Hardsigmoid.html
+++ b/docs/1.8.1/generated/torch.nn.Hardsigmoid.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Hardswish.html
+++ b/docs/1.8.1/generated/torch.nn.Hardswish.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Hardtanh.html
+++ b/docs/1.8.1/generated/torch.nn.Hardtanh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.HingeEmbeddingLoss.html
+++ b/docs/1.8.1/generated/torch.nn.HingeEmbeddingLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Identity.html
+++ b/docs/1.8.1/generated/torch.nn.Identity.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.InstanceNorm1d.html
+++ b/docs/1.8.1/generated/torch.nn.InstanceNorm1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.InstanceNorm2d.html
+++ b/docs/1.8.1/generated/torch.nn.InstanceNorm2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.InstanceNorm3d.html
+++ b/docs/1.8.1/generated/torch.nn.InstanceNorm3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.KLDivLoss.html
+++ b/docs/1.8.1/generated/torch.nn.KLDivLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.L1Loss.html
+++ b/docs/1.8.1/generated/torch.nn.L1Loss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LPPool1d.html
+++ b/docs/1.8.1/generated/torch.nn.LPPool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LPPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.LPPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LSTM.html
+++ b/docs/1.8.1/generated/torch.nn.LSTM.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LSTMCell.html
+++ b/docs/1.8.1/generated/torch.nn.LSTMCell.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LayerNorm.html
+++ b/docs/1.8.1/generated/torch.nn.LayerNorm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConv1d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConv1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConv2d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConv2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConv3d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConv3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConvTranspose1d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConvTranspose1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConvTranspose2d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConvTranspose2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyConvTranspose3d.html
+++ b/docs/1.8.1/generated/torch.nn.LazyConvTranspose3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LazyLinear.html
+++ b/docs/1.8.1/generated/torch.nn.LazyLinear.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LeakyReLU.html
+++ b/docs/1.8.1/generated/torch.nn.LeakyReLU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Linear.html
+++ b/docs/1.8.1/generated/torch.nn.Linear.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LocalResponseNorm.html
+++ b/docs/1.8.1/generated/torch.nn.LocalResponseNorm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LogSigmoid.html
+++ b/docs/1.8.1/generated/torch.nn.LogSigmoid.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.LogSoftmax.html
+++ b/docs/1.8.1/generated/torch.nn.LogSoftmax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MSELoss.html
+++ b/docs/1.8.1/generated/torch.nn.MSELoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MarginRankingLoss.html
+++ b/docs/1.8.1/generated/torch.nn.MarginRankingLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxPool1d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxPool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxPool2d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxPool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxPool3d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxPool3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxUnpool1d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxUnpool1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxUnpool2d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxUnpool2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MaxUnpool3d.html
+++ b/docs/1.8.1/generated/torch.nn.MaxUnpool3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Module.html
+++ b/docs/1.8.1/generated/torch.nn.Module.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ModuleDict.html
+++ b/docs/1.8.1/generated/torch.nn.ModuleDict.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ModuleList.html
+++ b/docs/1.8.1/generated/torch.nn.ModuleList.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MultiLabelMarginLoss.html
+++ b/docs/1.8.1/generated/torch.nn.MultiLabelMarginLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MultiLabelSoftMarginLoss.html
+++ b/docs/1.8.1/generated/torch.nn.MultiLabelSoftMarginLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MultiMarginLoss.html
+++ b/docs/1.8.1/generated/torch.nn.MultiMarginLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.MultiheadAttention.html
+++ b/docs/1.8.1/generated/torch.nn.MultiheadAttention.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.NLLLoss.html
+++ b/docs/1.8.1/generated/torch.nn.NLLLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.PReLU.html
+++ b/docs/1.8.1/generated/torch.nn.PReLU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.PairwiseDistance.html
+++ b/docs/1.8.1/generated/torch.nn.PairwiseDistance.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ParameterDict.html
+++ b/docs/1.8.1/generated/torch.nn.ParameterDict.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ParameterList.html
+++ b/docs/1.8.1/generated/torch.nn.ParameterList.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.PixelShuffle.html
+++ b/docs/1.8.1/generated/torch.nn.PixelShuffle.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.PixelUnshuffle.html
+++ b/docs/1.8.1/generated/torch.nn.PixelUnshuffle.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.PoissonNLLLoss.html
+++ b/docs/1.8.1/generated/torch.nn.PoissonNLLLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.RNN.html
+++ b/docs/1.8.1/generated/torch.nn.RNN.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.RNNBase.html
+++ b/docs/1.8.1/generated/torch.nn.RNNBase.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.RNNCell.html
+++ b/docs/1.8.1/generated/torch.nn.RNNCell.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.RReLU.html
+++ b/docs/1.8.1/generated/torch.nn.RReLU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReLU.html
+++ b/docs/1.8.1/generated/torch.nn.ReLU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReLU6.html
+++ b/docs/1.8.1/generated/torch.nn.ReLU6.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReflectionPad1d.html
+++ b/docs/1.8.1/generated/torch.nn.ReflectionPad1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReflectionPad2d.html
+++ b/docs/1.8.1/generated/torch.nn.ReflectionPad2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReplicationPad1d.html
+++ b/docs/1.8.1/generated/torch.nn.ReplicationPad1d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReplicationPad2d.html
+++ b/docs/1.8.1/generated/torch.nn.ReplicationPad2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ReplicationPad3d.html
+++ b/docs/1.8.1/generated/torch.nn.ReplicationPad3d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.SELU.html
+++ b/docs/1.8.1/generated/torch.nn.SELU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Sequential.html
+++ b/docs/1.8.1/generated/torch.nn.Sequential.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.SiLU.html
+++ b/docs/1.8.1/generated/torch.nn.SiLU.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Sigmoid.html
+++ b/docs/1.8.1/generated/torch.nn.Sigmoid.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.SmoothL1Loss.html
+++ b/docs/1.8.1/generated/torch.nn.SmoothL1Loss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.SoftMarginLoss.html
+++ b/docs/1.8.1/generated/torch.nn.SoftMarginLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softmax.html
+++ b/docs/1.8.1/generated/torch.nn.Softmax.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softmax2d.html
+++ b/docs/1.8.1/generated/torch.nn.Softmax2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softmin.html
+++ b/docs/1.8.1/generated/torch.nn.Softmin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softplus.html
+++ b/docs/1.8.1/generated/torch.nn.Softplus.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softshrink.html
+++ b/docs/1.8.1/generated/torch.nn.Softshrink.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Softsign.html
+++ b/docs/1.8.1/generated/torch.nn.Softsign.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.SyncBatchNorm.html
+++ b/docs/1.8.1/generated/torch.nn.SyncBatchNorm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Tanh.html
+++ b/docs/1.8.1/generated/torch.nn.Tanh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Tanhshrink.html
+++ b/docs/1.8.1/generated/torch.nn.Tanhshrink.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Threshold.html
+++ b/docs/1.8.1/generated/torch.nn.Threshold.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Transformer.html
+++ b/docs/1.8.1/generated/torch.nn.Transformer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TransformerDecoder.html
+++ b/docs/1.8.1/generated/torch.nn.TransformerDecoder.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TransformerDecoderLayer.html
+++ b/docs/1.8.1/generated/torch.nn.TransformerDecoderLayer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TransformerEncoder.html
+++ b/docs/1.8.1/generated/torch.nn.TransformerEncoder.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TransformerEncoderLayer.html
+++ b/docs/1.8.1/generated/torch.nn.TransformerEncoderLayer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TripletMarginLoss.html
+++ b/docs/1.8.1/generated/torch.nn.TripletMarginLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.TripletMarginWithDistanceLoss.html
+++ b/docs/1.8.1/generated/torch.nn.TripletMarginWithDistanceLoss.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Unflatten.html
+++ b/docs/1.8.1/generated/torch.nn.Unflatten.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Unfold.html
+++ b/docs/1.8.1/generated/torch.nn.Unfold.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.Upsample.html
+++ b/docs/1.8.1/generated/torch.nn.Upsample.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.UpsamplingBilinear2d.html
+++ b/docs/1.8.1/generated/torch.nn.UpsamplingBilinear2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.UpsamplingNearest2d.html
+++ b/docs/1.8.1/generated/torch.nn.UpsamplingNearest2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.ZeroPad2d.html
+++ b/docs/1.8.1/generated/torch.nn.ZeroPad2d.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.modules.lazy.LazyModuleMixin.html
+++ b/docs/1.8.1/generated/torch.nn.modules.lazy.LazyModuleMixin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.modules.module.register_module_backward_hook.html
+++ b/docs/1.8.1/generated/torch.nn.modules.module.register_module_backward_hook.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.modules.module.register_module_forward_hook.html
+++ b/docs/1.8.1/generated/torch.nn.modules.module.register_module_forward_hook.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.modules.module.register_module_forward_pre_hook.html
+++ b/docs/1.8.1/generated/torch.nn.modules.module.register_module_forward_pre_hook.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.parallel.DistributedDataParallel.html
+++ b/docs/1.8.1/generated/torch.nn.parallel.DistributedDataParallel.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.parameter.Parameter.html
+++ b/docs/1.8.1/generated/torch.nn.parameter.Parameter.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.parameter.UninitializedParameter.html
+++ b/docs/1.8.1/generated/torch.nn.parameter.UninitializedParameter.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.clip_grad_norm_.html
+++ b/docs/1.8.1/generated/torch.nn.utils.clip_grad_norm_.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.clip_grad_value_.html
+++ b/docs/1.8.1/generated/torch.nn.utils.clip_grad_value_.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.parameters_to_vector.html
+++ b/docs/1.8.1/generated/torch.nn.utils.parameters_to_vector.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.BasePruningMethod.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.BasePruningMethod.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.CustomFromMask.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.CustomFromMask.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.Identity.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.Identity.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.L1Unstructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.L1Unstructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.LnStructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.LnStructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.PruningContainer.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.PruningContainer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.RandomStructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.RandomStructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.RandomUnstructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.RandomUnstructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.custom_from_mask.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.custom_from_mask.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.global_unstructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.global_unstructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.identity.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.identity.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.is_pruned.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.is_pruned.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.l1_unstructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.l1_unstructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.ln_structured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.ln_structured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.random_structured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.random_structured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.random_unstructured.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.random_unstructured.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.prune.remove.html
+++ b/docs/1.8.1/generated/torch.nn.utils.prune.remove.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.remove_spectral_norm.html
+++ b/docs/1.8.1/generated/torch.nn.utils.remove_spectral_norm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.remove_weight_norm.html
+++ b/docs/1.8.1/generated/torch.nn.utils.remove_weight_norm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.rnn.PackedSequence.html
+++ b/docs/1.8.1/generated/torch.nn.utils.rnn.PackedSequence.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.rnn.pack_padded_sequence.html
+++ b/docs/1.8.1/generated/torch.nn.utils.rnn.pack_padded_sequence.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.rnn.pack_sequence.html
+++ b/docs/1.8.1/generated/torch.nn.utils.rnn.pack_sequence.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.rnn.pad_packed_sequence.html
+++ b/docs/1.8.1/generated/torch.nn.utils.rnn.pad_packed_sequence.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.rnn.pad_sequence.html
+++ b/docs/1.8.1/generated/torch.nn.utils.rnn.pad_sequence.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.spectral_norm.html
+++ b/docs/1.8.1/generated/torch.nn.utils.spectral_norm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.vector_to_parameters.html
+++ b/docs/1.8.1/generated/torch.nn.utils.vector_to_parameters.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nn.utils.weight_norm.html
+++ b/docs/1.8.1/generated/torch.nn.utils.weight_norm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.no_grad.html
+++ b/docs/1.8.1/generated/torch.no_grad.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.nonzero.html
+++ b/docs/1.8.1/generated/torch.nonzero.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.norm.html
+++ b/docs/1.8.1/generated/torch.norm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.normal.html
+++ b/docs/1.8.1/generated/torch.normal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.not_equal.html
+++ b/docs/1.8.1/generated/torch.not_equal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.numel.html
+++ b/docs/1.8.1/generated/torch.numel.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ones.html
+++ b/docs/1.8.1/generated/torch.ones.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ones_like.html
+++ b/docs/1.8.1/generated/torch.ones_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.orgqr.html
+++ b/docs/1.8.1/generated/torch.orgqr.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ormqr.html
+++ b/docs/1.8.1/generated/torch.ormqr.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.outer.html
+++ b/docs/1.8.1/generated/torch.outer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.pca_lowrank.html
+++ b/docs/1.8.1/generated/torch.pca_lowrank.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.pinverse.html
+++ b/docs/1.8.1/generated/torch.pinverse.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.poisson.html
+++ b/docs/1.8.1/generated/torch.poisson.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.polar.html
+++ b/docs/1.8.1/generated/torch.polar.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.polygamma.html
+++ b/docs/1.8.1/generated/torch.polygamma.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.pow.html
+++ b/docs/1.8.1/generated/torch.pow.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.prod.html
+++ b/docs/1.8.1/generated/torch.prod.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.promote_types.html
+++ b/docs/1.8.1/generated/torch.promote_types.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.qr.html
+++ b/docs/1.8.1/generated/torch.qr.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.quantile.html
+++ b/docs/1.8.1/generated/torch.quantile.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.quantize_per_channel.html
+++ b/docs/1.8.1/generated/torch.quantize_per_channel.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.quantize_per_tensor.html
+++ b/docs/1.8.1/generated/torch.quantize_per_tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.quasirandom.SobolEngine.html
+++ b/docs/1.8.1/generated/torch.quasirandom.SobolEngine.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.rad2deg.html
+++ b/docs/1.8.1/generated/torch.rad2deg.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.rand.html
+++ b/docs/1.8.1/generated/torch.rand.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.rand_like.html
+++ b/docs/1.8.1/generated/torch.rand_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.randint.html
+++ b/docs/1.8.1/generated/torch.randint.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.randint_like.html
+++ b/docs/1.8.1/generated/torch.randint_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.randn.html
+++ b/docs/1.8.1/generated/torch.randn.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.randn_like.html
+++ b/docs/1.8.1/generated/torch.randn_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.randperm.html
+++ b/docs/1.8.1/generated/torch.randperm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.range.html
+++ b/docs/1.8.1/generated/torch.range.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.ravel.html
+++ b/docs/1.8.1/generated/torch.ravel.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.real.html
+++ b/docs/1.8.1/generated/torch.real.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.reciprocal.html
+++ b/docs/1.8.1/generated/torch.reciprocal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.remainder.html
+++ b/docs/1.8.1/generated/torch.remainder.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.renorm.html
+++ b/docs/1.8.1/generated/torch.renorm.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.repeat_interleave.html
+++ b/docs/1.8.1/generated/torch.repeat_interleave.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.reshape.html
+++ b/docs/1.8.1/generated/torch.reshape.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.result_type.html
+++ b/docs/1.8.1/generated/torch.result_type.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.roll.html
+++ b/docs/1.8.1/generated/torch.roll.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.rot90.html
+++ b/docs/1.8.1/generated/torch.rot90.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.round.html
+++ b/docs/1.8.1/generated/torch.round.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.row_stack.html
+++ b/docs/1.8.1/generated/torch.row_stack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.rsqrt.html
+++ b/docs/1.8.1/generated/torch.rsqrt.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.save.html
+++ b/docs/1.8.1/generated/torch.save.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.scatter.html
+++ b/docs/1.8.1/generated/torch.scatter.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.scatter_add.html
+++ b/docs/1.8.1/generated/torch.scatter_add.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.searchsorted.html
+++ b/docs/1.8.1/generated/torch.searchsorted.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.seed.html
+++ b/docs/1.8.1/generated/torch.seed.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_default_dtype.html
+++ b/docs/1.8.1/generated/torch.set_default_dtype.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_default_tensor_type.html
+++ b/docs/1.8.1/generated/torch.set_default_tensor_type.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_flush_denormal.html
+++ b/docs/1.8.1/generated/torch.set_flush_denormal.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_grad_enabled.html
+++ b/docs/1.8.1/generated/torch.set_grad_enabled.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_num_interop_threads.html
+++ b/docs/1.8.1/generated/torch.set_num_interop_threads.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_num_threads.html
+++ b/docs/1.8.1/generated/torch.set_num_threads.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_printoptions.html
+++ b/docs/1.8.1/generated/torch.set_printoptions.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.set_rng_state.html
+++ b/docs/1.8.1/generated/torch.set_rng_state.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sgn.html
+++ b/docs/1.8.1/generated/torch.sgn.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sigmoid.html
+++ b/docs/1.8.1/generated/torch.sigmoid.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sign.html
+++ b/docs/1.8.1/generated/torch.sign.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.signbit.html
+++ b/docs/1.8.1/generated/torch.signbit.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sin.html
+++ b/docs/1.8.1/generated/torch.sin.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sinc.html
+++ b/docs/1.8.1/generated/torch.sinc.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sinh.html
+++ b/docs/1.8.1/generated/torch.sinh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.slogdet.html
+++ b/docs/1.8.1/generated/torch.slogdet.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.solve.html
+++ b/docs/1.8.1/generated/torch.solve.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sort.html
+++ b/docs/1.8.1/generated/torch.sort.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sparse_coo_tensor.html
+++ b/docs/1.8.1/generated/torch.sparse_coo_tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.split.html
+++ b/docs/1.8.1/generated/torch.split.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sqrt.html
+++ b/docs/1.8.1/generated/torch.sqrt.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.square.html
+++ b/docs/1.8.1/generated/torch.square.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.squeeze.html
+++ b/docs/1.8.1/generated/torch.squeeze.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.stack.html
+++ b/docs/1.8.1/generated/torch.stack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.std.html
+++ b/docs/1.8.1/generated/torch.std.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.std_mean.html
+++ b/docs/1.8.1/generated/torch.std_mean.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.stft.html
+++ b/docs/1.8.1/generated/torch.stft.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sub.html
+++ b/docs/1.8.1/generated/torch.sub.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.subtract.html
+++ b/docs/1.8.1/generated/torch.subtract.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.sum.html
+++ b/docs/1.8.1/generated/torch.sum.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.svd.html
+++ b/docs/1.8.1/generated/torch.svd.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.svd_lowrank.html
+++ b/docs/1.8.1/generated/torch.svd_lowrank.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.swapaxes.html
+++ b/docs/1.8.1/generated/torch.swapaxes.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.swapdims.html
+++ b/docs/1.8.1/generated/torch.swapdims.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.symeig.html
+++ b/docs/1.8.1/generated/torch.symeig.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.t.html
+++ b/docs/1.8.1/generated/torch.t.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.take.html
+++ b/docs/1.8.1/generated/torch.take.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tan.html
+++ b/docs/1.8.1/generated/torch.tan.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tanh.html
+++ b/docs/1.8.1/generated/torch.tanh.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tensor.html
+++ b/docs/1.8.1/generated/torch.tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tensor_split.html
+++ b/docs/1.8.1/generated/torch.tensor_split.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tensordot.html
+++ b/docs/1.8.1/generated/torch.tensordot.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tile.html
+++ b/docs/1.8.1/generated/torch.tile.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.topk.html
+++ b/docs/1.8.1/generated/torch.topk.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.trace.html
+++ b/docs/1.8.1/generated/torch.trace.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.transpose.html
+++ b/docs/1.8.1/generated/torch.transpose.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.trapz.html
+++ b/docs/1.8.1/generated/torch.trapz.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.triangular_solve.html
+++ b/docs/1.8.1/generated/torch.triangular_solve.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tril.html
+++ b/docs/1.8.1/generated/torch.tril.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.tril_indices.html
+++ b/docs/1.8.1/generated/torch.tril_indices.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.triu.html
+++ b/docs/1.8.1/generated/torch.triu.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.triu_indices.html
+++ b/docs/1.8.1/generated/torch.triu_indices.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.true_divide.html
+++ b/docs/1.8.1/generated/torch.true_divide.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.trunc.html
+++ b/docs/1.8.1/generated/torch.trunc.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.unbind.html
+++ b/docs/1.8.1/generated/torch.unbind.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.unique.html
+++ b/docs/1.8.1/generated/torch.unique.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.unique_consecutive.html
+++ b/docs/1.8.1/generated/torch.unique_consecutive.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.unsqueeze.html
+++ b/docs/1.8.1/generated/torch.unsqueeze.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.use_deterministic_algorithms.html
+++ b/docs/1.8.1/generated/torch.use_deterministic_algorithms.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.vander.html
+++ b/docs/1.8.1/generated/torch.vander.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.var.html
+++ b/docs/1.8.1/generated/torch.var.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.var_mean.html
+++ b/docs/1.8.1/generated/torch.var_mean.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.vdot.html
+++ b/docs/1.8.1/generated/torch.vdot.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.view_as_complex.html
+++ b/docs/1.8.1/generated/torch.view_as_complex.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.view_as_real.html
+++ b/docs/1.8.1/generated/torch.view_as_real.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.vstack.html
+++ b/docs/1.8.1/generated/torch.vstack.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.where.html
+++ b/docs/1.8.1/generated/torch.where.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.xlogy.html
+++ b/docs/1.8.1/generated/torch.xlogy.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.zeros.html
+++ b/docs/1.8.1/generated/torch.zeros.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/generated/torch.zeros_like.html
+++ b/docs/1.8.1/generated/torch.zeros_like.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/genindex.html
+++ b/docs/1.8.1/genindex.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/hub.html
+++ b/docs/1.8.1/hub.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/index.html
+++ b/docs/1.8.1/index.html
@@ -184,7 +184,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -253,7 +253,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>
@@ -438,7 +438,7 @@ flags, and are at an early stage for feedback and testing.</p>
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/jit.html
+++ b/docs/1.8.1/jit.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/jit_builtin_functions.html
+++ b/docs/1.8.1/jit_builtin_functions.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/jit_language_reference.html
+++ b/docs/1.8.1/jit_language_reference.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/jit_python_reference.html
+++ b/docs/1.8.1/jit_python_reference.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/jit_unsupported.html
+++ b/docs/1.8.1/jit_unsupported.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1 current"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/linalg.html
+++ b/docs/1.8.1/linalg.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/mobile_optimizer.html
+++ b/docs/1.8.1/mobile_optimizer.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/model_zoo.html
+++ b/docs/1.8.1/model_zoo.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/multiprocessing.html
+++ b/docs/1.8.1/multiprocessing.html
@@ -183,7 +183,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -252,7 +252,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/name_inference.html
+++ b/docs/1.8.1/name_inference.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/named_tensor.html
+++ b/docs/1.8.1/named_tensor.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/nn.functional.html
+++ b/docs/1.8.1/nn.functional.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/nn.html
+++ b/docs/1.8.1/nn.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/nn.init.html
+++ b/docs/1.8.1/nn.init.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/amp_examples.html
+++ b/docs/1.8.1/notes/amp_examples.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/autograd.html
+++ b/docs/1.8.1/notes/autograd.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/broadcasting.html
+++ b/docs/1.8.1/notes/broadcasting.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/cpu_threading_torchscript_inference.html
+++ b/docs/1.8.1/notes/cpu_threading_torchscript_inference.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/cuda.html
+++ b/docs/1.8.1/notes/cuda.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/ddp.html
+++ b/docs/1.8.1/notes/ddp.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/extending.html
+++ b/docs/1.8.1/notes/extending.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/faq.html
+++ b/docs/1.8.1/notes/faq.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/large_scale_deployments.html
+++ b/docs/1.8.1/notes/large_scale_deployments.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/modules.html
+++ b/docs/1.8.1/notes/modules.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/multiprocessing.html
+++ b/docs/1.8.1/notes/multiprocessing.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/randomness.html
+++ b/docs/1.8.1/notes/randomness.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/serialization.html
+++ b/docs/1.8.1/notes/serialization.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/notes/windows.html
+++ b/docs/1.8.1/notes/windows.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/onnx.html
+++ b/docs/1.8.1/onnx.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/optim.html
+++ b/docs/1.8.1/optim.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.optim</a></li>

--- a/docs/1.8.1/pipeline.html
+++ b/docs/1.8.1/pipeline.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/profiler.html
+++ b/docs/1.8.1/profiler.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 

--- a/docs/1.8.1/py-modindex.html
+++ b/docs/1.8.1/py-modindex.html
@@ -186,7 +186,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -255,7 +255,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/quantization-support.html
+++ b/docs/1.8.1/quantization-support.html
@@ -183,7 +183,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -252,7 +252,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/quantization.html
+++ b/docs/1.8.1/quantization.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/random.html
+++ b/docs/1.8.1/random.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/rpc.html
+++ b/docs/1.8.1/rpc.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/rpc/distributed_autograd.html
+++ b/docs/1.8.1/rpc/distributed_autograd.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/rpc/rref.html
+++ b/docs/1.8.1/rpc/rref.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="../profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="../nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../optim.html">torch.optim</a></li>

--- a/docs/1.8.1/search.html
+++ b/docs/1.8.1/search.html
@@ -183,7 +183,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -252,7 +252,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/sparse.html
+++ b/docs/1.8.1/sparse.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/storage.html
+++ b/docs/1.8.1/storage.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/tensor_attributes.html
+++ b/docs/1.8.1/tensor_attributes.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/tensor_view.html
+++ b/docs/1.8.1/tensor_view.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/tensorboard.html
+++ b/docs/1.8.1/tensorboard.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/tensors.html
+++ b/docs/1.8.1/tensors.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.html
+++ b/docs/1.8.1/torch.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.intrinsic.html
+++ b/docs/1.8.1/torch.nn.intrinsic.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.intrinsic.qat.html
+++ b/docs/1.8.1/torch.nn.intrinsic.qat.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.intrinsic.quantized.html
+++ b/docs/1.8.1/torch.nn.intrinsic.quantized.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.qat.html
+++ b/docs/1.8.1/torch.nn.qat.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.quantized.dynamic.html
+++ b/docs/1.8.1/torch.nn.quantized.dynamic.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.nn.quantized.html
+++ b/docs/1.8.1/torch.nn.quantized.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.overrides.html
+++ b/docs/1.8.1/torch.overrides.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1 current"><a class="current reference internal" href="#">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/torch.quantization.html
+++ b/docs/1.8.1/torch.quantization.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/1.8.1/type_info.html
+++ b/docs/1.8.1/type_info.html
@@ -185,7 +185,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.8.0a0+56b43f4 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>1.8.1 &#x25BC</a>
     </div>
     
 
@@ -254,7 +254,7 @@
 <li class="toctree-l1"><a class="reference internal" href="jit.html">torch.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="linalg.html">torch.linalg</a></li>
 <li class="toctree-l1"><a class="reference internal" href="torch.overrides.html">torch.overrides</a></li>
-<li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li>
+<!--- li class="toctree-l1"><a class="reference internal" href="profiler.html">torch.profiler</a></li --->
 <li class="toctree-l1"><a class="reference internal" href="nn.init.html">torch.nn.init</a></li>
 <li class="toctree-l1"><a class="reference internal" href="onnx.html">torch.onnx</a></li>
 <li class="toctree-l1"><a class="reference internal" href="optim.html">torch.optim</a></li>

--- a/docs/versions.html
+++ b/docs/versions.html
@@ -21,6 +21,9 @@
           <a class="reference internal" href="master/">master (unstable)</a>
         </li>
         <li class="toctree-l1">
+          <a class="reference internal" href="1.8.1/">v1.8.1 (pre-release)</a>
+        </li>
+        <li class="toctree-l1">
           <a class="reference internal" href="1.8.0/">v1.8.0 (stable release)</a>
         </li>
         <li class="toctree-l1">


### PR DESCRIPTION
Edit all the pages to replace `1.8.0a0+56b43f4` with `1.8.1` and to hide torch.profile from the left navbar.

Also add 1.8.1 to the versions.html

@brianjo