### PR TITLE
quick-start: Remove lts macOS install commands

### DIFF
--- a/assets/quick-start-module.js
+++ b/assets/quick-start-module.js
@@ -437,16 +437,16 @@ function commandMessage(key) {
       "conda install pytorch torchvision torchaudio cpuonly -c pytorch-lts",
 
     "lts,conda,macos,cuda10.2,python":
-      "conda install pytorch torchvision torchaudio -c pytorch<br /># MacOS Binaries dont support CUDA, install from source if CUDA is needed",
+      "# macOS is not currently supported for lts",
 
     "lts,conda,macos,cuda11.1,python":
-      "conda install pytorch torchvision torchaudio -c pytorch<br /># MacOS Binaries dont support CUDA, install from source if CUDA is needed",
+      "# macOS is not currently supported for lts",
 
     "lts,conda,macos,rocm4.2,python":
-      "<b>NOTE:</b> ROCm is not supported in LTS",
+      "# macOS is not currently supported for lts",
 
     "lts,conda,macos,accnone,python":
-      "conda install pytorch torchvision torchaudio -c pytorch-lts",
+      "# macOS is not currently supported for lts",
 
     "lts,conda,windows,cuda10.2,python":
       "conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-lts",
@@ -461,15 +461,16 @@ function commandMessage(key) {
       "conda install pytorch torchvision torchaudio cpuonly -c pytorch-lts",
 
     "lts,pip,macos,cuda10.2,python":
-      "pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html<br /># MacOS Binaries dont support CUDA, install from source if CUDA is needed",
+      "# macOS is not currently supported for lts",
 
     "lts,pip,macos,cuda11.1,python":
-      "pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html<br /># MacOS Binaries dont support CUDA, install from source if CUDA is needed",
+      "# macOS is not currently supported for lts",
 
     "lts,pip,macos,rocm4.2,python":
-      "<b>NOTE:</b> ROCm is not supported in LTS",
+      "# macOS is not currently supported for lts",
 
-    "lts,pip,macos,accnone,python": "pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html",
+    "lts,pip,macos,accnone,python":
+      "# macOS is not currently supported for lts",
 
     "lts,pip,linux,accnone,python":
       "pip3 install torch==1.8.2+cpu torchvision==0.9.2+cpu torchaudio==0.8.2 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html",
@@ -508,16 +509,16 @@ function commandMessage(key) {
       "<b>NOTE:</b> ROCm is not supported in LTS",
 
     "lts,libtorch,macos,accnone,cplusplus":
-      "Download here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip </a>",
+      "# macOS is not currently supported for lts",
 
     "lts,libtorch,macos,cuda10.2,cplusplus":
-      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip </a>",
+      "# macOS is not currently supported for lts",
 
     "lts,libtorch,macos,cuda11.1,cplusplus":
-      "MacOS binaries do not support CUDA. Download CPU libtorch here: <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip'> https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.8.2.zip </a>",
+      "# macOS is not currently supported for lts",
 
     "lts,libtorch,macos,rocm4.2,cplusplus":
-      "<b>NOTE:</b> ROCm is not supported in LTS",
+      "# macOS is not currently supported for lts",
 
     "lts,libtorch,windows,accnone,cplusplus":
       "Download here (Release version): <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.8.2%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.8.2%2Bcpu.zip</a><br/><br>  Download here (Debug version): <br/><a href='https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-debug-1.8.2%2Bcpu.zip'>https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-debug-1.8.2%2Bcpu.zip</a>",


### PR DESCRIPTION
We're not going to support macOS for lts so let's remove the install
commands

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>