### PR TITLE
Randomize ecosystem cards on refresh

### DIFF
--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -121,6 +121,18 @@ body-class: ecosystem
     $(this).attr("data-date-added", date);
   });
 
+  //Randomize Ecosystem cards on page reload
+  $.fn.randomize = function(ecosystemCards) {
+    (ecosystemCards ? this.find(ecosystemCards) : this).parent().each(function() {
+        $(this).children(ecosystemCards).sort(function() {
+            return Math.random() - 0.5;
+        }).detach().appendTo(this);
+    });
+    return this;
+  };
+
+  $('#ecosystem-index-cards').randomize('#ecosystemCards');
+
 </script>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>

--- a/ecosystem/ecosystem.html
+++ b/ecosystem/ecosystem.html
@@ -124,9 +124,9 @@ body-class: ecosystem
   //Randomize Ecosystem cards on page reload
   $.fn.randomize = function(ecosystemCards) {
     (ecosystemCards ? this.find(ecosystemCards) : this).parent().each(function() {
-        $(this).children(ecosystemCards).sort(function() {
-            return Math.random() - 0.5;
-        }).detach().appendTo(this);
+      $(this).children(ecosystemCards).sort(function() {
+        return Math.random() - 0.5;
+      }).detach().appendTo(this);
     });
     return this;
   };


### PR DESCRIPTION
This PR adds JS function to randomize Ecosystem cards on page refresh/reload. The JS function randomizes **all** Ecosystem cards on reload, not just the first page of cards

Preview: https://6064ca2712733c64a2f96cd8--shiftlab-pytorch-github-io.netlify.app/ecosystem/