### PR TITLE
remove duplicate docs item from mobile menu

### DIFF
--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -51,12 +51,8 @@
           <a href="{{ site.external_urls.tutorials }}">Tutorials</a>
         </li>
 
-        <li>
-          <a href="{{ site.baseurl }}/docs">Docs</a>
-        </li>
-
         <li class="resources-mobile-menu-title">
-          Docs
+          <a href="{{ site.baseurl }}/docs">Docs</a>
         </li>
 
         <ul class="resources-mobile-menu-items">


### PR DESCRIPTION
Currently the docs menu looks like this on mobile:
<img width="314" alt="Screen Shot 2021-05-06 at 2 08 26 PM" src="https://user-images.githubusercontent.com/175163/117365711-8eca6400-ae74-11eb-8a90-1092f7dffbe9.png">


This removes the duplicate docs line.