### PR TITLE
Rename "Demo Model Output" button into "Open Model Demo"

### DIFF
--- a/_layouts/hub_detail.html
+++ b/_layouts/hub_detail.html
@@ -32,7 +32,7 @@
               <a href="https://colab.research.google.com/github/pytorch/pytorch.github.io/blob/master/{{ page.path | replace: "_hub", "assets/hub" | replace: ".md", ".ipynb" }}"><button class="btn btn-lg with-right-white-arrow detail-colab-link">Open on Google Colab</button></a>
               {% if page.demo-model-link %}
                 {% if page.demo-model-button-text == blank or page.demo-model-button-text == nil %}
-                  <a href="{{ page.demo-model-link }}"><button class="btn btn-lg with-right-white-arrow detail-web-demo-link">Demo Model Output</button></a>
+                  <a href="{{ page.demo-model-link }}"><button class="btn btn-lg with-right-white-arrow detail-web-demo-link">Open Model Demo</button></a>
                 {% else %}
                   <a href="{{ page.demo-model-link }}"><button class="btn btn-lg with-right-white-arrow detail-web-demo-link">{{ page.demo-model-button-text }}</button></a>
                 {% endif %}


### PR DESCRIPTION
As suggested by our Huggingface/gradio partners, it feels more inviting and consistent with the "Open on Google Colab" button