### PR TITLE
[PYT-580] Integrate functioning Salesforce sign up on Contributors page

### DIFF
--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -204,6 +204,7 @@
   }
 
   .content-left {
+    flex: 60%;
     padding-top: 76px;
 
     @include desktop {
@@ -213,9 +214,25 @@
     h2 {
       color: $orange;
     }
+
+    .contributor-consent-check {
+      max-width: 400px;
+    }
+
+    .email-consent {
+      color: $mid_gray;
+      font-size: 14px;
+    }
+    
+    .please-accept-terms {
+      display: none;
+      color: $orange;
+      font-size: 14px;
+    }
   }
 
   .content-right {
+    flex: 40%;
     padding-top: 76px;
 
     h2 {
@@ -235,37 +252,50 @@
     }
 
     form {
-      display: flex;
       width: 100%;
-      flex-wrap: wrap;
-
-      input[type="text"] {
-        border: 1px solid darken($color: #f3f3f3, $amount: 5);
-        border-radius: 4px;
-        flex: 1 70%;
-        padding: 5px 8px 5px 8px;
-        margin-right: 10px;
-
-        &::placeholder {
-          color: darken($color: #f3f3f3, $amount: 20);
+      
+      .contributor-form-ui {
+        display: flex;
+        max-width: 390px;
+        flex-wrap: wrap;
+        
+        input[type="text"] {
+          border: 1px solid darken($color: #f3f3f3, $amount: 5);
+          border-radius: 4px;
+          flex: 1 70%;
+          padding: 5px 8px 5px 8px;
+          margin-right: 10px;
+  
+          &::placeholder {
+            color: darken($color: #f3f3f3, $amount: 20);
+          }
+  
+          &:focus {
+            border: 1px solid $orange;
+          }
         }
-
-        &:focus {
-          border: 1px solid $orange;
+  
+        input[type="submit"] {
+          background: darken($color: #f3f3f3, $amount: 5);
+          border: none;
+          border-radius: 4px;
+          color: #6d6d6d;
+  
+          &:hover {
+            background: darken($color: #f3f3f3, $amount: 20);
+            color: darken($color: #6d6d6d, $amount: 20);
+          }
         }
       }
+    }
 
-      input[type="submit"] {
-        background: darken($color: #f3f3f3, $amount: 5);
-        border: none;
-        border-radius: 4px;
-        color: #6d6d6d;
+    input[type="checkbox"] { 
+      margin: 1px 6px 0 0;
+    }
 
-        &:hover {
-          background: darken($color: #f3f3f3, $amount: 20);
-          color: darken($color: #6d6d6d, $amount: 20);
-        }
-      }
+    .contributor-consent-check {
+      color: $mid_gray;
+      margin-top: 1rem;
     }
   }
 
@@ -291,50 +321,4 @@
 
     @include animated_border_hover_state;
   }
-}
-
-.email-consent {
-  color: $mid_gray;
-  font-size: 14px;
-}
-
-.contributor-consent-check {
-  color: $mid_gray;
-  margin-top: 1rem;
-  input[type=checkbox] {
-    display: none;
-  }
-  input[type="checkbox"] + *::before {
-    content: "";
-    display: inline-block;
-    vertical-align: bottom;
-    width: 1.2rem;
-    height: 1.2rem;
-    margin-right: 0.3rem;
-    border-radius: 10%;
-    border-style: solid;
-    border-width: 0.1rem;
-    border-color: gray;
-  }
-  input[type="checkbox"]:checked + *::before {
-    content: "✓";
-    color: white;
-    text-align: center;
-    background: $orange;
-    border-color: $orange;
-    font-size: 14px;
-    &:hover {
-      cursor: pointer;
-    }
-  }
-}
-
-.please-accept-terms {
-  display: none;
-  color: $orange;
-  font-size: 18px;
-}
-
-input[type=checkbox]:checked {
-background-color: $orange;
 }

--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -301,8 +301,40 @@
 .contributor-consent-check {
   color: $mid_gray;
   margin-top: 1rem;
+  input[type=checkbox] {
+    display: none;
+  }
+  input[type="checkbox"] + *::before {
+    content: "";
+    display: inline-block;
+    vertical-align: bottom;
+    width: 1.2rem;
+    height: 1.2rem;
+    margin-right: 0.3rem;
+    border-radius: 10%;
+    border-style: solid;
+    border-width: 0.1rem;
+    border-color: gray;
+  }
+  input[type="checkbox"]:checked + *::before {
+    content: "✓";
+    color: white;
+    text-align: center;
+    background: $orange;
+    border-color: $orange;
+    font-size: 14px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
 }
 
-#agree:checked {
-  background-color: red;
+.please-accept-terms {
+  display: none;
+  color: $orange;
+  font-size: 18px;
+}
+
+input[type=checkbox]:checked {
+background-color: $orange;
 }

--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -237,6 +237,7 @@
     form {
       display: flex;
       width: 100%;
+      flex-wrap: wrap;
 
       input[type="text"] {
         border: 1px solid darken($color: #f3f3f3, $amount: 5);
@@ -244,16 +245,16 @@
         flex: 1 70%;
         padding: 5px 8px 5px 8px;
         margin-right: 10px;
-        
+
         &::placeholder {
           color: darken($color: #f3f3f3, $amount: 20);
         }
-  
+
         &:focus {
           border: 1px solid $orange;
         }
       }
-  
+
       input[type="submit"] {
         background: darken($color: #f3f3f3, $amount: 5);
         border: none;
@@ -287,7 +288,21 @@
     a {
       color: $dark_grey;
     }
-  
+
     @include animated_border_hover_state;
   }
+}
+
+.email-consent {
+  color: $mid_gray;
+  font-size: 14px;
+}
+
+.contributor-consent-check {
+  color: $mid_gray;
+  margin-top: 1rem;
+}
+
+#agree:checked {
+  background-color: red;
 }

--- a/_sass/contributors.scss
+++ b/_sass/contributors.scss
@@ -224,20 +224,21 @@
   }
 
   .contributor-form {
-    display: flex;
     margin: -8px 0 47px 0;
 
-    .form-success {
+    .form-success,
+    .form-fail {
       color: $orange;
       display: none;
-      margin: -6px 0 0 0;
+      flex: none;
+      margin: 8px 0 12px 0;
     }
 
     form {
       display: flex;
       width: 100%;
 
-      input[type="email"] {
+      input[type="text"] {
         border: 1px solid darken($color: #f3f3f3, $amount: 5);
         border-radius: 4px;
         flex: 1 70%;

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -38,7 +38,7 @@ background-class: features-background
     <div class="two-column-row">
       <div class="content-left">
         <h2>Newsletter Sign Up</h2>
-        <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>   
+        <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
         <div class="contributor-form">
           <form action="https://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
             <input type="hidden" name="_clientID" value="515009167">
@@ -49,10 +49,25 @@ background-class: features-background
             <input type="hidden" name="_errorURL" value="https://pytorch.org/resources/contributors?signUp=fail">
             <input type="text" name="Email Address">
             <input type="submit" value="Submit">
+            <div class="contributor-consent-check">
+              <input type="checkbox" id="agree" oninvalid="this.setCustomValidity('Please accept the terms and conditions below')" onvalid="this.setCustomValidity('')" required>
+              <label for="agree">I accept the terms and conditions below</label>
+            </div>
           </form>
           <p class="form-success">Thanks! You are now subscribed to the PyTorch Contributors Newsletter.</p>
           <p class="form-fail">There was an error submitting your email address. Please try again.</p>
         </div>
+        <p class="email-consent">
+          ☨Brand Domain (send/server) is from or in NA and ROW excluding EU/EEA
+          By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Inc, including news, events, and updates.
+          You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails.
+          For more information about how Facebook handles your data, please read our Data Policy
+        </p>
+        <p class="email-consent">
+          ☨Brand Domain (send/server) is from or in EU/EEA:
+          By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Ireland Limited, including news, events, and updates.
+          You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails. For more information about how Facebook handles your data, please read our Data Policy.
+        </p>
         <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
       </div>
 

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -50,24 +50,21 @@ background-class: features-background
             <input type="text" name="Email Address">
             <input type="submit" value="Submit">
             <div class="contributor-consent-check">
-              <input type="checkbox" id="agree" oninvalid="this.setCustomValidity('Please accept the terms and conditions below')" onvalid="this.setCustomValidity('')" required>
-              <label for="agree">I accept the terms and conditions below</label>
+              <input type="checkbox" id="agree" oninvalid="this.setCustomValidity('')" required>
+              <label for="agree">
+                <span>I accept the terms and conditions below</span>
+              </label>
             </div>
           </form>
           <p class="form-success">Thanks! You are now subscribed to the PyTorch Contributors Newsletter.</p>
           <p class="form-fail">There was an error submitting your email address. Please try again.</p>
+          <p class="please-accept-terms">Please accept the terms and conditions below</p>
         </div>
         <p class="email-consent">
-          ☨Brand Domain (send/server) is from or in NA and ROW excluding EU/EEA
-          By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Inc, including news, events, and updates.
-          You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails.
-          For more information about how Facebook handles your data, please read our Data Policy
+          By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Inc, and its affiliated businesses, including news, events, and updates.
+          You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails. For more information about how Facebook handles your data, please read our <a href="https://pytorch.org/assets/tos-oss-privacy-policy/fb-oss-privacy-policy.pdf">Data Policy</a>
         </p>
-        <p class="email-consent">
-          ☨Brand Domain (send/server) is from or in EU/EEA:
-          By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Ireland Limited, including news, events, and updates.
-          You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails. For more information about how Facebook handles your data, please read our Data Policy.
-        </p>
+
         <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
       </div>
 
@@ -105,4 +102,15 @@ background-class: features-background
     $(".form-success").hide();
     $(".form-fail").show();
   }
+
+    $('input[type=submit]').on("click", function(e) {
+      var checked = $('input[type=checkbox]').prop('checked');
+      if (!checked) {
+        $(".please-accept-terms").show().fadeOut(4000);
+        e.preventDefault();
+      }else{
+        return;
+      }
+    });
+
 </script>

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -47,8 +47,10 @@ background-class: features-background
             <input type="hidden" name="_returnXML" value="0">
             <input type="hidden" name="_successURL" value="https://pytorch.org/resources/contributors?signUp=success">
             <input type="hidden" name="_errorURL" value="https://pytorch.org/resources/contributors?signUp=fail">
-            <input type="text" name="Email Address">
-            <input type="submit" value="Submit">
+            <div class="contributor-form-ui">
+              <input type="text" name="Email Address">
+              <input type="submit" value="Submit">
+            </div>
             <div class="contributor-consent-check">
               <input type="checkbox" id="agree" oninvalid="this.setCustomValidity('')" required>
               <label for="agree">
@@ -64,7 +66,6 @@ background-class: features-background
           By submitting your email, you agree to receive technical updates and marketing-related electronic communications from Facebook Inc, and its affiliated businesses, including news, events, and updates.
           You may withdraw your consent and unsubscribe from these at any time, for example, by clicking the unsubscribe link included on our emails. For more information about how Facebook handles your data, please read our <a href="https://pytorch.org/assets/tos-oss-privacy-policy/fb-oss-privacy-policy.pdf">Data Policy</a>
         </p>
-
         <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
       </div>
 
@@ -103,14 +104,11 @@ background-class: features-background
     $(".form-fail").show();
   }
 
-    $('input[type=submit]').on("click", function(e) {
-      var checked = $('input[type=checkbox]').prop('checked');
-      if (!checked) {
-        $(".please-accept-terms").show().fadeOut(4000);
-        e.preventDefault();
-      }else{
-        return;
-      }
-    });
-
+  $('input[type=submit]').on("click", function(e) {
+    var checked = $('input[type=checkbox]').prop('checked');
+    if (!checked) {
+      $(".please-accept-terms").show().fadeOut(4000);
+      e.preventDefault();
+    }
+  });
 </script>

--- a/ecosystem/contributors.html
+++ b/ecosystem/contributors.html
@@ -38,8 +38,21 @@ background-class: features-background
     <div class="two-column-row">
       <div class="content-left">
         <h2>Newsletter Sign Up</h2>
-        <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>
-        <a id="subscribe" class="contributors-button" href="https://forms.gle/1Edh9z6ExzJSGAiS6">Subscribe</a>
+        <p>Follow the contributors newsletter for curated news from across the PyTorch developer community</p>   
+        <div class="contributor-form">
+          <form action="https://cl.s10.exct.net/DEManager.aspx" name="subscribeForm" method="post">
+            <input type="hidden" name="_clientID" value="515009167">
+            <input type="hidden" name="_deExternalKey" value="BBAD707C-57C6-46F4-9701-D24E5550FB79">
+            <input type="hidden" name="_action" value="add">
+            <input type="hidden" name="_returnXML" value="0">
+            <input type="hidden" name="_successURL" value="https://pytorch.org/resources/contributors?signUp=success">
+            <input type="hidden" name="_errorURL" value="https://pytorch.org/resources/contributors?signUp=fail">
+            <input type="text" name="Email Address">
+            <input type="submit" value="Submit">
+          </form>
+          <p class="form-success">Thanks! You are now subscribed to the PyTorch Contributors Newsletter.</p>
+          <p class="form-fail">There was an error submitting your email address. Please try again.</p>
+        </div>
         <a id="issue-toggle" class="contributors-button" href="#pytorch-1">View Issues</a>
       </div>
 
@@ -57,34 +70,24 @@ background-class: features-background
 <script type="text/javascript">
   $("#past-issues, #issue-toggle" ).on("click", function() {
     $(".hidden").show();
-    $(".marketo-contain").hide();
     $("#sign-up").removeClass("nav-select");
     $("#past-issues").addClass("nav-select");
   })
 
   $("#sign-up").on("click", function() {
     $(".hidden").hide();
-    $(".marketo-contain").show();
     $("#past-issues").removeClass("nav-select");
     $(this).addClass("nav-select");
   });
 
-  $( "#mc-embedded-subscribe-form").submit(function( event ) {
-    event.preventDefault();
-  });
+  var urlParams = new URLSearchParams(window.location.search);
+  var paramValue = urlParams.has('signUp') ? urlParams.get('signUp') : null;
 
-  $("#mc-embedded-subscribe").on("click", function() {
-    if ($("#mce-EMAIL").val()) {
-      $.ajax({
-        type: "POST",
-        crossDomain: true,
-        url: "https://shiftlab.us1.list-manage.com/subscribe/post?u=450bf01a83b20e12a0affdd10&amp;id=10b00504eb",
-        data: $("#mc-embedded-subscribe-form").serialize()
-      });
-      $("#mc-embedded-subscribe-form").hide();
-      $(".form-success").show();
-    } else {
-      alert("Please enter a valid email address.");
-    }
-  })
+  if (paramValue == 'success') {
+    $(".form-fail").hide();
+    $(".form-success").show();
+  } else if (paramValue == 'fail') {
+    $(".form-success").hide();
+    $(".form-fail").show();
+  }
 </script>


### PR DESCRIPTION
Page impacted: `/resources/contributors`

Changes made:

1. Removed link to Google Form in favor of functioning Salesforce sign-up form
2. Adding success and failure URL params to show messaging to user post-submit
3. Add a confirmation check box for user's to acknowledge Data Policy

<img width="1352" alt="Screen Shot 2021-04-29 at 10 19 49 PM" src="https://user-images.githubusercontent.com/213593/116640657-1a099e00-a939-11eb-8916-b7288b4d2722.png">


# Success
- Enter a valid email address that has not yet been added to the system.
- Hit submit.
- Observe success message on automatic page refresh

`/resources/contributors/?signUp=success`

<img width="1352" alt="Screen Shot 2021-04-29 at 10 21 21 PM" src="https://user-images.githubusercontent.com/213593/116640836-6f45af80-a939-11eb-8027-4cbd672b944d.png">


# Failure
- Leave email field blank.
- Hit submit.
- Observe failure message on automatic page refresh

`/resources/contributors/?signUp=fail`

<img width="1303" alt="Screen Shot 2021-04-29 at 10 21 50 PM" src="https://user-images.githubusercontent.com/213593/116640781-50471d80-a939-11eb-8c53-726fbb1eb02e.png">
