### PR TITLE
ci: Try out windows.2022.small for windows testing

### DIFF
--- a/.github/workflows/check-quickstartmodule.yml
+++ b/.github/workflows/check-quickstartmodule.yml
@@ -54,14 +54,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rel_type: [ "latest_stable", "latest_lts" ]
-        acc_type: [ "cuda11.x", "cuda10.2", "accnone" ]
-        py_vers: [ "3.7", "3.8", "3.9" ]
-        os: ["ubuntu-18.04", "macos-latest", "windows.4xlarge"]
+        rel_type: ["latest_stable", "latest_lts"]
+        acc_type: ["cuda11.x", "cuda10.2", "accnone"]
+        py_vers: ["3.7", "3.8", "3.9"]
+        os: ["ubuntu-18.04", "macos-latest", "windows.2022.small"]
         # We don't actively build for CUDA 10.2 on windows so we should
         # skip it in our test matrix for pip install
         exclude:
-          - os: "windows.4xlarge"
+          - os: "windows.2022.small"
             acc_type: "cuda10.2"
     env:
       TEST_ACC: ${{ matrix.acc_type }}
@@ -90,9 +90,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rel_type: [ "latest_stable" ]
-        acc_type: [ "cuda11.x", "cuda10.2", "accnone" ]
-        py_vers: [ "3.7", "3.8", "3.9" ]
+        rel_type: ["latest_stable"]
+        acc_type: ["cuda11.x", "cuda10.2", "accnone"]
+        py_vers: ["3.7", "3.8", "3.9"]
         os: ["ubuntu-18.04", "macos-latest"]
     env:
       TEST_ACC: ${{ matrix.acc_type }}


### PR DESCRIPTION
Tries out our new runner type `windows.2022.small` to see if it'll work for this application