### PR TITLE
Add documentation link to PyTorch Enterprise on Azure section

### DIFF
--- a/_get_started/installation/azure.md
+++ b/_get_started/installation/azure.md
@@ -16,7 +16,7 @@ Microsoft is one of the founding members and also the inaugural participant of t
 
 To learn more and get started with PyTorch Enterprise on Microsoft Azure, [visit here](https://azure.microsoft.com/en-us/develop/pytorch/).
 
-For documentation, [visit here](https://docs.microsoft.com/en-us/azure/pytorch-enterprise/)
+For documentation, [visit here](https://docs.microsoft.com/en-us/azure/pytorch-enterprise/).
 
 ## Azure Primer
 {: #microsoft-azure-primer}

--- a/_get_started/installation/azure.md
+++ b/_get_started/installation/azure.md
@@ -16,6 +16,8 @@ Microsoft is one of the founding members and also the inaugural participant of t
 
 To learn more and get started with PyTorch Enterprise on Microsoft Azure, [visit here](https://azure.microsoft.com/en-us/develop/pytorch/).
 
+For documentation, [visit here](https://docs.microsoft.com/en-us/azure/pytorch-enterprise/)
+
 ## Azure Primer
 {: #microsoft-azure-primer}
 


### PR DESCRIPTION
This PR adds documentation link to PyTorch Enterprise on Azure 

Preview: https://60f1eeb3dda5dd137d4c897c--shiftlab-pytorch-github-io.netlify.app/get-started/cloud-partners//get-started/cloud-partners/
