### PR TITLE
.circleci: Use python3 for notedown install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: yarn install --cache-folder ~/.cache/yarn
       - run:
           name: Notedown Install
-          command: sudo apt update && sudo apt install python-pip && sudo -H pip install pyrsistent==0.16 notedown pyyaml -Iv nbformat==4.4.0
+          command: sudo apt update && sudo apt install python3-pip && sudo -H pip3 install pyrsistent==0.16 notedown pyyaml -Iv nbformat==4.4.0
       - save_cache:
           key: pytorch-yarn-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
Looks like notedown isn't installable with python2 anymore, python3
should resolve the issue

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>