### PR TITLE
Pin nvidia/DeepLearningExamples for waveglow ipynb

### DIFF
--- a/assets/hub/nvidia_deeplearningexamples_waveglow.ipynb
+++ b/assets/hub/nvidia_deeplearningexamples_waveglow.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "waveglow = torch.hub.load('nvidia/DeepLearningExamples:9a6c5241d76de232bc221825f958284dc84e6e35', 'nvidia_waveglow')"
+    "waveglow = torch.hub.load('nvidia/DeepLearningExamples:a8328ce1690fe473f3c5ac55811dab6b0f36700d', 'nvidia_waveglow')"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tacotron2 = torch.hub.load('nvidia/DeepLearningExamples:9a6c5241d76de232bc221825f958284dc84e6e35', 'nvidia_tacotron2')\n",
+    "tacotron2 = torch.hub.load('nvidia/DeepLearningExamples:a8328ce1690fe473f3c5ac55811dab6b0f36700d', 'nvidia_tacotron2')\n",
     "tacotron2 = tacotron2.to('cuda')\n",
     "tacotron2.eval()"
    ]

--- a/assets/hub/nvidia_deeplearningexamples_waveglow.ipynb
+++ b/assets/hub/nvidia_deeplearningexamples_waveglow.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "waveglow = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_waveglow')"
+    "waveglow = torch.hub.load('nvidia/DeepLearningExamples:9a6c5241d76de232bc221825f958284dc84e6e35', 'nvidia_waveglow')"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tacotron2 = torch.hub.load('nvidia/DeepLearningExamples:torchhub', 'nvidia_tacotron2')\n",
+    "tacotron2 = torch.hub.load('nvidia/DeepLearningExamples:9a6c5241d76de232bc221825f958284dc84e6e35', 'nvidia_tacotron2')\n",
     "tacotron2 = tacotron2.to('cuda')\n",
     "tacotron2.eval()"
    ]


### PR DESCRIPTION
Updates to the `nvidia/DeepLearningExamples` repository have caused this particular notebook to start failing see https://github.com/NVIDIA/DeepLearningExamples/issues/955

Originally surfaced from testing for the 1.9 release

~*NOTE*: Currently untested since I'm hitting Github rate limits within colab trying to do a `torch.hub.load`~ I've verified that this works locally

I'm honestly a bit worried about pinning this particular notebook since the commit we have to pin to is ~2 years since they disabled importing from master directly a while ago so all of the commits in between are not as useful