### PR TITLE
Socials not scraping blog header + featured image

### DIFF
--- a/_includes/open_graph_and_meta.html
+++ b/_includes/open_graph_and_meta.html
@@ -16,8 +16,8 @@
   property="og:image"
   content="{{ site.url }}{{ site.baseurl }}/assets/images/pytorch-logo.png"
   />
+  <meta property="og:url" content="https://www.pytorch.org" />
 {% endif %}
 
-<meta property="og:url" content="https://www.pytorch.org" />
 <meta property="og:type" content="website" />
 <meta name="robots" content="index, follow" />


### PR DESCRIPTION
This PR changes the open graph meta to only show `og:url` if the page is not a blog with a featured image