### PR TITLE
fix nightly version (#986)

### DIFF
--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -1,5 +1,5 @@
 <p>Select your preferences and run the install command. Stable represents the most currently tested and supported version of PyTorch. This should
-   be suitable for many users. Preview is available if you want the latest, not fully tested and supported, 1.11 builds that are generated nightly.
+   be suitable for many users. Preview is available if you want the latest, not fully tested and supported, 1.12 builds that are generated nightly.
    Please ensure that you have <b>met the prerequisites below (e.g., numpy)</b>,  depending on your package manager. Anaconda is our recommended
    package manager since it installs all dependencies. You can also
   <a href="{{ site.baseurl }}/get-started/previous-versions">install previous versions of PyTorch</a>. Note that LibTorch is only available for C++.


### PR DESCRIPTION
As I reported #986, nightly version should be 1.12, not 1.11 as below screenshot.

<img src="https://user-images.githubusercontent.com/9343724/160276956-9e618f01-1730-43ed-950c-14f3def15a5b.png">

