### PR TITLE
Test conda install instructions on  Mac

### DIFF
--- a/.github/workflows/check-quickstartmodule.yml
+++ b/.github/workflows/check-quickstartmodule.yml
@@ -3,11 +3,19 @@ on:
   push:
     branches:
       - site
+    paths:
+      - assets/quick-start-module.js
+      - _includes/quick-start-module.js
+      - published_versions.json
+      - scripts/**
+      - .github/**
   pull_request:
     paths:
       - assets/quick-start-module.js
       - _includes/quick-start-module.js
       - published_versions.json
+      - scripts/**
+      - .github/**
 
 jobs:
   check-regen:
@@ -26,6 +34,7 @@ jobs:
           CHANGES=$(git status --porcelain "assets/quick-start-module.js")
           echo "$CHANGES"
           [ -z "$CHANGES" ]
+
   libtorch-downloadable:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/check-quickstartmodule.yml
+++ b/.github/workflows/check-quickstartmodule.yml
@@ -81,7 +81,7 @@ jobs:
         rel_type: [ "latest_stable" ]
         acc_type: [ "cuda11.1", "cuda10.2", "accnone" ]
         py_vers: [ "3.7", "3.8", "3.9" ]
-        os: ["ubuntu-18.04"]
+        os: ["ubuntu-18.04", "macos-latest"]
     env:
       TEST_ACC: ${{ matrix.acc_type }}
       TEST_VER: ${{ matrix.rel_type }}


### PR DESCRIPTION
Modify workflow path rules to include both .github and script folders
Use `conda.cli.main` instead of `subprocess.check_call`