### PR TITLE
Revert "Use shallow clone"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.5.1-node
     steps:
-      - run:
-          name: Checkout
-          command: git clone https://github.com/pytorch/pytorch.github.io --depth 1
+      - checkout
       - restore_cache:
           keys:
             - pytorch-gem-cache-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Reverts pytorch/pytorch.github.io#694