### PR TITLE
Use correct capitalization of GitHub

### DIFF
--- a/docs/master/_modules/index.html
+++ b/docs/master/_modules/index.html
@@ -161,7 +161,7 @@
           </li>
 
           <li>
-            <a href="https://github.com/pytorch/pytorch">Github</a>
+            <a href="https://github.com/pytorch/pytorch">GitHub</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This PR changes the capitalization from _Github_ to _GitHub_ in the page navigation menu.