### PR TITLE
Changed typo for v1.8.0, CUDA 11.1 not 11.0

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -57,7 +57,7 @@ pip install torch -f https://download.pytorch.org/whl/rocm4.0.1/torch_stable.htm
 pip install ninja
 pip install 'git+https://github.com/pytorch/vision.git@v0.9.0'
 
-# CUDA 11.0
+# CUDA 11.1
 pip install torch==1.8.0+cu111 torchvision==0.9.0+cu111 torchaudio==0.8.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 10.2


### PR DESCRIPTION
pip packages for v1.8.0 have installation command for CUDA 11.1 but are listed in CUDA 11.0 which is not accurate. This has been changed.