### PR TITLE
Update 2022-3-10-pytorch-1.11-new-library-releases.md

### DIFF
--- a/_posts/2022-3-10-pytorch-1.11-new-library-releases.md
+++ b/_posts/2022-3-10-pytorch-1.11-new-library-releases.md
@@ -8,7 +8,7 @@ featured-img: "assets/images/pytorch-logo.jpg"
 We are introducing the beta release of TorchRec and a number of improvements to the current PyTorch domain libraries, alongside the [PyTorch 1.11 release](https://pytorch.org/blog/pytorch-1.11-released/). These updates demonstrate our focus on developing common and extensible APIs across all domains to make it easier for our community to build ecosystem projects on PyTorch. Highlights include:
 
 - **TorchRec**, a PyTorch domain library for Recommendation Systems, is available in beta. [View it on GitHub](https://github.com/pytorch/torchrec).
-- **TorchAudio** - Added Enformer- and RNN-T-based models and recipes to support the full development lifecycle of a streaming ASR model. See the release notes [here](https://github.com/pytorch/torchrec).
+- **TorchAudio** - Added Enformer- and RNN-T-based models and recipes to support the full development lifecycle of a streaming ASR model. See the release notes [here](https://github.com/pytorch/audio/releases).
 - **TorchText** - Added beta support for RoBERTa and XLM-R models, byte-level BPE tokenizer, and text datasets backed by TorchData. See the release notes [here](https://github.com/pytorch/text/releases).
 - **TorchVision** - Added 4 new model families and 14 new classification datasets such as CLEVR, GTSRB, FER2013. See the release notes [here](https://github.com/pytorch/vision/releases).
 

--- a/_posts/2022-3-10-pytorch-1.11-new-library-releases.md
+++ b/_posts/2022-3-10-pytorch-1.11-new-library-releases.md
@@ -151,8 +151,8 @@ import torch
 from torchvision import models
 
 x = torch.rand(1, 3, 224, 224)
-vit = models.detection.vit_b_16(pretrained=True).eval()
-convnext = models.detection.convnext_tiny(pretrained=True).eval()
+vit = models.vit_b_16(pretrained=True).eval()
+convnext = models.convnext_tiny(pretrained=True).eval()
 predictions1 = vit(x)
 predictions2 = convnext(x)
 ```


### PR DESCRIPTION
Fixes link to torch audio in blog post.