### PR TITLE
fix of AWS SageMaker broken link 

### DIFF
--- a/_get_started/installation/aws.md
+++ b/_get_started/installation/aws.md
@@ -99,7 +99,7 @@ Once you decided upon your instance type, you will need to create, optionally co
 
 With [SageMaker](https://aws.amazon.com/sagemaker) service AWS provides a fully-managed service that allows developers and data scientists to build, train, and deploy machine learning models.
 
-See AWS documentation to learn [how to configure Amazon SageMaker with PyTorch]((https://docs.aws.amazon.com/sagemaker/latest/dg/pytorch.html)).
+See AWS documentation to learn [how to configure Amazon SageMaker with PyTorch](https://docs.aws.amazon.com/sagemaker/latest/dg/pytorch.html).
 
 ## Pre-Built AMIs
 {: #aws-amis}


### PR DESCRIPTION
Open https://pytorch.org/get-started/cloud-partners, select Amazon Web Services, then go to the AWS SAGEMAKER section and click how to configure Amazon SageMaker with PyTorch: Oops will show due to extra () in the md doc link.