### PR TITLE
Fix link to torchvision in mobile menu

### DIFF
--- a/_includes/mobile_menu.html
+++ b/_includes/mobile_menu.html
@@ -72,7 +72,7 @@
           </li>
 
           <li class="{% if current[1] == 'torchvision' %}active{% endif %}">
-            <a href="{{ site.baseurl }}/docs/stable/torchvision">torchvision</a>
+            <a href="{{ site.baseurl }}/vision">torchvision</a>
           </li>
 
           <li class="{% if current[1] == 'hub' %}active{% endif %}">


### PR DESCRIPTION
The link should point to https://pytorch.org/vision as in the desktop menu instead of https://pytorch.org/docs/stable/torchvision