### PR TITLE
Deprecating python py3.6 from documents

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -25,7 +25,7 @@ PyTorch is supported on Linux distributions that use [glibc](https://www.gnu.org
 ### Python
 {: #linux-python}
 
-Python 3.6 or greater is generally installed by default on any of our supported Linux distributions, which meets our recommendation.
+Python 3.7 or greater is generally installed by default on any of our supported Linux distributions, which meets our recommendation.
 
 > Tip: By default, you will have to use the command `python3` to run Python. If you want to use just the command `python`, instead of `python3`, you can symlink `python` to the `python3` binary.
 

--- a/_get_started/installation/mac.md
+++ b/_get_started/installation/mac.md
@@ -15,7 +15,7 @@ PyTorch is supported on macOS 10.10 (Yosemite) or above.
 ### Python
 {: #mac-python}
 
-It is recommended that you use Python 3.5 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
+It is recommended that you use Python 3.7 or greater, which can be installed either through the Anaconda package manager (see [below](#anaconda)), [Homebrew](https://brew.sh/), or the [Python website](https://www.python.org/downloads/mac-osx/).
 
 ### Package Manager
 {: #mac-package-manager}

--- a/_get_started/installation/windows.md
+++ b/_get_started/installation/windows.md
@@ -18,7 +18,7 @@ PyTorch is supported on the following Windows distributions:
 ### Python
 {: #windows-python}
 
-Currently, PyTorch on Windows only supports Python 3.x; Python 2.x is not supported.
+Currently, PyTorch on Windows only supports Python 3.7-3.9; Python 2.x is not supported.
 
 As it is not installed by default on Windows, there are multiple ways to install Python:
 


### PR DESCRIPTION
Deprecating python py3.6 from documents