### PR TITLE
ci: Skip CUDA 10.2 checks for windows

### DIFF
--- a/.github/workflows/check-quickstartmodule.yml
+++ b/.github/workflows/check-quickstartmodule.yml
@@ -58,6 +58,11 @@ jobs:
         acc_type: [ "cuda11.x", "cuda10.2", "accnone" ]
         py_vers: [ "3.7", "3.8", "3.9" ]
         os: ["ubuntu-18.04", "macos-latest", "windows.4xlarge"]
+        # We don't actively build for CUDA 10.2 on windows so we should
+        # skip it in our test matrix for pip install
+        exclude:
+          - os: "windows.4xlarge"
+            acc_type: "cuda10.2"
     env:
       TEST_ACC: ${{ matrix.acc_type }}
       TEST_VER: ${{ matrix.rel_type }}


### PR DESCRIPTION
We stopped build CUDA 10.2 for windows a while back so we should just
remove it from the test matrix

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>