### PR TITLE
Fix some previous versions installation instructions

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -32,7 +32,16 @@ conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 -c pytorch
 
 ```
 # CUDA 10.2
-conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=10.2 -c pytorch
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=10.2 -c pytorch -c conda-forge
+
+# CUDA 11.0
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.0 -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.1 -c conda-forge
+
+# CUDA 11.2
+conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.2 -c conda-forge
 
 # CUDA 11.3
 conda install pytorch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0 cudatoolkit=11.3 -c pytorch
@@ -55,6 +64,9 @@ pip install torch==1.11.0 torchvision==0.12.0 torchaudio==0.11.0
 # ROCM 4.5.2 (Linux only)
 pip install torch==1.11.0+rocm4.5.2 torchvision==0.12.0+rocm4.5.2 torchaudio==0.11.0 --extra-index-url  https://download.pytorch.org/whl/rocm4.5.2
 
+# CUDA 11.5
+pip install torch==1.11.0+cu115 torchvision==0.12.0+cu115 torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cu115
+
 # CUDA 11.3
 pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cu113
 
@@ -63,6 +75,69 @@ pip install torch==1.11.0+cu102 torchvision==0.12.0+cu102 torchaudio==0.11.0 --e
 
 # CPU only
 pip install torch==1.11.0+cpu torchvision==0.12.0+cpu torchaudio==0.11.0 --extra-index-url https://download.pytorch.org/whl/cpu
+```
+
+### v1.10.2
+
+#### Conda
+
+##### OSX
+
+```
+# conda
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 -c pytorch
+```
+
+#####  Linux and Windows
+
+```
+# CUDA 10.2
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=10.2 -c pytorch -c conda-forge
+
+# CUDA 11.0
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.0 -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.1 -c pytorch -c conda-forge
+
+# CUDA 11.2
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.2 -c conda-forge
+
+# CUDA 11.3
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.3 -c pytorch
+
+# CPU Only
+conda install pytorch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1 cpuonly -c pytorch
+```
+
+#### Wheel
+
+##### OSX
+
+```
+pip install torch==1.10.2 torchvision==0.11.2 torchaudio==0.10.1
+```
+
+##### Linux and Windows
+
+```
+# ROCM 4.2 (Linux only)
+pip install torch==1.10.2+rocm4.2 torchvision==0.11.2+rocm4.2 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+
+# ROCM 4.1 (Linux only)
+pip install torch==1.10.2+rocm4.1 torchvision==0.11.2+rocm4.1 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+
+# CUDA 11.3
+pip install torch==1.10.2+cu113 torchvision==0.11.2+cu113 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+
+# CUDA 11.1
+pip install torch==1.10.2+cu111 torchvision==0.11.2+cu111 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+
+# CUDA 10.2
+pip install torch==1.10.2+cu102 torchvision==0.11.2+cu102 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+
+# CPU only
+pip install torch==1.10.2+cpu torchvision==0.11.2+cpu torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 ### v1.10.1
@@ -80,10 +155,19 @@ conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 -c pytorch
 
 ```
 # CUDA 10.2
-conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=10.2 -c pytorch
+conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=10.2 -c pytorch -c conda-forge
+
+# CUDA 11.0
+conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.0 -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.1 -c pytorch -c conda-forge
+
+# CUDA 11.2
+conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.2 -c conda-forge
 
 # CUDA 11.3
-conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.3 -c pytorch -c conda-forge
+conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.3 -c pytorch
 
 # CPU Only
 conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cpuonly -c pytorch
@@ -106,8 +190,8 @@ pip install torch==1.10.1+rocm4.2 torchvision==0.11.2+rocm4.2 torchaudio==0.10.1
 # ROCM 4.1 (Linux only)
 pip install torch==1.10.1+rocm4.1 torchvision==0.11.2+rocm4.1 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
 
-# ROCM 4.0.1 (Linux only)
-pip install torch==1.10.1+rocm4.0.1 torchvision==0.10.2+rocm4.0.1 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
+# CUDA 11.3
+pip install torch==1.10.1+cu113 torchvision==0.11.2+cu113 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 11.1
 pip install torch==1.10.1+cu111 torchvision==0.11.2+cu111 torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
@@ -118,7 +202,6 @@ pip install torch==1.10.1+cu102 torchvision==0.11.2+cu102 torchaudio==0.10.1 -f 
 # CPU only
 pip install torch==1.10.1+cpu torchvision==0.11.2+cpu torchaudio==0.10.1 -f https://download.pytorch.org/whl/torch_stable.html
 ```
-
 
 ### v1.10.0
 
@@ -135,10 +218,13 @@ conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 -c pytorch
 
 ```
 # CUDA 10.2
-conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=10.2 -c pytorch
+conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=10.2 -c pytorch -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=11.1 -c pytorch -c conda-forge
 
 # CUDA 11.3
-conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=11.3 -c pytorch -c conda-forge
+conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=11.3 -c pytorch
 
 # CPU Only
 conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cpuonly -c pytorch
@@ -161,8 +247,8 @@ pip install torch==1.10.0+rocm4.2 torchvision==0.11.0+rocm4.2 torchaudio==0.10.0
 # ROCM 4.1 (Linux only)
 pip install torch==1.10.0+rocm4.1 torchvision==0.11.0+rocm4.1 torchaudio==0.10.0 -f https://download.pytorch.org/whl/torch_stable.html
 
-# ROCM 4.0.1 (Linux only)
-pip install torch==1.10.0+rocm4.0.1 torchvision==0.10.1+rocm4.0.1 torchaudio==0.10.0 -f https://download.pytorch.org/whl/torch_stable.html
+# CUDA 11.3
+pip install torch==1.10.0+cu113 torchvision==0.11.0+cu113 torchaudio==0.10.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 11.1
 pip install torch==1.10.0+cu111 torchvision==0.11.0+cu111 torchaudio==0.10.0 -f https://download.pytorch.org/whl/torch_stable.html
@@ -192,11 +278,17 @@ conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 -c pytorch
 # CUDA 10.2
 conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=10.2 -c pytorch
 
-# CUDA 11.3
-conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.0
+conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.0 -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.1 -c pytorch -c conda-forge
+
+# CUDA 11.2
+conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.2 -c conda-forge
 
 # CPU Only
-conda install pytorch==1.9.0 torchvision==0.10.1 torchaudio==0.9.1 cpuonly -c pytorch
+conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cpuonly -c pytorch
 ```
 
 #### Wheel
@@ -211,13 +303,10 @@ pip install torch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1
 
 ```
 # ROCM 4.2 (Linux only)
-pip install torch==1.9.0+rocm4.2 torchvision==0.10.1+rocm4.2 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
+pip install torch==1.9.1+rocm4.2 torchvision==0.10.1+rocm4.2 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
 
 # ROCM 4.1 (Linux only)
-pip install torch==1.9.0+rocm4.1 torchvision==0.10.1+rocm4.1 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
-
-# ROCM 4.0.1 (Linux only)
-pip install torch==1.9.1+rocm4.0.1 torchvision==0.10.1+rocm4.0.1 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
+pip install torch==1.9.1+rocm4.1 torchvision==0.10.1+rocm4.1 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 11.1
 pip install torch==1.9.1+cu111 torchvision==0.10.1+cu111 torchaudio==0.9.1 -f https://download.pytorch.org/whl/torch_stable.html
@@ -244,10 +333,16 @@ conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 -c pytorch
 
 ```
 # CUDA 10.2
-conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=10.2 -c pytorch
+conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=10.2 -c pytorch -c conda-forge
 
-# CUDA 11.3
-conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.0
+conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.0 -c conda-forge
+
+# CUDA 11.1
+conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.1 -c pytorch -c conda-forge
+
+# CUDA 11.2
+conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.2 -c conda-forge
 
 # CPU Only
 conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cpuonly -c pytorch
@@ -269,9 +364,6 @@ pip install torch==1.9.0+rocm4.2 torchvision==0.10.0+rocm4.2 torchaudio==0.9.0 -
 
 # ROCM 4.1 (Linux only)
 pip install torch==1.9.0+rocm4.1 torchvision==0.10.0+rocm4.1 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
-
-# ROCM 4.0.1 (Linux only)
-pip install torch==1.9.0+rocm4.0.1 torchvision==0.10.0+rocm4.0.1 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # CUDA 11.1
 pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
@@ -300,8 +392,8 @@ conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 -c pytorch
 # CUDA 10.2
 conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=10.2 -c pytorch
 
-# CUDA 11.3
-conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.1
+conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=11.1 -c pytorch
 
 # CPU Only
 conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cpuonly -c pytorch


### PR DESCRIPTION
Fixed some installation instructions down from 1.11.0 to 1.8.1

I didn't test those lines but I checked all the repositories manually:
- https://download.pytorch.org/whl/torch/
- https://anaconda.org/conda-forge/pytorch/files
- https://anaconda.org/pytorch/pytorch/files
- https://download.pytorch.org/whl/torchvision/
- https://anaconda.org/conda-forge/torchvision/files
- https://anaconda.org/pytorch/torchvision/files

Summary:
- Added some cuda version missing (mostly 11.0 and 11.2 from conda-forge)
- Added installation instructions for torch==1.10.2
- Fix some repository that are wrongly assigned (example: pytorch==1.10.0 with cuda 11.3 doesn't have any file in conda-forge)
- removed installation instruction for ROCM 4.0.1 since there is no torchvision with this version on https://download.pytorch.org/whl/torchvision/
- Remove mismatch torch / cuda (example: torch==1.9.0 doesn't have a cuda==11.3)