### PR TITLE
Add image and headline for blog post social sharing

### DIFF
--- a/_includes/open_graph_and_meta.html
+++ b/_includes/open_graph_and_meta.html
@@ -1,13 +1,23 @@
-<meta property="og:title" content="PyTorch" />
-<meta
-  name="description"
-  property="og:description"
-  content="An open source machine learning framework that accelerates the path from research prototyping to production deployment."
-/>
-<meta property="og:url" content="https://www.pytorch.org" />
-<meta property="og:type" content="website" />
-<meta
+{% if page.featured-img %}
+  <meta property="og:title" content="{{ page.title }}" />
+  <meta property="og:description" content="{{ page.excerpt | strip_html }}" />
+  <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/{{ page.featured-img }}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="{{ page.title }}">
+  <meta name="twitter:description" content="{{ page.excerpt | strip_html }}" />
+{% else %}
+  <meta property="og:title" content="PyTorch" />
+  <meta
+    name="description"
+    property="og:description"
+    content="An open source machine learning framework that accelerates the path from research prototyping to production deployment."
+  />
+  <meta
   property="og:image"
   content="{{ site.url }}{{ site.baseurl }}/assets/images/pytorch-logo.png"
-/>
+  />
+{% endif %}
+
+<meta property="og:url" content="https://www.pytorch.org" />
+<meta property="og:type" content="website" />
 <meta name="robots" content="index, follow" />


### PR DESCRIPTION
This PR updates `open_graph_and_meta.html` to allow blog posts to have specific headlines and images.

Example blog post code change:
![Screen Shot 2021-06-09 at 4 24 58 PM](https://user-images.githubusercontent.com/31549535/121431899-009c3e80-c948-11eb-8dd0-3b1f813aff55.png)
The `featured-img` variable is used to set the social preview image.

FB sharing example(generated locally): 

![Screen Shot 2021-06-09 at 4 22 53 PM](https://user-images.githubusercontent.com/31549535/121432138-4822ca80-c948-11eb-9453-493e5e529178.png)

Example Twitter card(generated locally): 

![Screen Shot 2021-06-09 at 4 23 04 PM](https://user-images.githubusercontent.com/31549535/121432222-64266c00-c948-11eb-89be-b425218316a1.png)

