### PR TITLE
fix formatter to not raise on empty header, update build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby2.6-node
     steps:
       - run:
           name: Checkout

--- a/_devel/formatter.py
+++ b/_devel/formatter.py
@@ -17,7 +17,12 @@ with open('/dev/stdin', 'r') as input, open('/dev/stdout', 'w') as output:
         else:
             markdown += [line]
 
-    header = yaml.load(''.join(header))
+    header = yaml.load(''.join(header), Loader=yaml.BaseLoader)
+    if header is None:
+        # This assumes the markdown document has a yaml header
+        # but some documents, like the README.md do not
+        # Don't bother rendering them
+        exit()
 
     images = []
     try:


### PR DESCRIPTION
Closes #853 

- Some files, like README.md and CONTRIBUTOR.md in the _hub subrepo do not have header indexes. Do not bother rendering them through notebook.
- Update the CircleCI build image

@malfet, @brianjo