### PR TITLE
Double dot on active state under resources on main nav on contributors page

### DIFF
--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -65,7 +65,7 @@
 
     {% assign resources = "resources, features, hub" | split: ", " %}
 
-    <li class="main-menu-item {% if resources contains current[1] %}active{% endif %}">
+    <li class="main-menu-item {% if resources contains current[1] %}active resources-active{% endif %}">
 
       <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
         <a class="resource-option {% if current[1] == {{ site.baseurl }} %}with-down-white-arrow{% else %}with-down-arrow{% endif %}">

--- a/_sass/navigation.scss
+++ b/_sass/navigation.scss
@@ -106,17 +106,6 @@
         text-align: center;
       }
 
-      .resources-dropdown:after {
-        content: "•";
-        bottom: -24px;
-        color: $orange;
-        font-size: rem(22px);
-        left: -27px;
-        position: absolute;
-        right: 0;
-        text-align: center;
-      }
-
       a {
         color: $orange;
       }
@@ -124,6 +113,10 @@
       .with-down-arrow {
         background-image: url($baseurl + "/assets/images/chevron-down-orange.svg");
       }
+    }
+
+    &.resources-active:after {
+      left: -27px;
     }
 
     &:last-of-type {
@@ -257,16 +250,6 @@
   }
 }
 
-.resources, .features, .hub {
-  .main-menu ul li{
-    &.active {
-      &:after {
-        display: none;
-      }
-    }
-  }
-}
-
 .main-menu ul li {
   .ecosystem-dropdown, .resources-dropdown a {
     cursor: pointer;
@@ -359,7 +342,7 @@
   border-radius: 0.25rem;
 }
 
-.ecosystem-dropdown:hover, .resources-dropdown:hover {
+.ecosystem-dropdown:hover, .resources-dropdown:hover, .resources-active:hover {
   .ecosystem-dropdown-menu, .resources-dropdown-menu {
     display: block;
   }


### PR DESCRIPTION
This PR removes the duplicate dot under the Resources nav item on the Contributors page.
Issue:
![Screen Shot 2021-03-25 at 5 25 53 PM](https://user-images.githubusercontent.com/31549535/112669168-c4bc0780-8e35-11eb-8293-3996314be645.png)

Preview with 2nd dot removed: https://605cff07fa7e32d147297959--shiftlab-pytorch-github-io.netlify.app/resources/contributors/