### PR TITLE
Add contributor card to homepage

### DIFF
--- a/_resources/contributor.md
+++ b/_resources/contributor.md
@@ -1,8 +1,9 @@
 ---
 title: Contributors
+summary-home: Stay up to date with the codebase and discover RFCs, PRs and more
 summary: Stay up to date with the codebase and discover RFCs, PRs and more
 link: https://pytorch.org/resources/contributors
 class: pytorch-resource
 order: 13
-featured-home: false
+featured-home: true
 ---


### PR DESCRIPTION
This PR adds Contributors card to the PyTorch homepage

https://6061dfa0a425da1ab5feb04b--shiftlab-pytorch-github-io.netlify.app/