### PR TITLE
[PYT-567] Add an email subscribe form to Contributors page

### DIFF
--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -237,7 +237,7 @@
       display: flex;
       width: 100%;
 
-      input[type="text"] {
+      input[type="email"] {
         border: 1px solid darken($color: #f3f3f3, $amount: 5);
         border-radius: 4px;
         flex: 1 70%;
@@ -255,6 +255,7 @@
   
       input[type="submit"] {
         background: darken($color: #f3f3f3, $amount: 5);
+        border: none;
         border-radius: 4px;
         color: #6d6d6d;
 

--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -1,6 +1,6 @@
 .ecosystem .join-wrapper .marketo-contain {
   display: flex;
-  height: 35rem;
+  // height: 35rem;
   width: 90%;
   max-width: 920px;
   flex-wrap: wrap;
@@ -10,7 +10,7 @@
   padding-bottom: 1rem;
   @include desktop {
     max-width: 920px;
-    height: 20rem;
+    // height: 20rem;
     flex-wrap: nowrap;
     padding-top: 0;
     padding-bottom: 0;

--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -1,29 +1,3 @@
-.ecosystem .join-wrapper .marketo-contain {
-  display: flex;
-  // height: 35rem;
-  width: 90%;
-  max-width: 920px;
-  flex-wrap: wrap;
-  padding-left: 30px;
-  padding-right: 30px;
-  padding-top: 3rem;
-  padding-bottom: 1rem;
-  @include desktop {
-    max-width: 920px;
-    // height: 20rem;
-    flex-wrap: nowrap;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-  @include small-desktop {
-    width: 90%;
-  }
-}
-
-.ecosystem .contributor-wrapper {
-  background-color: $white;
-}
-
 .ecosystem .contributor-jumbotron {
   @include desktop {
     height: 262px;
@@ -50,90 +24,6 @@
   h2 {
     color: white;
     padding-top: 0;
-  }
-}
-
-.marketo-left {
-  margin: auto;
-  bottom: -3rem;
-  padding: 0;
-  h2 {
-    text-transform: uppercase;
-    color: $orange;
-    font-weight: 100;
-  }
-  .module-button {
-    background-color: $white;
-    max-height: 3rem;
-    margin-top: 1rem;
-  }
-  p {
-    margin-right: 2rem;
-  }
-  @include desktop {
-    margin-top: 54px;
-    white-space: pre-line;
-    .module-button {
-      margin-top: 0;
-    }
-  }
-  @media (min-width: 768px) and (max-width: 900px) {
-    margin-top: 60px;
-    .input-group.mb-3 {
-      padding-left: 3rem;
-    }
-  }
-}
-
-.marketo-right {
-  justify-content: center;
-  white-space: pre-line;
-  margin: auto;
-  h2 {
-    text-transform: uppercase;
-    color: $purple;
-    font-weight: 100;
-  }
-  @include max-width-desktop {
-    margin-left: 1rem;
-  }
-}
-
-.marketo-contain .contributors-button {
-  font-size: 1.125rem;
-  position: relative;
-  cursor: pointer;
-  outline: none;
-  padding: rem(10px) rem(30px) rem(10px) rem(20px);
-  background-color: $white;
-  margin-bottom: 0.125rem;
-  border: 2px solid $light_grey;
-  letter-spacing: -0.25px;
-  line-height: rem(28px);
-  color: $dark_grey;
-  background-image: url($baseurl + "/assets/images/chevron-right-orange.svg");
-  background-size: 6px 13px;
-  background-position: center right 10px;
-  background-repeat: no-repeat;
-  a {
-    color: $dark_grey;
-  }
-
-  @include animated_border_hover_state;
-}
-
-.contributor-row {
-  text-align: left;
-  .contributor-submit {
-    background-color: $white;
-    border: 2px solid $light_grey;
-    outline: none;
-    font-size: 1.125rem;
-    left: 1rem;
-    @include animated_border_hover_state;
-  }
-  input {
-    height: auto;
   }
 }
 
@@ -291,4 +181,111 @@
 
 #get-started-contributor-sidebar-list {
   padding-left: 0;
+}
+
+.two-column-row {
+  max-width: 920px;
+  margin: 0 auto 0 auto;
+  padding: 0 30px 43px 30px;
+  width: 90%;
+
+  @include desktop {
+    display: flex;
+  }
+
+  h2 {
+    text-transform: uppercase;
+    font-weight: 100;
+    margin-bottom: 30px;
+  }
+
+  p {
+    margin-bottom: 40px;
+  }
+
+  .content-left {
+    padding-top: 76px;
+
+    @include desktop {
+      margin-right: 62px;
+    }
+
+    h2 {
+      color: $orange;
+    }
+  }
+
+  .content-right {
+    padding-top: 76px;
+
+    h2 {
+      color: $purple;
+    }
+  }
+
+  .contributor-form {
+    display: flex;
+    margin: -8px 0 47px 0;
+
+    .form-success {
+      color: $orange;
+      display: none;
+      margin: -6px 0 0 0;
+    }
+
+    form {
+      display: flex;
+      width: 100%;
+
+      input[type="text"] {
+        border: 1px solid darken($color: #f3f3f3, $amount: 5);
+        border-radius: 4px;
+        flex: 1 70%;
+        padding: 5px 8px 5px 8px;
+        margin-right: 10px;
+        
+        &::placeholder {
+          color: darken($color: #f3f3f3, $amount: 20);
+        }
+  
+        &:focus {
+          border: 1px solid $orange;
+        }
+      }
+  
+      input[type="submit"] {
+        background: darken($color: #f3f3f3, $amount: 5);
+        border-radius: 4px;
+        color: #6d6d6d;
+
+        &:hover {
+          background: darken($color: #f3f3f3, $amount: 20);
+          color: darken($color: #6d6d6d, $amount: 20);
+        }
+      }
+    }
+  }
+
+  .contributors-button {
+    background-image: url($baseurl + "/assets/images/chevron-right-orange.svg");
+    background-color: $white;
+    background-size: 6px 13px;
+    background-position: center right 10px;
+    background-repeat: no-repeat;
+    border: 2px solid $light_grey;
+    color: $dark_grey;
+    cursor: pointer;
+    font-size: 1.125rem;
+    outline: none;
+    letter-spacing: -0.25px;
+    line-height: rem(28px);
+    margin-bottom: 0.125rem;
+    padding: rem(10px) rem(30px) rem(10px) rem(20px);
+
+    a {
+      color: $dark_grey;
+    }
+  
+    @include animated_border_hover_state;
+  }
 }

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -35,31 +35,28 @@ background-class: features-background
 
     {% include past_issues.html %}
 
-    <div class="marketo-contain container-fluid">
-      <!-- START CONTENT -->
-      <div class="row col-f-6 marketo-left">
-        <div class="contributor-row">
-          <h2>Newsletter Sign Up</h2>
-          <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
-
-          <div class="input-group mb-3">
-            <form class="contributor-form" action="http://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
-              <input type="hidden" name="_clientID" value="515009167" />
-              <input type="hidden" name="_deExternalKey" value="BBAD707C-57C6-46F4-9701-D24E5550FB79" />
-              <input type="hidden" name="_action" value="add" />
-              <input type="hidden" name="_returnXML" value="0" />
-              <input type="hidden" name="_successURL" value="http://example.com/Success" />
-              <input type="hidden" name="_errorURL" value="http://example.com/Failed" />
-              <input type="text" name="Email Address"placeholder="Enter your email"><br />
-              <input class="btn btn-primary" type="submit" value="Submit">
-            </form>
-          </div>
-
+    <div class="two-column-row">
+      <div class="content-left">
+        <h2>Newsletter Sign Up</h2>
+        <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
+        <div class="contributor-form">
+          <form id="contributorForm" action="http://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
+            <input type="hidden" name="_clientID" value="515009167" />
+            <input type="hidden" name="_deExternalKey" value="BBAD707C-57C6-46F4-9701-D24E5550FB79" />
+            <input type="hidden" name="_action" value="add" />
+            <input type="hidden" name="_returnXML" value="0" />
+            <input type="hidden" name="_successURL" value="http://example.com/Success" />
+            <input type="hidden" name="_errorURL" value="http://example.com/Failed" />
+            <input type="text" id="emailField" name="Email Address" placeholder="Enter your email">
+            <input id="formSubmit" class="btn btn-primary" type="submit" value="Submit">
+          </form>
+          <p class="form-success">Thanks! You are now subscribed to the PyTorch Contributors Newsletter.</p>
         </div>
+        <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
       </div>
 
-      <div class="row col-f-6 marketo-right">
-        <div class="contributor-row">
+      <div class="content-right">
+        <div>
           <h2>Join the conversation</h2>
           <p>Join the contributor's discussion forum to learn and collaborate on the latest development across PyTorch</p>
           <a class="contributors-button" href="{{ site.external_urls.contributor_forum }}">Contributor Forums</a>
@@ -82,5 +79,23 @@ background-class: features-background
     $(".marketo-contain").show();
     $("#past-issues").removeClass("nav-select");
     $(this).addClass("nav-select");
+  });
+
+  $( "#contributorForm").submit(function( event ) {
+    event.preventDefault();
+  });
+
+  $("#formSubmit").on("click", function() {
+
+    console.log($("#emailField").val())
+
+    if ($("#emailField").val()) {
+      $( "#contributorForm").submit(function() {
+        $("#contributorForm").hide();
+        $(".form-success").show();
+      });
+    } else {
+      alert("Please enter a valid email address.");
+    }
   })
 </script>

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -39,16 +39,14 @@ background-class: features-background
       <div class="content-left">
         <h2>Newsletter Sign Up</h2>
         <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
-        <div class="contributor-form">
-          <form id="contributorForm" action="http://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
-            <input type="hidden" name="_clientID" value="515009167" />
-            <input type="hidden" name="_deExternalKey" value="BBAD707C-57C6-46F4-9701-D24E5550FB79" />
-            <input type="hidden" name="_action" value="add" />
-            <input type="hidden" name="_returnXML" value="0" />
-            <input type="hidden" name="_successURL" value="http://example.com/Success" />
-            <input type="hidden" name="_errorURL" value="http://example.com/Failed" />
-            <input type="text" id="emailField" name="Email Address" placeholder="Enter your email">
-            <input id="formSubmit" class="btn btn-primary" type="submit" value="Submit">
+        <div id="mc_embed_signup" class="contributor-form">
+          <form action="" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" novalidate>
+            <input type="email" value="" name="EMAIL" id="mce-EMAIL" />
+            <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+            <div style="position: absolute; left: -5000px;" aria-hidden="true">
+              <input type="text" name="b_450bf01a83b20e12a0affdd10_10b00504eb" tabindex="-1" value="" />
+            </div>
+            <input type="submit" value="Submit" name="subscribe" id="mc-embedded-subscribe" class="button" />
           </form>
           <p class="form-success">Thanks! You are now subscribed to the PyTorch Contributors Newsletter.</p>
         </div>
@@ -81,19 +79,20 @@ background-class: features-background
     $(this).addClass("nav-select");
   });
 
-  $( "#contributorForm").submit(function( event ) {
+  $( "#mc-embedded-subscribe-form").submit(function( event ) {
     event.preventDefault();
   });
 
-  $("#formSubmit").on("click", function() {
-
-    console.log($("#emailField").val())
-
-    if ($("#emailField").val()) {
-      $( "#contributorForm").submit(function() {
-        $("#contributorForm").hide();
-        $(".form-success").show();
+  $("#mc-embedded-subscribe").on("click", function() {
+    if ($("#mce-EMAIL").val()) {
+      $.ajax({
+        type: "POST",
+        crossDomain: true,
+        url: "https://shiftlab.us1.list-manage.com/subscribe/post?u=450bf01a83b20e12a0affdd10&amp;id=10b00504eb",
+        data: $("#mc-embedded-subscribe-form").serialize()
       });
+      $("#mc-embedded-subscribe-form").hide();
+      $(".form-success").show();
     } else {
       alert("Please enter a valid email address.");
     }

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -39,18 +39,22 @@ background-class: features-background
       <!-- START CONTENT -->
       <div class="row col-f-6 marketo-left">
         <div class="contributor-row">
-          <h2>Newsletter</h2>
+          <h2>Newsletter Sign Up</h2>
           <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
-          <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
-          <!-- <div class="contributor-row">
-            <h2>Sign up for the newsletter</h2>
-            <div class="input-group mb-3">
-              <input type="text" class="form-control" placeholder="email" aria-label="email" aria-describedby="email">
-              <div class="input-group-append">
-                <button id ="submit" class="contributor-submit btn btn-outline-secondary" type="button">Submit</button>
-              </div>
-            </div>
-          </div> -->
+
+          <div class="input-group mb-3">
+            <form class="contributor-form" action="http://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
+              <input type="hidden" name="_clientID" value="515009167" />
+              <input type="hidden" name="_deExternalKey" value="BBAD707C-57C6-46F4-9701-D24E5550FB79" />
+              <input type="hidden" name="_action" value="add" />
+              <input type="hidden" name="_returnXML" value="0" />
+              <input type="hidden" name="_successURL" value="http://example.com/Success" />
+              <input type="hidden" name="_errorURL" value="http://example.com/Failed" />
+              <input type="text" name="Email Address"placeholder="Enter your email"><br />
+              <input class="btn btn-primary" type="submit" value="Submit">
+            </form>
+          </div>
+
         </div>
       </div>
 


### PR DESCRIPTION
This PR adds a Salesforce form to the /resources/contributors page for email capture.

A few test submissions have been made. We will need @pytorchsam to confirm if they are working or not before we can move forward with merging this.

Preview: https://deploy-preview-676--frosty-bhabha-29c509.netlify.app/resources/contributors/


# Mobile Rendering

## On load
<img width="323" alt="Screen Shot 2021-04-19 at 8 38 22 PM" src="https://user-images.githubusercontent.com/213593/115320264-8de4c300-a14f-11eb-958e-0173add833f5.png">

## On email input
<img width="324" alt="Screen Shot 2021-04-19 at 8 38 11 PM" src="https://user-images.githubusercontent.com/213593/115320281-93daa400-a14f-11eb-84aa-cb0975e9c5f3.png">

## On submission
<img width="324" alt="Screen Shot 2021-04-19 at 8 37 59 PM" src="https://user-images.githubusercontent.com/213593/115320309-a0f79300-a14f-11eb-897d-363cb1ad678d.png">

# Desktop Rendering

## On load
<img width="1280" alt="Screen Shot 2021-04-19 at 8 32 12 PM" src="https://user-images.githubusercontent.com/213593/115320384-c84e6000-a14f-11eb-8e75-0f865118699f.png">

## On email input
<img width="1317" alt="Screen Shot 2021-04-19 at 8 35 08 PM" src="https://user-images.githubusercontent.com/213593/115320411-d3a18b80-a14f-11eb-821e-b0744c45961e.png">

## On submission
<img width="1325" alt="Screen Shot 2021-04-19 at 8 37 46 PM" src="https://user-images.githubusercontent.com/213593/115320420-d9976c80-a14f-11eb-952d-58e7540de4f3.png">
