### PR TITLE
Fix argument name: `with_trace` -> `with_stack`

### DIFF
--- a/_posts/2021-3-25-introducing-pytorch-profiler-the-new-and-improved-performance-tool.md
+++ b/_posts/2021-3-25-introducing-pytorch-profiler-the-new-and-improved-performance-tool.md
@@ -26,7 +26,7 @@ PyTorch Profiler is the next version of the PyTorch autograd profiler. It has a 
         active=6,
         repeat=1),
     on_trace_ready=tensorboard_trace_handler,
-    with_trace=True
+    with_stack=True
 ) as profiler:
     for step, data in enumerate(trainloader, 0):
         print("step:{}".format(step))


### PR DESCRIPTION
Referencing https://pytorch.org/docs/stable/profiler.html#torch.profiler.profile, I think `with_trace` should be `with_stack`.