### PR TITLE
Copy community docs from trunk to stable

### DIFF
--- a/docs/1.12/amp.html
+++ b/docs/1.12/amp.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/autograd.html
+++ b/docs/1.12/autograd.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/backends.html
+++ b/docs/1.12/backends.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/benchmark_utils.html
+++ b/docs/1.12/benchmark_utils.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/bottleneck.html
+++ b/docs/1.12/bottleneck.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/checkpoint.html
+++ b/docs/1.12/checkpoint.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/community/build_ci_governance.html
+++ b/docs/1.12/community/build_ci_governance.html
@@ -10,14 +10,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Contribution Guide &mdash; PyTorch master documentation</title>
+  <title>PyTorch Governance | Build + CI &mdash; PyTorch master documentation</title>
   
 
   
   
   
   
-    <link rel="canonical" href="https://pytorch.org/docs/stable/community/contribution_guide.html"/>
+    <link rel="canonical" href="https://pytorch.org/docs/stable/community/build_ci_governance.html"/>
   
 
   
@@ -41,8 +41,8 @@
   <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
-    <link rel="next" title="PyTorch Design Philosophy" href="design.html" />
-    <link rel="prev" title="PyTorch Governance | Build + CI" href="build_ci_governance.html" />
+    <link rel="next" title="PyTorch Contribution Guide" href="contribution_guide.html" />
+    <link rel="prev" title="PyTorch documentation" href="../index.html" />
 
 <!--
   Search engines should not index the master version of documentation.
@@ -242,7 +242,7 @@
           
 
 <div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/contribution_guide.html">
+  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/build_ci_governance.html">
     You are viewing unstable developer preview docs.
     Click here to view docs for latest stable release.
   </a>
@@ -256,8 +256,8 @@
             
               <p class="caption" role="heading"><span class="caption-text">Community</span></p>
 <ul class="current">
-<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
 <li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
 <li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
 <li class="toctree-l1"><a class="reference internal" href="persons_of_interest.html">PyTorch Governance | Maintainers</a></li>
@@ -398,13 +398,13 @@
       </li>
 
         
-      <li>PyTorch Contribution Guide</li>
+      <li>PyTorch Governance | Build + CI</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/community/contribution_guide.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="../_sources/community/build_ci_governance.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -430,365 +430,23 @@
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
               
-  <section id="pytorch-contribution-guide">
-<h1>PyTorch Contribution Guide<a class="headerlink" href="#pytorch-contribution-guide" title="Permalink to this heading">¶</a></h1>
-<p>PyTorch is a GPU-accelerated Python tensor computation package for
-building deep neural networks using a on tape-based autograd systems.</p>
-<section id="contribution-process">
-<h2>Contribution Process<a class="headerlink" href="#contribution-process" title="Permalink to this heading">¶</a></h2>
-<p>The PyTorch organization is governed by <a class="reference internal" href="governance.html"><span class="doc">PyTorch
-Governance</span></a> and the technical guide to contributing
-can be found in <a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
-<p>The PyTorch development process involves a healthy amount of open
-discussions between the core development team and the community.</p>
-<p>PyTorch operates similarly to most open source projects on GitHub.
-However, if you’ve never contributed to an open source project before,
-here is the basic process.</p>
+  <section id="pytorch-governance-build-ci">
+<h1>PyTorch Governance | Build + CI<a class="headerlink" href="#pytorch-governance-build-ci" title="Permalink to this heading">¶</a></h1>
+<section id="how-to-add-a-new-maintainer">
+<h2>How to Add a New Maintainer<a class="headerlink" href="#how-to-add-a-new-maintainer" title="Permalink to this heading">¶</a></h2>
+<p>For the person to be a maintainer, a person needs to:</p>
 <ul class="simple">
-<li><p><strong>Figure out what you’re going to work on.</strong> The majority of open
-source contributions come from people scratching their own itches.
-However, if you don’t know what you want to work on, or are just
-looking to get more acquainted with the project, here are some tips
-for how to find appropriate tasks:</p>
-<ul>
-<li><p>Look through the <a class="reference external" href="https://github.com/pytorch/pytorch/issues/">issue
-tracker</a> and see if
-there are any issues you know how to fix. Issues that are
-confirmed by other contributors tend to be better to investigate.
-We also maintain some labels for issues that are likely to be
-good for new people, e.g., <strong>bootcamp</strong> and <strong>1hr</strong>, although
-these labels are less well maintained.</p></li>
-<li><p>Join us on <a class="reference external" href="https://dev-discuss.pytorch.org/">dev discuss</a>
-and let us know you’re interested in getting to
-know PyTorch. We’re very happy to help out researchers and
-partners get up to speed with the codebase.</p></li>
+<li><p>Land at least six commits to the related part of the PyTorch repository</p></li>
+<li><p>At least one of these commits must be submitted in the last six months</p></li>
 </ul>
-</li>
-<li><p><strong>Figure out the scope of your change and reach out for design
-comments on a GitHub issue if it’s large.</strong> The majority of pull
-requests are small; in that case, no need to let us know about what
-you want to do, just get cracking. But if the change is going to be
-large, it’s usually a good idea to get some design comments about it
-first by <a class="reference external" href="https://github.com/pytorch/rfcs/blob/master/README.md">submitting an RFC</a>.</p>
-<ul>
-<li><p>If you don’t know how big a change is going to be, we can help you
-figure it out! Just post about it on
-<a class="reference external" href="https://github.com/pytorch/pytorch/issues/">issues</a> or
-<a class="reference external" href="https://dev-discuss.pytorch.org/">dev discuss</a>.</p></li>
-<li><p>Some feature additions are very standardized; for example, lots of
-people add new operators or optimizers to PyTorch. Design
-discussion in these cases boils down mostly to, “Do we want this
-operator/optimizer?” Giving evidence for its utility, e.g., usage
-in peer reviewed papers, or existence in other frameworks, helps a
-bit when making this case.</p>
-<ul>
-<li><p><strong>Adding operators / algorithms from recently-released research</strong>
-is generally not accepted unless there is overwhelming evidence that
-this newly published work has ground-breaking results and will eventually
-become a standard in the field. If you are not sure where your method falls,
-open an issue first before implementing a PR.</p></li>
-</ul>
-</li>
-<li><p>Core changes and refactors can be quite difficult to coordinate
-since the pace of development on PyTorch master is quite fast.
-Definitely reach out about fundamental or cross-cutting changes;
-we can often give guidance about how to stage such changes into
-more easily reviewable pieces.</p></li>
-</ul>
-</li>
-<li><p><strong>Code it out!</strong></p>
-<ul>
-<li><p>See the <a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a> file for advice for working with PyTorch in a
-technical form.</p></li>
-</ul>
-</li>
-<li><p><strong>Open a pull request.</strong></p>
-<ul>
-<li><p>If you are not ready for the pull request to be reviewed, create a draft
-pull request first - you can later convert it to a full PR by pressing
-“Ready for review” button. You can also prepend the title of the PR with
-“[WIP]” (“work in progress”) while it’s still in draft. We will ignore
-draft PRs when doing review passes. If you are working on a complex change,
-it’s good to start things off as a draft, because you will need to spend
-time looking at CI results to see if things worked out or not.</p></li>
-<li><p>Find an appropriate reviewer for your change. We have some folks
-who regularly go through the PR queue and try to review
-everything, but if you happen to know who the maintainer for a
-given subsystem affected by your patch is, feel free to include
-them directly on the pull request. You can learn more about
-<a class="reference external" href="https://pytorch.org/docs/master/community/persons_of_interest.html">Persons of Interest</a>
-that could review your code.</p></li>
-</ul>
-</li>
-<li><p><strong>Iterate on the pull request until it’s accepted!</strong></p>
-<ul>
-<li><p>We’ll try our best to minimize the number of review round trips and
-block PRs only when there are major issues. For the most common
-issues in pull requests, take a look at <a class="reference external" href="#common-mistakes-to-avoid">Common Mistakes</a>.</p></li>
-<li><p>Once a pull request is accepted and CI is passing, there is
-nothing else you need to do; we will merge the PR for you.</p></li>
-</ul>
-</li>
-</ul>
-</section>
-<section id="getting-started">
-<h2>Getting Started<a class="headerlink" href="#getting-started" title="Permalink to this heading">¶</a></h2>
-<section id="proposing-new-features">
-<h3>Proposing New Features<a class="headerlink" href="#proposing-new-features" title="Permalink to this heading">¶</a></h3>
-<p>New feature ideas are best discussed on a specific issue. Please include
-as much information as you can, any accompanying data, and your proposed
-solution. The PyTorch team and community frequently review new issues
-and comments where they think they can help. If you feel confident in
-your solution, go ahead and implement it.</p>
-</section>
-<section id="reporting-issues">
-<h3>Reporting Issues<a class="headerlink" href="#reporting-issues" title="Permalink to this heading">¶</a></h3>
-<p>If you’ve identified an issue, first search through the <a class="reference external" href="https://github.com/pytorch/pytorch/issues">list of
-existing issues</a> on the
-repo. If you are unable to find a similar issue, then create a new one.
-Supply as much information you can to reproduce the problematic
-behavior. Also, include any additional insights like the behavior you
-expect.</p>
-</section>
-<section id="implementing-features-or-fixing-bugs">
-<h3>Implementing Features or Fixing Bugs<a class="headerlink" href="#implementing-features-or-fixing-bugs" title="Permalink to this heading">¶</a></h3>
-<p>If you want to fix a specific issue, it’s best to comment on the
-individual issue with your intent. However, we do not lock or assign
-issues except in cases where we have worked with the developer before.
-It’s best to strike up a conversation on the issue and discuss your
-proposed solution. The PyTorch team can provide guidance that saves you
-time.</p>
-<p>Issues that are labeled first-new-issue, low, or medium priority provide
-the best entrance point are great places to start.</p>
-</section>
-<section id="adding-tutorials">
-<h3>Adding Tutorials<a class="headerlink" href="#adding-tutorials" title="Permalink to this heading">¶</a></h3>
-<p>A great deal of the tutorials on <a class="reference external" href="https://pytorch.org/">pytorch.org</a>
-come from the community itself and we welcome additional contributions.
-To learn more about how to contribute a new tutorial you can learn more
-here: <a class="reference external" href="https://github.com/pytorch/tutorials/#contributing">PyTorch.org Tutorial Contribution Guide on
-Github</a></p>
-</section>
-<section id="improving-documentation-tutorials">
-<h3>Improving Documentation &amp; Tutorials<a class="headerlink" href="#improving-documentation-tutorials" title="Permalink to this heading">¶</a></h3>
-<p>We aim to produce high quality documentation and tutorials. On rare
-occasions that content includes typos or bugs. If you find something you
-can fix, send us a pull request for consideration.</p>
-<p>Take a look at the <a class="reference external" href="#on-documentation">Documentation</a> section to learn how our system
-works.</p>
-</section>
-<section id="participating-in-online-discussions">
-<h3>Participating in Online Discussions<a class="headerlink" href="#participating-in-online-discussions" title="Permalink to this heading">¶</a></h3>
-<p>You can find active discussions happening on the <a class="reference external" href="https://discuss.pytorch.org/">PyTorch Discussion
-Forums</a>  for users as well as the
-<a class="reference external" href="https://dev-discuss.pytorch.org/">PyTorch Dev Discussion Forums</a>
-for developers and maintainers.</p>
-</section>
-<section id="submitting-pull-requests-to-fix-open-issues">
-<h3>Submitting Pull Requests to Fix Open Issues<a class="headerlink" href="#submitting-pull-requests-to-fix-open-issues" title="Permalink to this heading">¶</a></h3>
-<p>You can view a list of all open issues
-<a class="reference external" href="https://github.com/pytorch/pytorch/issues">here</a>. Commenting on an
-issue is a great way to get the attention of the team. From here you can
-share your ideas and how you plan to resolve the issue.</p>
-<p>For more challenging issues, the team will provide feedback and
-direction for how to best solve the issue.</p>
-<p>If you’re not able to fix the issue yourself, commenting and sharing
-whether you can reproduce the issue can help the team
-identify problem areas.</p>
-</section>
-<section id="reviewing-open-pull-requests">
-<h3>Reviewing Open Pull Requests<a class="headerlink" href="#reviewing-open-pull-requests" title="Permalink to this heading">¶</a></h3>
-<p>We appreciate your help reviewing and commenting on pull requests. Our
-team strives to keep the number of open pull requests at a manageable
-size, we respond quickly for more information if we need it, and we
-merge PRs that we think are useful. However, due to the high level of
-interest, additional eyes on the pull requests are always appreciated.</p>
-</section>
-<section id="improving-code-readability">
-<h3>Improving Code Readability<a class="headerlink" href="#improving-code-readability" title="Permalink to this heading">¶</a></h3>
-<p>Improving code readability helps everyone. It is often better to submit a
-small number of pull requests that touch a few files versus a large pull
-request that touches many files. Starting a discussion in the PyTorch
-forum <a class="reference external" href="https://discuss.pytorch.org/">here</a> or on an issue related to
-your improvement is the best way to get started.</p>
-</section>
-<section id="adding-test-cases-to-make-the-codebase-more-robust">
-<h3>Adding Test Cases to Make the Codebase More Robust<a class="headerlink" href="#adding-test-cases-to-make-the-codebase-more-robust" title="Permalink to this heading">¶</a></h3>
-<p>Additional test coverage is appreciated.</p>
-</section>
-<section id="promoting-pytorch">
-<h3>Promoting PyTorch<a class="headerlink" href="#promoting-pytorch" title="Permalink to this heading">¶</a></h3>
-<p>Your use of PyTorch in your projects, research papers, write ups, blogs,
-or general discussions around the internet helps to raise awareness for
-PyTorch and our growing community. Please reach out to
-<a class="reference external" href="mailto:marketing&#37;&#52;&#48;pytorch&#46;org">marketing<span>&#64;</span>pytorch<span>&#46;</span>org</a>
-for marketing support.</p>
-</section>
-<section id="triaging-issues">
-<h3>Triaging Issues<a class="headerlink" href="#triaging-issues" title="Permalink to this heading">¶</a></h3>
-<p>If you feel that an issue could benefit from a particular tag or level
-of complexity, comment on the issue and share your opinion. If you
-feel an issue isn’t categorized properly, comment and let the team know.</p>
-</section>
-</section>
-<section id="about-open-source-development">
-<h2>About Open Source Development<a class="headerlink" href="#about-open-source-development" title="Permalink to this heading">¶</a></h2>
-<p>If this is your first time contributing to an open source project, some
-aspects of the development process may seem unusual to you.</p>
-<ul class="simple">
-<li><p><strong>There is no way to “claim” issues.</strong> People often want to “claim”
-an issue when they decide to work on it, to ensure that there isn’t
-wasted work when someone else ends up working on it. This doesn’t
-really work too well in open source, since someone may decide to work
-on something, and end up not having time to do it. Feel free to give
-information in an advisory fashion, but at the end of the day, we
-will take running code and rough consensus to move forward quickly.</p></li>
-<li><p><strong>There is a high bar for new functionality.</strong> Unlike
-in a corporate environment, where the person who wrote code
-implicitly “owns” it and can be expected to take care of it for the
-code’s lifetime, once a pull request is merged into an open
-source project, it immediately becomes the collective responsibility
-of all maintainers on the project. When we merge code, we are saying
-that we, the maintainers, can review subsequent changes and
-make a bugfix to the code. This naturally leads to a higher standard
-of contribution.</p></li>
-</ul>
-</section>
-<section id="common-mistakes-to-avoid">
-<h2>Common Mistakes To Avoid<a class="headerlink" href="#common-mistakes-to-avoid" title="Permalink to this heading">¶</a></h2>
-<ul class="simple">
-<li><p><strong>Did you add tests?</strong> (Or if the change is hard to test, did you
-describe how you tested your change?)</p>
-<ul>
-<li><p>We have a few motivations for why we ask for tests:</p>
-<ol class="arabic simple">
-<li><p>to help us tell if we break it later</p></li>
-<li><p>to help us tell if the patch is correct in the first place
-(yes, we did review it, but as Knuth says, “beware of the
-following code, for I have not run it, merely proven it
-correct”)</p></li>
-</ol>
-</li>
-<li><p>When is it OK not to add a test? Sometimes a change can’t be
-conveniently tested, or the change is so obviously correct (and
-unlikely to be broken) that it’s OK not to test it. On the
-contrary, if a change seems likely (or is known to be likely)
-to be accidentally broken, it’s important to put in the time to
-work out a testing strategy.</p></li>
-</ul>
-</li>
-<li><p><strong>Is your PR too long?</strong></p>
-<ul>
-<li><p>It’s easier for us to review and merge small PRs. The difficulty of
-reviewing a PR scales nonlinearly with its size.</p></li>
-<li><p>When is it OK to submit a large PR? It helps a lot if there was a
-corresponding design discussion in an issue, with sign off from
-the people who are going to review your diff. We can also help
-give advice about how to split up a large change into individually
-shippable parts. Similarly, it helps if there is a complete
-description of the contents of the PR: it’s easier to review code
-if we know what’s inside!</p></li>
-</ul>
-</li>
-<li><p><strong>Comments for subtle things?</strong> In cases where the behavior of your code
-is nuanced, please include extra comments and documentation to allow
-us to better understand the intention of your code.</p></li>
-<li><p><strong>Did you add a hack?</strong> Sometimes, the right answer is a hack. But
-usually, we will have to discuss it.</p></li>
-<li><p><strong>Do you want to touch a very core component?</strong> To prevent
-major regressions, pull requests that touch core components receive
-extra scrutiny. Make sure you’ve discussed your changes with the team
-before undertaking major changes.</p></li>
-<li><p><strong>Want to add a new feature?</strong> If you want to add new features,
-comment your intention on the related issue. Our team tries to
-comment on and provide feedback to the community. It’s better to have
-an open discussion with the team and the rest of the community before
-building new features. This helps us stay aware of what you’re
-working on and increases the chance that it’ll be merged.</p></li>
-<li><p><strong>Did you touch code unrelated to the PR?</strong> To aid in code review,
-please only include files in your pull request that are directly
-related to your changes.</p></li>
-</ul>
-</section>
-<section id="frequently-asked-questions">
-<h2>Frequently Asked Questions<a class="headerlink" href="#frequently-asked-questions" title="Permalink to this heading">¶</a></h2>
-<ul class="simple">
-<li><p><strong>How can I contribute as a reviewer?</strong> There is lots of value if
-community developers reproduce issues, try out new functionality, or
-otherwise help us identify or troubleshoot issues. Commenting on
-tasks or pull requests with your environment details is helpful and
-appreciated.</p></li>
-<li><p><strong>CI tests failed, what does it mean?</strong> Maybe your PR is based
-off a broken master? You can try to rebase your change on top
-of the latest master. You can also see the current status of
-master’s CI at <a class="reference external" href="https://hud.pytorch.org/">https://hud.pytorch.org/</a>.</p></li>
-<li><p><strong>What are the most high risk changes?</strong> Anything that touches build
-configuration is a risky area. Please avoid changing these unless
-you’ve had a discussion with the team beforehand.</p></li>
-<li><p><strong>Hey, a commit showed up on my branch, what’s up with that?</strong>
-Sometimes another community member will provide a patch or fix to
-your pull request or branch. This is often needed for getting CI tests
-to pass.</p></li>
-</ul>
-</section>
-<section id="on-documentation">
-<h2>On Documentation<a class="headerlink" href="#on-documentation" title="Permalink to this heading">¶</a></h2>
-<section id="python-docs">
-<h3>Python Docs<a class="headerlink" href="#python-docs" title="Permalink to this heading">¶</a></h3>
-<p>PyTorch documentation is generated from python source using
-<a class="reference external" href="https://www.sphinx-doc.org/en/master/">Sphinx</a>. Generated HTML is
-copied to the docs folder in the master branch of
-<a class="reference external" href="https://github.com/pytorch/pytorch.github.io/tree/master/docs">pytorch.github.io</a>,
-and is served via GitHub pages.</p>
-<ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/docs">https://pytorch.org/docs</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/pytorch/tree/master/docs">https://github.com/pytorch/pytorch/tree/master/docs</a></p></li>
-<li><p>Served from:
-<a class="reference external" href="https://github.com/pytorch/pytorch.github.io/tree/master/docs">https://github.com/pytorch/pytorch.github.io/tree/master/doc</a></p></li>
-</ul>
-</section>
-<section id="c-docs">
-<h3>C++ Docs<a class="headerlink" href="#c-docs" title="Permalink to this heading">¶</a></h3>
-<p>For C++ code we use Doxygen to generate the content files. The C++ docs
-are built on a special server and the resulting files are copied to the
-<a class="reference external" href="https://github.com/pytorch/cppdocs">https://github.com/pytorch/cppdocs</a> repo, and are served from GitHub
-pages.</p>
-<ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/cppdocs">https://pytorch.org/cppdocs</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/pytorch/tree/master/docs/cpp">https://github.com/pytorch/pytorch/tree/master/docs/cpp</a></p></li>
-<li><p>Served from: <a class="reference external" href="https://github.com/pytorch/cppdocs">https://github.com/pytorch/cppdocs</a></p></li>
-</ul>
-</section>
-</section>
-<section id="tutorials">
-<h2>Tutorials<a class="headerlink" href="#tutorials" title="Permalink to this heading">¶</a></h2>
-<p>PyTorch tutorials are documents used to help understand using PyTorch to
-accomplish specific tasks or to understand more holistic concepts.
-Tutorials are built using
-<a class="reference external" href="https://sphinx-gallery.readthedocs.io/en/latest/index.html">Sphinx-Gallery</a>
-from executable python source files, or from restructured-text (rst)
-files.</p>
-<ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/tutorials">https://pytorch.org/tutorials</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/tutorials">https://github.com/pytorch/tutorials</a></p></li>
-</ul>
-<section id="tutorials-build-overview">
-<h3>Tutorials Build Overview<a class="headerlink" href="#tutorials-build-overview" title="Permalink to this heading">¶</a></h3>
-<p>For tutorials, <a class="reference external" href="https://github.com/pytorch/tutorials/pulls">pull
-requests</a> trigger a
-rebuild of the entire site using CircleCI to test the effects of the
-change. This build is sharded into 9 worker builds and takes around 40
-minutes total. At the same time, we do a Netlify build using <em>make
-html-noplot</em>, which builds the site without rendering the notebook
-output into pages for quick review.</p>
-<p>After a PR is accepted, the site is rebuilt and deployed using GitHub
-Actions.</p>
-</section>
-<section id="contributing-a-new-tutorial">
-<h3>Contributing a New Tutorial<a class="headerlink" href="#contributing-a-new-tutorial" title="Permalink to this heading">¶</a></h3>
-<p>See <a class="reference external" href="https://github.com/pytorch/tutorials/#contributing">PyTorch.org Tutorial Contribution
-Guide</a>.</p>
-</section>
+<p>To add a qualified person to the maintainers’ list, please create
+a PR that adds a person to the <a class="reference external" href="https://pytorch.org/docs/master/community/persons_of_interest.html">persons of interests</a> page and
+<a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/.github/merge_rules.json">merge_rules</a> files. Current maintainers will cast their votes of
+support. Decision criteria for approving the PR:
+* Not earlier than two business days passed before merging (ensure the majority of the contributors have seen it)
+* PR has the correct label (<cite>module: ci</cite>)
+* There are no objections from the current maintainers
+* There are at least three net <em>thumbs up</em> from current maintainers (or all maintainers vote <em>thumbs up</em> when the module has less than 3 maintainers).</p>
 </section>
 </section>
 
@@ -800,10 +458,10 @@ Guide</a>.</p>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="design.html" class="btn btn-neutral float-right" title="PyTorch Design Philosophy" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="contribution_guide.html" class="btn btn-neutral float-right" title="PyTorch Contribution Guide" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="build_ci_governance.html" class="btn btn-neutral" title="PyTorch Governance | Build + CI" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="../index.html" class="btn btn-neutral" title="PyTorch documentation" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -835,36 +493,8 @@ Guide</a>.</p>
           <div class="pytorch-right-menu" id="pytorch-right-menu">
             <div class="pytorch-side-scroll" id="pytorch-side-scroll-right">
               <ul>
-<li><a class="reference internal" href="#">PyTorch Contribution Guide</a><ul>
-<li><a class="reference internal" href="#contribution-process">Contribution Process</a></li>
-<li><a class="reference internal" href="#getting-started">Getting Started</a><ul>
-<li><a class="reference internal" href="#proposing-new-features">Proposing New Features</a></li>
-<li><a class="reference internal" href="#reporting-issues">Reporting Issues</a></li>
-<li><a class="reference internal" href="#implementing-features-or-fixing-bugs">Implementing Features or Fixing Bugs</a></li>
-<li><a class="reference internal" href="#adding-tutorials">Adding Tutorials</a></li>
-<li><a class="reference internal" href="#improving-documentation-tutorials">Improving Documentation &amp; Tutorials</a></li>
-<li><a class="reference internal" href="#participating-in-online-discussions">Participating in Online Discussions</a></li>
-<li><a class="reference internal" href="#submitting-pull-requests-to-fix-open-issues">Submitting Pull Requests to Fix Open Issues</a></li>
-<li><a class="reference internal" href="#reviewing-open-pull-requests">Reviewing Open Pull Requests</a></li>
-<li><a class="reference internal" href="#improving-code-readability">Improving Code Readability</a></li>
-<li><a class="reference internal" href="#adding-test-cases-to-make-the-codebase-more-robust">Adding Test Cases to Make the Codebase More Robust</a></li>
-<li><a class="reference internal" href="#promoting-pytorch">Promoting PyTorch</a></li>
-<li><a class="reference internal" href="#triaging-issues">Triaging Issues</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#about-open-source-development">About Open Source Development</a></li>
-<li><a class="reference internal" href="#common-mistakes-to-avoid">Common Mistakes To Avoid</a></li>
-<li><a class="reference internal" href="#frequently-asked-questions">Frequently Asked Questions</a></li>
-<li><a class="reference internal" href="#on-documentation">On Documentation</a><ul>
-<li><a class="reference internal" href="#python-docs">Python Docs</a></li>
-<li><a class="reference internal" href="#c-docs">C++ Docs</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#tutorials">Tutorials</a><ul>
-<li><a class="reference internal" href="#tutorials-build-overview">Tutorials Build Overview</a></li>
-<li><a class="reference internal" href="#contributing-a-new-tutorial">Contributing a New Tutorial</a></li>
-</ul>
-</li>
+<li><a class="reference internal" href="#">PyTorch Governance | Build + CI</a><ul>
+<li><a class="reference internal" href="#how-to-add-a-new-maintainer">How to Add a New Maintainer</a></li>
 </ul>
 </li>
 </ul>

--- a/docs/1.12/community/build_ci_governance.html
+++ b/docs/1.12/community/build_ci_governance.html
@@ -241,15 +241,6 @@
 
           
 
-<div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/build_ci_governance.html">
-    You are viewing unstable developer preview docs.
-    Click here to view docs for latest stable release.
-  </a>
-</div>
-
-
-            
             
               
             

--- a/docs/1.12/community/contribution_guide.html
+++ b/docs/1.12/community/contribution_guide.html
@@ -241,15 +241,6 @@
 
           
 
-<div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/contribution_guide.html">
-    You are viewing unstable developer preview docs.
-    Click here to view docs for latest stable release.
-  </a>
-</div>
-
-
-            
             
               
             

--- a/docs/1.12/community/design.html
+++ b/docs/1.12/community/design.html
@@ -10,14 +10,14 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Contribution Guide &mdash; PyTorch master documentation</title>
+  <title>PyTorch Design Philosophy &mdash; PyTorch master documentation</title>
   
 
   
   
   
   
-    <link rel="canonical" href="https://pytorch.org/docs/stable/community/contribution_guide.html"/>
+    <link rel="canonical" href="https://pytorch.org/docs/stable/community/design.html"/>
   
 
   
@@ -41,8 +41,8 @@
   <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
-    <link rel="next" title="PyTorch Design Philosophy" href="design.html" />
-    <link rel="prev" title="PyTorch Governance | Build + CI" href="build_ci_governance.html" />
+    <link rel="next" title="PyTorch Governance | Mechanics" href="governance.html" />
+    <link rel="prev" title="PyTorch Contribution Guide" href="contribution_guide.html" />
 
 <!--
   Search engines should not index the master version of documentation.
@@ -242,7 +242,7 @@
           
 
 <div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/contribution_guide.html">
+  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/design.html">
     You are viewing unstable developer preview docs.
     Click here to view docs for latest stable release.
   </a>
@@ -257,8 +257,8 @@
               <p class="caption" role="heading"><span class="caption-text">Community</span></p>
 <ul class="current">
 <li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Design Philosophy</a></li>
 <li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
 <li class="toctree-l1"><a class="reference internal" href="persons_of_interest.html">PyTorch Governance | Maintainers</a></li>
 </ul>
@@ -398,13 +398,13 @@
       </li>
 
         
-      <li>PyTorch Contribution Guide</li>
+      <li>PyTorch Design Philosophy</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
         
             
-            <a href="../_sources/community/contribution_guide.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
+            <a href="../_sources/community/design.rst.txt" rel="nofollow"><img src="../_static/images/view-page-source-icon.svg"></a>
           
         
       </li>
@@ -430,364 +430,152 @@
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
               
-  <section id="pytorch-contribution-guide">
-<h1>PyTorch Contribution Guide<a class="headerlink" href="#pytorch-contribution-guide" title="Permalink to this heading">¶</a></h1>
-<p>PyTorch is a GPU-accelerated Python tensor computation package for
-building deep neural networks using a on tape-based autograd systems.</p>
-<section id="contribution-process">
-<h2>Contribution Process<a class="headerlink" href="#contribution-process" title="Permalink to this heading">¶</a></h2>
-<p>The PyTorch organization is governed by <a class="reference internal" href="governance.html"><span class="doc">PyTorch
-Governance</span></a> and the technical guide to contributing
-can be found in <a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
-<p>The PyTorch development process involves a healthy amount of open
-discussions between the core development team and the community.</p>
-<p>PyTorch operates similarly to most open source projects on GitHub.
-However, if you’ve never contributed to an open source project before,
-here is the basic process.</p>
+  <section id="pytorch-design-philosophy">
+<h1>PyTorch Design Philosophy<a class="headerlink" href="#pytorch-design-philosophy" title="Permalink to this heading">¶</a></h1>
+<p>This document is designed to help contributors and module maintainers
+understand the high-level design principles that have developed over
+time in PyTorch. These are not meant to be hard-and-fast rules, but to
+serve as a guide to help trade off different concerns and to resolve
+disagreements that may come up while developing PyTorch. For more
+information on contributing, module maintainership, and how to escalate a
+disagreement to the Core Maintainers, please see <a class="reference external" href="https://pytorch.org/docs/master/community/governance.html">PyTorch
+Governance</a>.</p>
+<section id="design-principles">
+<h2>Design Principles<a class="headerlink" href="#design-principles" title="Permalink to this heading">¶</a></h2>
+<section id="principle-1-usability-over-performance">
+<h3>Principle 1: Usability over Performance<a class="headerlink" href="#principle-1-usability-over-performance" title="Permalink to this heading">¶</a></h3>
+<p>This principle may be surprising! As one Hacker News poster wrote:
+<em>PyTorch is amazing! […] Although I’m confused. How can a ML framework be
+not obsessed with speed/performance?</em> See <a class="reference external" href="https://news.ycombinator.com/item?id=28066093">Hacker News discussion on
+PyTorch</a>.</p>
+<p>Soumith’s blog post on <a class="reference external" href="https://soumith.ch/posts/2021/02/growing-opensource/?fbclid=IwAR1bvN_xZ8avGvu14ODJzS8Zp7jX1BOyfuGUf-zoRawpyL-s95Vjxf88W7s">Growing the PyTorch
+Community</a>
+goes into this in some depth, but at a high-level:</p>
 <ul class="simple">
-<li><p><strong>Figure out what you’re going to work on.</strong> The majority of open
-source contributions come from people scratching their own itches.
-However, if you don’t know what you want to work on, or are just
-looking to get more acquainted with the project, here are some tips
-for how to find appropriate tasks:</p>
-<ul>
-<li><p>Look through the <a class="reference external" href="https://github.com/pytorch/pytorch/issues/">issue
-tracker</a> and see if
-there are any issues you know how to fix. Issues that are
-confirmed by other contributors tend to be better to investigate.
-We also maintain some labels for issues that are likely to be
-good for new people, e.g., <strong>bootcamp</strong> and <strong>1hr</strong>, although
-these labels are less well maintained.</p></li>
-<li><p>Join us on <a class="reference external" href="https://dev-discuss.pytorch.org/">dev discuss</a>
-and let us know you’re interested in getting to
-know PyTorch. We’re very happy to help out researchers and
-partners get up to speed with the codebase.</p></li>
+<li><p>PyTorch’s primary goal is usability</p></li>
+<li><p>A secondary goal is to have <em>reasonable</em> performance</p></li>
 </ul>
-</li>
-<li><p><strong>Figure out the scope of your change and reach out for design
-comments on a GitHub issue if it’s large.</strong> The majority of pull
-requests are small; in that case, no need to let us know about what
-you want to do, just get cracking. But if the change is going to be
-large, it’s usually a good idea to get some design comments about it
-first by <a class="reference external" href="https://github.com/pytorch/rfcs/blob/master/README.md">submitting an RFC</a>.</p>
-<ul>
-<li><p>If you don’t know how big a change is going to be, we can help you
-figure it out! Just post about it on
-<a class="reference external" href="https://github.com/pytorch/pytorch/issues/">issues</a> or
-<a class="reference external" href="https://dev-discuss.pytorch.org/">dev discuss</a>.</p></li>
-<li><p>Some feature additions are very standardized; for example, lots of
-people add new operators or optimizers to PyTorch. Design
-discussion in these cases boils down mostly to, “Do we want this
-operator/optimizer?” Giving evidence for its utility, e.g., usage
-in peer reviewed papers, or existence in other frameworks, helps a
-bit when making this case.</p>
-<ul>
-<li><p><strong>Adding operators / algorithms from recently-released research</strong>
-is generally not accepted unless there is overwhelming evidence that
-this newly published work has ground-breaking results and will eventually
-become a standard in the field. If you are not sure where your method falls,
-open an issue first before implementing a PR.</p></li>
-</ul>
-</li>
-<li><p>Core changes and refactors can be quite difficult to coordinate
-since the pace of development on PyTorch master is quite fast.
-Definitely reach out about fundamental or cross-cutting changes;
-we can often give guidance about how to stage such changes into
-more easily reviewable pieces.</p></li>
-</ul>
-</li>
-<li><p><strong>Code it out!</strong></p>
-<ul>
-<li><p>See the <a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a> file for advice for working with PyTorch in a
-technical form.</p></li>
-</ul>
-</li>
-<li><p><strong>Open a pull request.</strong></p>
-<ul>
-<li><p>If you are not ready for the pull request to be reviewed, create a draft
-pull request first - you can later convert it to a full PR by pressing
-“Ready for review” button. You can also prepend the title of the PR with
-“[WIP]” (“work in progress”) while it’s still in draft. We will ignore
-draft PRs when doing review passes. If you are working on a complex change,
-it’s good to start things off as a draft, because you will need to spend
-time looking at CI results to see if things worked out or not.</p></li>
-<li><p>Find an appropriate reviewer for your change. We have some folks
-who regularly go through the PR queue and try to review
-everything, but if you happen to know who the maintainer for a
-given subsystem affected by your patch is, feel free to include
-them directly on the pull request. You can learn more about
-<a class="reference external" href="https://pytorch.org/docs/master/community/persons_of_interest.html">Persons of Interest</a>
-that could review your code.</p></li>
-</ul>
-</li>
-<li><p><strong>Iterate on the pull request until it’s accepted!</strong></p>
-<ul>
-<li><p>We’ll try our best to minimize the number of review round trips and
-block PRs only when there are major issues. For the most common
-issues in pull requests, take a look at <a class="reference external" href="#common-mistakes-to-avoid">Common Mistakes</a>.</p></li>
-<li><p>Once a pull request is accepted and CI is passing, there is
-nothing else you need to do; we will merge the PR for you.</p></li>
-</ul>
-</li>
-</ul>
-</section>
-<section id="getting-started">
-<h2>Getting Started<a class="headerlink" href="#getting-started" title="Permalink to this heading">¶</a></h2>
-<section id="proposing-new-features">
-<h3>Proposing New Features<a class="headerlink" href="#proposing-new-features" title="Permalink to this heading">¶</a></h3>
-<p>New feature ideas are best discussed on a specific issue. Please include
-as much information as you can, any accompanying data, and your proposed
-solution. The PyTorch team and community frequently review new issues
-and comments where they think they can help. If you feel confident in
-your solution, go ahead and implement it.</p>
-</section>
-<section id="reporting-issues">
-<h3>Reporting Issues<a class="headerlink" href="#reporting-issues" title="Permalink to this heading">¶</a></h3>
-<p>If you’ve identified an issue, first search through the <a class="reference external" href="https://github.com/pytorch/pytorch/issues">list of
-existing issues</a> on the
-repo. If you are unable to find a similar issue, then create a new one.
-Supply as much information you can to reproduce the problematic
-behavior. Also, include any additional insights like the behavior you
-expect.</p>
-</section>
-<section id="implementing-features-or-fixing-bugs">
-<h3>Implementing Features or Fixing Bugs<a class="headerlink" href="#implementing-features-or-fixing-bugs" title="Permalink to this heading">¶</a></h3>
-<p>If you want to fix a specific issue, it’s best to comment on the
-individual issue with your intent. However, we do not lock or assign
-issues except in cases where we have worked with the developer before.
-It’s best to strike up a conversation on the issue and discuss your
-proposed solution. The PyTorch team can provide guidance that saves you
-time.</p>
-<p>Issues that are labeled first-new-issue, low, or medium priority provide
-the best entrance point are great places to start.</p>
-</section>
-<section id="adding-tutorials">
-<h3>Adding Tutorials<a class="headerlink" href="#adding-tutorials" title="Permalink to this heading">¶</a></h3>
-<p>A great deal of the tutorials on <a class="reference external" href="https://pytorch.org/">pytorch.org</a>
-come from the community itself and we welcome additional contributions.
-To learn more about how to contribute a new tutorial you can learn more
-here: <a class="reference external" href="https://github.com/pytorch/tutorials/#contributing">PyTorch.org Tutorial Contribution Guide on
-Github</a></p>
-</section>
-<section id="improving-documentation-tutorials">
-<h3>Improving Documentation &amp; Tutorials<a class="headerlink" href="#improving-documentation-tutorials" title="Permalink to this heading">¶</a></h3>
-<p>We aim to produce high quality documentation and tutorials. On rare
-occasions that content includes typos or bugs. If you find something you
-can fix, send us a pull request for consideration.</p>
-<p>Take a look at the <a class="reference external" href="#on-documentation">Documentation</a> section to learn how our system
-works.</p>
-</section>
-<section id="participating-in-online-discussions">
-<h3>Participating in Online Discussions<a class="headerlink" href="#participating-in-online-discussions" title="Permalink to this heading">¶</a></h3>
-<p>You can find active discussions happening on the <a class="reference external" href="https://discuss.pytorch.org/">PyTorch Discussion
-Forums</a>  for users as well as the
-<a class="reference external" href="https://dev-discuss.pytorch.org/">PyTorch Dev Discussion Forums</a>
-for developers and maintainers.</p>
-</section>
-<section id="submitting-pull-requests-to-fix-open-issues">
-<h3>Submitting Pull Requests to Fix Open Issues<a class="headerlink" href="#submitting-pull-requests-to-fix-open-issues" title="Permalink to this heading">¶</a></h3>
-<p>You can view a list of all open issues
-<a class="reference external" href="https://github.com/pytorch/pytorch/issues">here</a>. Commenting on an
-issue is a great way to get the attention of the team. From here you can
-share your ideas and how you plan to resolve the issue.</p>
-<p>For more challenging issues, the team will provide feedback and
-direction for how to best solve the issue.</p>
-<p>If you’re not able to fix the issue yourself, commenting and sharing
-whether you can reproduce the issue can help the team
-identify problem areas.</p>
-</section>
-<section id="reviewing-open-pull-requests">
-<h3>Reviewing Open Pull Requests<a class="headerlink" href="#reviewing-open-pull-requests" title="Permalink to this heading">¶</a></h3>
-<p>We appreciate your help reviewing and commenting on pull requests. Our
-team strives to keep the number of open pull requests at a manageable
-size, we respond quickly for more information if we need it, and we
-merge PRs that we think are useful. However, due to the high level of
-interest, additional eyes on the pull requests are always appreciated.</p>
-</section>
-<section id="improving-code-readability">
-<h3>Improving Code Readability<a class="headerlink" href="#improving-code-readability" title="Permalink to this heading">¶</a></h3>
-<p>Improving code readability helps everyone. It is often better to submit a
-small number of pull requests that touch a few files versus a large pull
-request that touches many files. Starting a discussion in the PyTorch
-forum <a class="reference external" href="https://discuss.pytorch.org/">here</a> or on an issue related to
-your improvement is the best way to get started.</p>
-</section>
-<section id="adding-test-cases-to-make-the-codebase-more-robust">
-<h3>Adding Test Cases to Make the Codebase More Robust<a class="headerlink" href="#adding-test-cases-to-make-the-codebase-more-robust" title="Permalink to this heading">¶</a></h3>
-<p>Additional test coverage is appreciated.</p>
-</section>
-<section id="promoting-pytorch">
-<h3>Promoting PyTorch<a class="headerlink" href="#promoting-pytorch" title="Permalink to this heading">¶</a></h3>
-<p>Your use of PyTorch in your projects, research papers, write ups, blogs,
-or general discussions around the internet helps to raise awareness for
-PyTorch and our growing community. Please reach out to
-<a class="reference external" href="mailto:marketing&#37;&#52;&#48;pytorch&#46;org">marketing<span>&#64;</span>pytorch<span>&#46;</span>org</a>
-for marketing support.</p>
-</section>
-<section id="triaging-issues">
-<h3>Triaging Issues<a class="headerlink" href="#triaging-issues" title="Permalink to this heading">¶</a></h3>
-<p>If you feel that an issue could benefit from a particular tag or level
-of complexity, comment on the issue and share your opinion. If you
-feel an issue isn’t categorized properly, comment and let the team know.</p>
-</section>
-</section>
-<section id="about-open-source-development">
-<h2>About Open Source Development<a class="headerlink" href="#about-open-source-development" title="Permalink to this heading">¶</a></h2>
-<p>If this is your first time contributing to an open source project, some
-aspects of the development process may seem unusual to you.</p>
+<p>We believe the ability to maintain our flexibility to support
+researchers who are building on top of our abstractions remains
+critical. We can’t see what the future of what workloads will be, but we
+know we want them to be built first on PyTorch and that requires
+flexibility.</p>
+<p>In more concrete terms, we operate in a <em>usability-first</em> manner and try
+to avoid jumping to <em>restriction-first</em> regimes (for example, static shapes,
+graph-mode only) without a clear-eyed view of the tradeoffs. Often there
+is a temptation to impose strict user restrictions upfront because it
+can simplify implementation, but this comes with risks:</p>
 <ul class="simple">
-<li><p><strong>There is no way to “claim” issues.</strong> People often want to “claim”
-an issue when they decide to work on it, to ensure that there isn’t
-wasted work when someone else ends up working on it. This doesn’t
-really work too well in open source, since someone may decide to work
-on something, and end up not having time to do it. Feel free to give
-information in an advisory fashion, but at the end of the day, we
-will take running code and rough consensus to move forward quickly.</p></li>
-<li><p><strong>There is a high bar for new functionality.</strong> Unlike
-in a corporate environment, where the person who wrote code
-implicitly “owns” it and can be expected to take care of it for the
-code’s lifetime, once a pull request is merged into an open
-source project, it immediately becomes the collective responsibility
-of all maintainers on the project. When we merge code, we are saying
-that we, the maintainers, can review subsequent changes and
-make a bugfix to the code. This naturally leads to a higher standard
-of contribution.</p></li>
+<li><p>The performance may not be worth the user friction, either because
+the performance benefit is not compelling enough or it only applies to
+a relatively narrow set of subproblems.</p></li>
+<li><p>Even if the performance benefit is compelling, the restrictions can
+fragment the ecosystem into different sets of limitations that can
+quickly become incomprehensible to users.</p></li>
 </ul>
+<p>We want users to be able to seamlessly move their PyTorch code to
+different hardware and software platforms, to interoperate with
+different libraries and frameworks, and to experience the full richness
+of the PyTorch user experience, not a least common denominator subset.</p>
 </section>
-<section id="common-mistakes-to-avoid">
-<h2>Common Mistakes To Avoid<a class="headerlink" href="#common-mistakes-to-avoid" title="Permalink to this heading">¶</a></h2>
+<section id="principle-2-simple-over-easy">
+<h3>Principle 2: Simple Over Easy<a class="headerlink" href="#principle-2-simple-over-easy" title="Permalink to this heading">¶</a></h3>
+<p>Here, we borrow from <a class="reference external" href="https://peps.python.org/pep-0020/">The Zen of
+Python</a>:</p>
 <ul class="simple">
-<li><p><strong>Did you add tests?</strong> (Or if the change is hard to test, did you
-describe how you tested your change?)</p>
-<ul>
-<li><p>We have a few motivations for why we ask for tests:</p>
-<ol class="arabic simple">
-<li><p>to help us tell if we break it later</p></li>
-<li><p>to help us tell if the patch is correct in the first place
-(yes, we did review it, but as Knuth says, “beware of the
-following code, for I have not run it, merely proven it
-correct”)</p></li>
-</ol>
-</li>
-<li><p>When is it OK not to add a test? Sometimes a change can’t be
-conveniently tested, or the change is so obviously correct (and
-unlikely to be broken) that it’s OK not to test it. On the
-contrary, if a change seems likely (or is known to be likely)
-to be accidentally broken, it’s important to put in the time to
-work out a testing strategy.</p></li>
+<li><p><em>Explicit is better than implicit</em></p></li>
+<li><p><em>Simple is better than complex</em></p></li>
 </ul>
-</li>
-<li><p><strong>Is your PR too long?</strong></p>
-<ul>
-<li><p>It’s easier for us to review and merge small PRs. The difficulty of
-reviewing a PR scales nonlinearly with its size.</p></li>
-<li><p>When is it OK to submit a large PR? It helps a lot if there was a
-corresponding design discussion in an issue, with sign off from
-the people who are going to review your diff. We can also help
-give advice about how to split up a large change into individually
-shippable parts. Similarly, it helps if there is a complete
-description of the contents of the PR: it’s easier to review code
-if we know what’s inside!</p></li>
-</ul>
-</li>
-<li><p><strong>Comments for subtle things?</strong> In cases where the behavior of your code
-is nuanced, please include extra comments and documentation to allow
-us to better understand the intention of your code.</p></li>
-<li><p><strong>Did you add a hack?</strong> Sometimes, the right answer is a hack. But
-usually, we will have to discuss it.</p></li>
-<li><p><strong>Do you want to touch a very core component?</strong> To prevent
-major regressions, pull requests that touch core components receive
-extra scrutiny. Make sure you’ve discussed your changes with the team
-before undertaking major changes.</p></li>
-<li><p><strong>Want to add a new feature?</strong> If you want to add new features,
-comment your intention on the related issue. Our team tries to
-comment on and provide feedback to the community. It’s better to have
-an open discussion with the team and the rest of the community before
-building new features. This helps us stay aware of what you’re
-working on and increases the chance that it’ll be merged.</p></li>
-<li><p><strong>Did you touch code unrelated to the PR?</strong> To aid in code review,
-please only include files in your pull request that are directly
-related to your changes.</p></li>
-</ul>
-</section>
-<section id="frequently-asked-questions">
-<h2>Frequently Asked Questions<a class="headerlink" href="#frequently-asked-questions" title="Permalink to this heading">¶</a></h2>
+<p>A more concise way of describing these two goals is <a class="reference external" href="https://www.infoq.com/presentations/Simple-Made-Easy/">Simple Over
+Easy</a>. Let’s start with an example because <em>simple</em> and <em>easy</em> are
+often used interchangeably in everyday English. Consider how one may
+model <a class="reference external" href="https://pytorch.org/docs/master/tensor_attributes.html#torch.device">devices</a>
+in PyTorch:</p>
 <ul class="simple">
-<li><p><strong>How can I contribute as a reviewer?</strong> There is lots of value if
-community developers reproduce issues, try out new functionality, or
-otherwise help us identify or troubleshoot issues. Commenting on
-tasks or pull requests with your environment details is helpful and
-appreciated.</p></li>
-<li><p><strong>CI tests failed, what does it mean?</strong> Maybe your PR is based
-off a broken master? You can try to rebase your change on top
-of the latest master. You can also see the current status of
-master’s CI at <a class="reference external" href="https://hud.pytorch.org/">https://hud.pytorch.org/</a>.</p></li>
-<li><p><strong>What are the most high risk changes?</strong> Anything that touches build
-configuration is a risky area. Please avoid changing these unless
-you’ve had a discussion with the team beforehand.</p></li>
-<li><p><strong>Hey, a commit showed up on my branch, what’s up with that?</strong>
-Sometimes another community member will provide a patch or fix to
-your pull request or branch. This is often needed for getting CI tests
-to pass.</p></li>
+<li><p><strong>Simple / Explicit (to understand, debug):</strong> every tensor is associated
+with a device. The user explicitly specifies tensor device movement.
+Operations that require cross-device movement result in an error.</p></li>
+<li><p><strong>Easy / Implicit (to use):</strong> the user does not have to worry about
+devices; the system figures out the globally optimal device
+placement.</p></li>
 </ul>
+<p>In this specific case, and as a general design philosophy, PyTorch
+favors exposing simple and explicit building blocks rather than APIs
+that are easy-to-use by practitioners. The simple version is immediately
+understandable and debuggable by a new PyTorch user: you get a clear
+error if you call an operator requiring cross-device movement at the
+point in the program where the operator is actually invoked. The easy
+solution may let a new user move faster initially, but debugging such a
+system can be complex: How did the system make its determination? What
+is the API for plugging into such a system and how are objects
+represented in its IR?</p>
+<p>Some classic arguments in favor of this sort of design come from <a class="reference external" href="https://dl.acm.org/doi/book/10.5555/974938">A
+Note on Distributed
+Computation</a> (TLDR: Do not
+model resources with very different performance characteristics
+uniformly, the details will leak) and the <a class="reference external" href="http://web.mit.edu/Saltzer/www/publications/endtoend/endtoend.pdf">End-to-End
+Principle</a>
+(TLDR: building smarts into the lower-layers of the stack can prevent
+building performant features at higher layers in the stack, and often
+doesn’t work anyway). For example, we could build operator-level or
+global device movement rules, but the precise choices aren’t obvious and
+building an extensible mechanism has unavoidable complexity and latency
+costs.</p>
+<p>A caveat here is that this does not mean that higher-level “easy” APIs
+are not valuable; certainly there is a value in, for example,
+higher-levels in the stack to support efficient tensor computations
+across heterogeneous compute in a large cluster. Instead, what we mean
+is that focusing on simple lower-level building blocks helps inform the
+easy API while still maintaining a good experience when users need to
+leave the beaten path. It also allows space for innovation and the
+growth of more opinionated tools at a rate we cannot support in the
+PyTorch core library, but ultimately benefit from, as evidenced by
+our <a class="reference external" href="https://pytorch.org/ecosystem/">rich ecosystem</a>. In other
+words, not automating at the start allows us to potentially reach levels
+of good automation faster.</p>
 </section>
-<section id="on-documentation">
-<h2>On Documentation<a class="headerlink" href="#on-documentation" title="Permalink to this heading">¶</a></h2>
-<section id="python-docs">
-<h3>Python Docs<a class="headerlink" href="#python-docs" title="Permalink to this heading">¶</a></h3>
-<p>PyTorch documentation is generated from python source using
-<a class="reference external" href="https://www.sphinx-doc.org/en/master/">Sphinx</a>. Generated HTML is
-copied to the docs folder in the master branch of
-<a class="reference external" href="https://github.com/pytorch/pytorch.github.io/tree/master/docs">pytorch.github.io</a>,
-and is served via GitHub pages.</p>
+<section id="principle-3-python-first-with-best-in-class-language-interoperability">
+<h3>Principle 3: Python First with Best In Class Language Interoperability<a class="headerlink" href="#principle-3-python-first-with-best-in-class-language-interoperability" title="Permalink to this heading">¶</a></h3>
+<p>This principle began as <strong>Python First</strong>:</p>
+<blockquote>
+<div><p>PyTorch is not a Python binding into a monolithic C++ framework.
+It is built to be deeply integrated into Python. You can use it
+naturally like you would use <a class="reference external" href="https://www.numpy.org/">NumPy</a>,
+<a class="reference external" href="https://www.scipy.org/">SciPy</a>, <a class="reference external" href="(https://scikit-learn.org/">scikit-learn</a>,
+or other Python libraries. You can write your new neural network
+layers in Python itself, using your favorite libraries and use
+packages such as <a class="reference external" href="https://cython.org/">Cython</a> and
+<a class="reference external" href="http://numba.pydata.org/">Numba</a>. Our goal is to not reinvent
+the wheel where appropriate.</p>
+</div></blockquote>
+<p>One thing PyTorch has needed to deal with over the years is Python
+overhead: we first rewrote the <cite>autograd</cite> engine in C++, then the majority
+of operator definitions, then developed TorchScript and the C++
+frontend.</p>
+<p>Still, working in Python provides easily the best experience for our
+users: it is flexible, familiar, and perhaps most importantly, has a
+huge ecosystem of scientific computing libraries and extensions
+available for use. This fact motivates a few of our most recent
+contributions, which attempt to hit a Pareto optimal point close to the
+Python usability end of the curve:</p>
 <ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/docs">https://pytorch.org/docs</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/pytorch/tree/master/docs">https://github.com/pytorch/pytorch/tree/master/docs</a></p></li>
-<li><p>Served from:
-<a class="reference external" href="https://github.com/pytorch/pytorch.github.io/tree/master/docs">https://github.com/pytorch/pytorch.github.io/tree/master/doc</a></p></li>
+<li><p><a class="reference external" href="https://dev-discuss.pytorch.org/t/torchdynamo-an-experiment-in-dynamic-python-bytecode-transformation/361">TorchDynamo</a>,
+a Python frame evaluation tool capable of speeding up existing
+eager-mode PyTorch programs with minimal user intervention.</p></li>
+<li><p><a class="reference external" href="https://pytorch.org/docs/master/notes/extending.html#extending-torch">torch_function</a>
+and <a class="reference external" href="https://dev-discuss.pytorch.org/t/what-and-why-is-torch-dispatch/557">torch_dispatch</a>
+extension points, which have enabled Python-first functionality to be
+built on-top of C++ internals, such as the <a class="reference external" href="https://pytorch.org/docs/stable/fx.html">torch.fx
+tracer</a>
+and <a class="reference external" href="https://github.com/pytorch/functorch">functorch</a>
+respectively.</p></li>
 </ul>
-</section>
-<section id="c-docs">
-<h3>C++ Docs<a class="headerlink" href="#c-docs" title="Permalink to this heading">¶</a></h3>
-<p>For C++ code we use Doxygen to generate the content files. The C++ docs
-are built on a special server and the resulting files are copied to the
-<a class="reference external" href="https://github.com/pytorch/cppdocs">https://github.com/pytorch/cppdocs</a> repo, and are served from GitHub
-pages.</p>
-<ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/cppdocs">https://pytorch.org/cppdocs</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/pytorch/tree/master/docs/cpp">https://github.com/pytorch/pytorch/tree/master/docs/cpp</a></p></li>
-<li><p>Served from: <a class="reference external" href="https://github.com/pytorch/cppdocs">https://github.com/pytorch/cppdocs</a></p></li>
-</ul>
-</section>
-</section>
-<section id="tutorials">
-<h2>Tutorials<a class="headerlink" href="#tutorials" title="Permalink to this heading">¶</a></h2>
-<p>PyTorch tutorials are documents used to help understand using PyTorch to
-accomplish specific tasks or to understand more holistic concepts.
-Tutorials are built using
-<a class="reference external" href="https://sphinx-gallery.readthedocs.io/en/latest/index.html">Sphinx-Gallery</a>
-from executable python source files, or from restructured-text (rst)
-files.</p>
-<ul class="simple">
-<li><p>Site: <a class="reference external" href="https://pytorch.org/tutorials">https://pytorch.org/tutorials</a></p></li>
-<li><p>GitHub: <a class="reference external" href="https://github.com/pytorch/tutorials">https://github.com/pytorch/tutorials</a></p></li>
-</ul>
-<section id="tutorials-build-overview">
-<h3>Tutorials Build Overview<a class="headerlink" href="#tutorials-build-overview" title="Permalink to this heading">¶</a></h3>
-<p>For tutorials, <a class="reference external" href="https://github.com/pytorch/tutorials/pulls">pull
-requests</a> trigger a
-rebuild of the entire site using CircleCI to test the effects of the
-change. This build is sharded into 9 worker builds and takes around 40
-minutes total. At the same time, we do a Netlify build using <em>make
-html-noplot</em>, which builds the site without rendering the notebook
-output into pages for quick review.</p>
-<p>After a PR is accepted, the site is rebuilt and deployed using GitHub
-Actions.</p>
-</section>
-<section id="contributing-a-new-tutorial">
-<h3>Contributing a New Tutorial<a class="headerlink" href="#contributing-a-new-tutorial" title="Permalink to this heading">¶</a></h3>
-<p>See <a class="reference external" href="https://github.com/pytorch/tutorials/#contributing">PyTorch.org Tutorial Contribution
-Guide</a>.</p>
+<p>These design principles are not hard-and-fast rules, but hard won
+choices and anchor how we built PyTorch to be the debuggable, hackable
+and flexible framework it is today. As we have more contributors and
+maintainers, we look forward to applying these core principles with you
+across our libraries and ecosystem. We are also open to evolving them as
+we learn new things and the AI space evolves, as we know it will.</p>
 </section>
 </section>
 </section>
@@ -800,10 +588,10 @@ Guide</a>.</p>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="design.html" class="btn btn-neutral float-right" title="PyTorch Design Philosophy" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="governance.html" class="btn btn-neutral float-right" title="PyTorch Governance | Mechanics" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="build_ci_governance.html" class="btn btn-neutral" title="PyTorch Governance | Build + CI" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="contribution_guide.html" class="btn btn-neutral" title="PyTorch Contribution Guide" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -835,34 +623,11 @@ Guide</a>.</p>
           <div class="pytorch-right-menu" id="pytorch-right-menu">
             <div class="pytorch-side-scroll" id="pytorch-side-scroll-right">
               <ul>
-<li><a class="reference internal" href="#">PyTorch Contribution Guide</a><ul>
-<li><a class="reference internal" href="#contribution-process">Contribution Process</a></li>
-<li><a class="reference internal" href="#getting-started">Getting Started</a><ul>
-<li><a class="reference internal" href="#proposing-new-features">Proposing New Features</a></li>
-<li><a class="reference internal" href="#reporting-issues">Reporting Issues</a></li>
-<li><a class="reference internal" href="#implementing-features-or-fixing-bugs">Implementing Features or Fixing Bugs</a></li>
-<li><a class="reference internal" href="#adding-tutorials">Adding Tutorials</a></li>
-<li><a class="reference internal" href="#improving-documentation-tutorials">Improving Documentation &amp; Tutorials</a></li>
-<li><a class="reference internal" href="#participating-in-online-discussions">Participating in Online Discussions</a></li>
-<li><a class="reference internal" href="#submitting-pull-requests-to-fix-open-issues">Submitting Pull Requests to Fix Open Issues</a></li>
-<li><a class="reference internal" href="#reviewing-open-pull-requests">Reviewing Open Pull Requests</a></li>
-<li><a class="reference internal" href="#improving-code-readability">Improving Code Readability</a></li>
-<li><a class="reference internal" href="#adding-test-cases-to-make-the-codebase-more-robust">Adding Test Cases to Make the Codebase More Robust</a></li>
-<li><a class="reference internal" href="#promoting-pytorch">Promoting PyTorch</a></li>
-<li><a class="reference internal" href="#triaging-issues">Triaging Issues</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#about-open-source-development">About Open Source Development</a></li>
-<li><a class="reference internal" href="#common-mistakes-to-avoid">Common Mistakes To Avoid</a></li>
-<li><a class="reference internal" href="#frequently-asked-questions">Frequently Asked Questions</a></li>
-<li><a class="reference internal" href="#on-documentation">On Documentation</a><ul>
-<li><a class="reference internal" href="#python-docs">Python Docs</a></li>
-<li><a class="reference internal" href="#c-docs">C++ Docs</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#tutorials">Tutorials</a><ul>
-<li><a class="reference internal" href="#tutorials-build-overview">Tutorials Build Overview</a></li>
-<li><a class="reference internal" href="#contributing-a-new-tutorial">Contributing a New Tutorial</a></li>
+<li><a class="reference internal" href="#">PyTorch Design Philosophy</a><ul>
+<li><a class="reference internal" href="#design-principles">Design Principles</a><ul>
+<li><a class="reference internal" href="#principle-1-usability-over-performance">Principle 1: Usability over Performance</a></li>
+<li><a class="reference internal" href="#principle-2-simple-over-easy">Principle 2: Simple Over Easy</a></li>
+<li><a class="reference internal" href="#principle-3-python-first-with-best-in-class-language-interoperability">Principle 3: Python First with Best In Class Language Interoperability</a></li>
 </ul>
 </li>
 </ul>

--- a/docs/1.12/community/design.html
+++ b/docs/1.12/community/design.html
@@ -241,15 +241,6 @@
 
           
 
-<div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/design.html">
-    You are viewing unstable developer preview docs.
-    Click here to view docs for latest stable release.
-  </a>
-</div>
-
-
-            
             
               
             

--- a/docs/1.12/community/governance.html
+++ b/docs/1.12/community/governance.html
@@ -6,10 +6,11 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Governance &mdash; PyTorch 1.12 documentation</title>
+  <title>PyTorch Governance | Mechanics &mdash; PyTorch master documentation</title>
   
 
   
@@ -29,17 +30,25 @@
 
   <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <link rel="stylesheet" href="../_static/copybutton.css" type="text/css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" type="text/css" />
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/panels-main.c949a650a448cc0ae9fd3441c0e17fb0.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/panels-variables.06eb56fa6e07937060861dad626602ad.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/sphinx-dropdown.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/panels-bootstrap.min.css" type="text/css" />
   <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
-    <link rel="next" title="PyTorch Governance | Persons of Interest" href="persons_of_interest.html" />
-    <link rel="prev" title="PyTorch Contribution Guide" href="contribution_guide.html" />
+    <link rel="next" title="PyTorch Governance | Maintainers" href="persons_of_interest.html" />
+    <link rel="prev" title="PyTorch Design Philosophy" href="design.html" />
+
+<!--
+  Search engines should not index the master version of documentation.
+  Stable documentation are built without release == 'master'.
+-->
+<meta name="robots" content="noindex">
 
 
   <!-- Google Analytics -->
@@ -212,7 +221,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.12 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>master (1.13.0a0+gitca3b2bf ) &#x25BC</a>
     </div>
     
 
@@ -232,13 +241,28 @@
 
           
 
+<div>
+  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/governance.html">
+    You are viewing unstable developer preview docs.
+    Click here to view docs for latest stable release.
+  </a>
+</div>
+
 
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
+              <p class="caption" role="heading"><span class="caption-text">Community</span></p>
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="persons_of_interest.html">PyTorch Governance | Maintainers</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">Developer Notes</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">CUDA Automatic Mixed Precision examples</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
@@ -259,13 +283,13 @@
 <li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
+<p class="caption" role="heading"><span class="caption-text">Language Bindings</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../deploy.html">torch::deploy</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
+<p class="caption" role="heading"><span class="caption-text">Python API</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
@@ -304,6 +328,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../masked.html">torch.masked</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../nested.html">torch.nested</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
@@ -313,6 +338,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../jit_utils.html">torch.utils.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
@@ -322,7 +348,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../config_mod.html">torch.__config__</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+<p class="caption" role="heading"><span class="caption-text">Libraries</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio/stable">torchaudio</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/data">TorchData</a></li>
@@ -331,12 +357,6 @@
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text/stable">torchtext</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/vision/stable">torchvision</a></li>
 <li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul class="current">
-<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
 </ul>
 
             
@@ -378,7 +398,7 @@
       </li>
 
         
-      <li>PyTorch Governance</li>
+      <li>PyTorch Governance | Mechanics</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
@@ -410,121 +430,279 @@
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
               
-  <div class="section" id="pytorch-governance">
-<h1>PyTorch Governance<a class="headerlink" href="#pytorch-governance" title="Permalink to this headline">¶</a></h1>
-<div class="section" id="governance-philosophy-and-guiding-tenets">
-<h2>Governance Philosophy and Guiding Tenets<a class="headerlink" href="#governance-philosophy-and-guiding-tenets" title="Permalink to this headline">¶</a></h2>
-<p>PyTorch adopts a governance structure with a small set of maintainers
-driving the overall project direction with a strong bias towards
-PyTorch’s design philosophy where design and code contributions are
-valued. Beyond the core maintainers, there is also a slightly broader
-set of core developers that have the ability to directly merge pull
-requests and own various parts of the core code base.</p>
-<p>Beyond the maintainers and core devs, the community is encouraged to
-contribute, file issues, make proposals, review pull requests and be
-present in the community. Given contributions and willingness to
-invest, anyone can be provided write access or ownership of parts of
-the codebase.</p>
-<p>Based on this governance structure, the project has the following core
-operating tenets by which decisions are made and overall culture is
-derived:</p>
+  <section id="pytorch-governance-mechanics">
+<h1>PyTorch Governance | Mechanics<a class="headerlink" href="#pytorch-governance-mechanics" title="Permalink to this heading">¶</a></h1>
+<section id="summary">
+<h2>Summary<a class="headerlink" href="#summary" title="Permalink to this heading">¶</a></h2>
+<p>PyTorch adopts a technical governance structure that is hierarchical.</p>
+<ul class="simple">
+<li><p>A community of <strong>contributors</strong> who file issues, make pull requests,
+and contribute to the project.</p></li>
+<li><p>A small set of <strong>module maintainers</strong> drive each module of the PyTorch
+project.</p></li>
+<li><p>They are overseen by <strong>core maintainers</strong>, who drive the
+overall project direction.</p></li>
+<li><p>The core maintainers have a <strong>lead core maintainer</strong>
+who is the catch-all decision maker.</p></li>
+</ul>
+<p>All maintainers are expected to have a strong bias towards
+PyTorch’s design philosophy.</p>
+<p>Beyond the maintainers, the community is encouraged to contribute,
+file issues, make proposals, review pull requests and be present
+in the community. Given contributions and willingness to invest,
+anyone can be accepted as a maintainer and provided write access
+or ownership of parts of the codebase.</p>
+<p>Technical governance is strictly separated from business governance.
+Separating technical from business governance ensures that there is
+no way for any person or company to “buy their way into” the
+technical guidance of the project. Additionally, membership in
+the technical governance process is for <strong>individuals</strong>, not companies.
+That is, there are no seats reserved for specific companies, and
+membership is associated with the person rather than the company
+employing that person.</p>
+</section>
+<section id="module-maintainers">
+<h2>Module Maintainers<a class="headerlink" href="#module-maintainers" title="Permalink to this heading">¶</a></h2>
+<p>Modules are defined as GitHub repositories within the PyTorch org,
+or as directories within the core repository
+<a class="reference external" href="https://github.com/pytorch/pytorch">pytorch/pytorch</a>.
+Each module will have its own maintainer group. Maintainer
+groups are responsible for reviewing and approving commits,
+improving design, and changing the scope of the module.
+Each maintainer group may adopt its own rules and procedures
+for making decisions (majority vote being default). Module
+maintainers have the right to dispute decisions made by other
+module maintainers – especially if it affects them. When
+disputes are made, the module maintainer group should
+provide a reasonable and public explanation of the dispute,
+the relevant arguments, and the resolution. In the exceptional
+cases where module maintainers cannot come to a conclusion
+themselves, they will escalate to core maintainers for review.
+The escalations are resolved by the core maintainers in
+accordance with their rules and procedures.</p>
+<p>Each maintainer group should publish publicly available
+communication for their module (a vision, rough roadmap,
+design docs, any disputes and dispute resolutions) so that
+contributors and other interested parties understand the
+future direction of the project and can participate in discussion.</p>
+<p>Responsibilities of the maintainer includes:
+* Triaging high priority issues of the module
+* Triaging and reviewing and landing high priority pull requests of the module
+* Supporting public documentation related to the module
+* Running public developer meetings</p>
+</section>
+<section id="core-maintainers">
+<h2>Core Maintainers<a class="headerlink" href="#core-maintainers" title="Permalink to this heading">¶</a></h2>
+<p>The core maintainers are expected to have a deep understanding
+of the PyTorch code base and design philosophies. Their responsibilities
+include:</p>
+<ul class="simple">
+<li><p>Articulating a cohesive long-term vision for the project</p></li>
+<li><p>Negotiating and resolving contentious issues in ways
+acceptable to all parties involved</p></li>
+<li><p>Receiving broad requests for changes from stakeholders of
+PyTorch and evaluating / accepting them (small module-level
+requests are handled by module maintainers)</p></li>
+</ul>
+<p>The core maintainers as a group have the power to veto any
+decision made at a Module maintainer level. The core
+maintainers have power to resolve disputes as they see fit.
+The core maintainers should publicly articulate their
+decision-making, and give a clear reasoning for their
+decisions, vetoes and dispute resolution.</p>
+<p>The core maintainers are admins of the PyTorch GitHub Org
+and are listed in <a class="reference external" href="https://pytorch.org/docs/stable/community/persons_of_interest.html">Maintainers</a>.</p>
+</section>
+<section id="lead-core-maintainer-bdfl">
+<h2>Lead Core Maintainer (BDFL)<a class="headerlink" href="#lead-core-maintainer-bdfl" title="Permalink to this heading">¶</a></h2>
+<p>There may be decisions in which the core maintainers cannot
+come to a consensus. To make such difficult decisions, the
+core maintainers have an assigned and publicly declared Lead
+Core Maintainer amongst them, also commonly known in open-source
+governance models as a BDFL.</p>
+<p>The Lead Core Maintainer should publicly articulate their
+decision-making, and give a clear reasoning for their
+decisions. The Lead Core Maintainer is also responsible for
+confirming or removing core maintainers.</p>
+</section>
+<section id="nominating-confirming-and-removing-maintainers">
+<h2>Nominating, Confirming and Removing Maintainers<a class="headerlink" href="#nominating-confirming-and-removing-maintainers" title="Permalink to this heading">¶</a></h2>
+<section id="the-principles">
+<h3>The Principles<a class="headerlink" href="#the-principles" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Membership in module maintainer groups is given to <strong>individuals</strong>
+on <strong>merit basis</strong> after they demonstrated strong expertise of the
+component through contributions, reviews and discussions and are
+aligned with how the component fits in overall PyTorch direction.</p></li>
+<li><p>For membership in the maintainer group the individual has to
+demonstrate strong and continued alignment with the overall
+PyTorch principles.</p></li>
+<li><p>No term limits for module maintainers or core maintainers</p></li>
+<li><p>Light criteria of moving module maintenance to ‘emeritus’
+status if they don’t actively participate over long periods
+of time. Each module maintainer group may define the inactive
+period that’s appropriate for that module.</p></li>
+<li><p>The membership is for an individual, not a company.</p></li>
+</ul>
+</section>
+<section id="the-process-for-nomination">
+<h3>The Process for Nomination<a class="headerlink" href="#the-process-for-nomination" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Each module has its own process. Please contact module maintainers for more information.
+However, if there is no process identified, you can file a request to the core maintainers
+by submitting [this form](<a class="reference external" href="https://forms.gle/xNeu1byGMZVHcA2q7">https://forms.gle/xNeu1byGMZVHcA2q7</a>). Core maintainers are
+meeting every three months.</p></li>
+<li><p>If you are submitting a request to the core maintainers, the information in your request
+must include the following items:</p>
+<ul>
+<li><p>The nominees depth and breadth of code, review and design
+contributions on the module</p></li>
+<li><p>Testimonials (positive and negative) of the nominee’s interactions
+with the maintainers, users, and the community</p></li>
+<li><p>General testimonials of support from the maintainers</p></li>
+</ul>
+</li>
+<li><p>The core maintainers then evaluate all information and make
+a final decision to Confirm or Decline the nomination. The
+decision of the core maintainers has to be articulated well
+and would be public.</p></li>
+</ul>
+</section>
+<section id="the-process-for-removal">
+<h3>The Process for Removal<a class="headerlink" href="#the-process-for-removal" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Similar to the process for nomination, anyone in the community
+can nominate a person to be removed from a Module maintainer
+position or a Core maintainer position.</p></li>
+<li><p>A person can also self-nominate to be removed</p></li>
+<li><p>The core maintainers (excluding persons with conflict of
+interest) will request or put together more information around
+the following:</p>
+<ul>
+<li><p>Their activity (or lack of) on the project</p></li>
+<li><p>Their changing thinking of the space, which results in
+conflict with the overall direction of the project</p></li>
+<li><p>Other information that makes them unfit to be a maintainer,
+such as Code of Conduct issues, their activity outside the
+scope of the project that conflicts with the project’s values</p></li>
+<li><p><strong>Conflicts of interest</strong>: filial or romantic relationships</p></li>
+</ul>
+</li>
+<li><p>The core maintainers then evaluate all information and make
+a final decision to Confirm or Decline the removal. The decision
+of the core maintainers has to be articulated well and would be
+public.</p></li>
+</ul>
+</section>
+<section id="nominating-core-maintainers">
+<h3>Nominating Core Maintainers<a class="headerlink" href="#nominating-core-maintainers" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Any core or module maintainer can nominate someone to become a
+core maintainer</p></li>
+<li><p>The lead maintainer (BDFL) is responsible for evaluating the
+nomination.</p></li>
+<li><p>The lead maintainer requests or puts together more information
+around the strength of the candidate to be a core maintainer:</p>
+<ul>
+<li><p>Letters of support from other core and module maintainers</p></li>
+<li><p>General letters of support from stakeholders within the PyTorch
+community</p></li>
+<li><p>Any new relevant information that is befitting for the candidacy</p></li>
+</ul>
+</li>
+<li><p>The lead maintainer evaluates all information and makes a final
+decision to Confirm or Decline the nomination, with a clear public
+articulation of their reasoning behind the decision.</p></li>
+</ul>
+</section>
+<section id="removing-the-lead-core-maintainer-and-nominating-a-new-lead-core-maintainer">
+<h3>Removing the Lead Core Maintainer and Nominating a New Lead Core Maintainer<a class="headerlink" href="#removing-the-lead-core-maintainer-and-nominating-a-new-lead-core-maintainer" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>A super-majority of core maintainers (75%) can choose to
+remove the Lead Core Maintainer</p></li>
+<li><p>After a removal of the Lead Core Maintainer or in unforeseen
+circumstances (such as permanent unavailability of the Lead Core
+Maintainer), the core maintainers follow a Ranked-Choice voting
+method to elect a new Lead Core Maintainer.</p></li>
+</ul>
+</section>
+</section>
+<section id="add-remove-and-re-scope-modules-and-projects">
+<h2>Add, Remove, and Re-Scope Modules and Projects<a class="headerlink" href="#add-remove-and-re-scope-modules-and-projects" title="Permalink to this heading">¶</a></h2>
+<p>The core maintainers together are responsible for taking
+decisions on adding, removing and re-scoping new modules
+in the PyTorch org, either as new repositories in the
+PyTorch GitHub org, or as folders in the
+<a class="reference external" href="https://github.com/pytorch/pytorch">pytorch/pytorch</a>
+repository.</p>
+<p>They invite proposals from members in the community
+(including themselves) for such changes.
+The proposals are open-ended, but should have some basic
+ground-work to make a convincing case to make change. The
+following is an example approach to this process:</p>
 <ol class="arabic simple">
-<li><p><strong>Code contributions</strong> matter much more than corporate sponsorship
-and independent developers are highly valued.</p></li>
-<li><p><strong>Project influence</strong> is gained through contributions (whether PRs,
-forum answers, code reviews or otherwise)</p></li>
+<li><p>Interview researchers / stakeholders, talk to community, gather issues;</p></li>
+<li><p>Read papers, attend conferences, build example pipelines based on experience;</p></li>
+<li><p>Create a state of the world - make sure this change is necessary,
+for example adding a new project or module is worth the maintenance
+cost; or removing a project or module will not remove too much value
+from PyTorch;</p></li>
+<li><p>Create a proposal; the proposal covers the maintainership, development
+and community plan once the proposal is approved.</p></li>
 </ol>
-</div>
-<div class="section" id="key-people-and-their-functions">
-<h2>Key people and their functions<a class="headerlink" href="#key-people-and-their-functions" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="project-maintainers">
-<h3>Project Maintainers<a class="headerlink" href="#project-maintainers" title="Permalink to this headline">¶</a></h3>
-<p>Project maintainers provide leadership and direction for the PyTorch
-project. Specifics include:</p>
-<ul class="simple">
-<li><p>Articulate a cohesive long-term vision for the project</p></li>
-<li><p>Possess a deep understanding of the PyTorch code base</p></li>
-<li><p>Negotiate and resolve contentious issues in ways acceptable to all
-parties involved</p></li>
-</ul>
-<p>PyTorch Maintainers:</p>
-<ul class="simple">
-<li><p>Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
-<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
-<li><p>Greg Chanan (<a class="reference external" href="https://github.com/gchanan">gchanan</a>)</p></li>
-<li><p>Dmytro Dzhulgakov (<a class="reference external" href="https://github.com/dzhulgakov">dzhulgakov</a>)</p></li>
-<li><p>(sunsetting) Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
-</ul>
-</div>
-<div class="section" id="core-developers">
-<h3>Core Developers<a class="headerlink" href="#core-developers" title="Permalink to this headline">¶</a></h3>
-<p>The PyTorch project is developed by a team of core developers. You can
-find the list of core developers at <a class="reference internal" href="persons_of_interest.html"><span class="doc">PyTorch Governance | Persons of
-Interest</span></a>.</p>
-<p>While membership is determined by presence in the “PyTorch core” team in
-the “PyTorch”
-<a class="reference external" href="https://github.com/orgs/pytorch/people">organization</a> on
-GitHub, contribution takes many forms:</p>
-<ul class="simple">
-<li><p>committing changes to the repository;</p></li>
-<li><p>reviewing pull requests by others;</p></li>
-<li><p>triaging bug reports on the issue tracker;</p></li>
-<li><p>discussing topics on official PyTorch communication channels.</p></li>
-</ul>
-</div>
-<div class="section" id="moderators">
-<h3>Moderators<a class="headerlink" href="#moderators" title="Permalink to this headline">¶</a></h3>
-<p>There is a group of people, some of which are not core developers,
-responsible for ensuring that discussions on official communication
-channels adhere to the Code of Conduct. They take action in view of
-violations and help to support a healthy community. You can find the
-list of moderators <a class="reference external" href="https://discuss.pytorch.org/about">here</a>.</p>
-</div>
-</div>
-<div class="section" id="decision-making">
-<h2>Decision Making<a class="headerlink" href="#decision-making" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="uncontroversial-changes">
-<h3>Uncontroversial Changes<a class="headerlink" href="#uncontroversial-changes" title="Permalink to this headline">¶</a></h3>
-<p>Primary work happens through bug tracker issues and pull requests on
-GitHub. Core developers should avoid pushing their changes directly to
+<p>The core maintainers take final decisions on the proposal, articulating
+the reasoning behind the decision publicly.</p>
+</section>
+<section id="decision-making">
+<h2>Decision Making<a class="headerlink" href="#decision-making" title="Permalink to this heading">¶</a></h2>
+<section id="uncontroversial-changes">
+<h3>Uncontroversial Changes<a class="headerlink" href="#uncontroversial-changes" title="Permalink to this heading">¶</a></h3>
+<p>Primary work happens through issues and pull requests on
+GitHub. Maintainers should avoid pushing their changes directly to
 the PyTorch repository, instead relying on pull requests. Approving a
-pull request by a core developer allows it to be merged without further
-process. Core Developers and Project Maintainers ultimately approve
-these changes.</p>
-<p>Notifying relevant experts about a bug tracker issue or a pull request
+pull request by a core or module maintainer allows it to be merged
+without further process. Core and module maintainers, as listed on
+the <a class="reference external" href="https://pytorch.org/docs/stable/community/persons_of_interest.html">Maintainers</a>
+page and within <a class="reference external" href="https://github.com/pytorch/pytorch/blob/master/CODEOWNERS">CODEOWNERS</a>
+ultimately approve these changes.</p>
+<p>Notifying relevant experts about an issue or a pull request
 is important. Reviews from experts in the given interest area are
 strongly preferred, especially on pull request approvals. Failure to do
 so might end up with the change being reverted by the relevant expert.</p>
-</div>
-<div class="section" id="controversial-decision-process">
-<h3>Controversial decision process<a class="headerlink" href="#controversial-decision-process" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="controversial-decision-process">
+<h3>Controversial Decision Process<a class="headerlink" href="#controversial-decision-process" title="Permalink to this heading">¶</a></h3>
 <p>Substantial changes in a given interest area require a GitHub issue to
 be opened for discussion. This includes:</p>
 <ul class="simple">
-<li><p>Any semantic or syntactic change to the framework.</p></li>
-<li><p>Backwards-incompatible changes to the Python or Cpp API.</p></li>
-<li><p>Additions to the core framework, including substantial new
+<li><p>Any semantic or syntactic change to the PyTorch framework or library.</p></li>
+<li><p>Backwards-incompatible changes to the Python or C++ API.</p></li>
+<li><p>Additions to the core framework or library, including substantial new
 functionality within an existing library.</p></li>
-<li><p>Removing core features</p></li>
+<li><p>Removal of core features or platform support</p></li>
 </ul>
-<p>Project Maintainers ultimately approve these changes.</p>
-</div>
-</div>
-<div class="section" id="faq">
-<h2>FAQ<a class="headerlink" href="#faq" title="Permalink to this headline">¶</a></h2>
+<p>Core and module maintainers ultimately approve these changes.</p>
+</section>
+</section>
+<section id="faq">
+<h2>FAQ<a class="headerlink" href="#faq" title="Permalink to this heading">¶</a></h2>
 <p><strong>Q: What if I would like to own (or partly own) a part of the project
-such as a domain api (i.e. Torch Vision)?</strong> This is absolutely possible.
+such as a feature area or domain library, for example</strong> <a class="reference external" href="https://github.com/pytorch/pytorch/tree/master/torch/linalg">Linear Algebra</a>
+<strong>or</strong> <a class="reference external" href="https://github.com/pytorch/vision">Torch Vision</a> <strong>?</strong>
+This is absolutely possible.
 The first step is to start contributing to the existing project area and
-contributing to its health and success. In addition to this, you can
+supporting its health and success. In addition to this, you can
 make a proposal through a GitHub issue for new functionality or changes
 to improve the project area.</p>
 <p><strong>Q: What if I am a company looking to use PyTorch internally for
 development, can I be granted or purchase a board seat to drive the
 project direction?</strong> No, the PyTorch project is strictly driven by the
-maintainer-driven project philosophy and does not have a board or
-vehicle to take financial contributions relating to gaining influence
-over technical direction.</p>
+a maintainer project philosophy and clearly separates technical
+governance from business governance. However, if you want to be
+involved in sponsorship and support, you can become involved in the
+PyTorch Foundation (PTF) and sponsorship through this. You can also
+have individual engineers look to become maintainers, but this is
+not guaranteed and is merit-based.</p>
 <p><strong>Q: Does the PyTorch project support grants or ways to support
 independent developers using or contributing to the project?</strong> No, not
 at this point. We are however looking at ways to better support the
@@ -544,14 +722,14 @@ infrastructure that can only be triggered by Facebook employees. We are
 however looking at ways to expand the committer base to individuals
 outside of Facebook and will provide an update when the tooling exists
 to allow this.</p>
-<p><strong>Q: What if i would like to deliver a PyTorch tutorial at a conference
+<p><strong>Q: What if I would like to deliver a PyTorch tutorial at a conference
 or otherwise? Do I need to be ‘officially’ a committer to do this?</strong> No,
 we encourage community members to showcase their work wherever and
 whenever they can. Please reach out to
-<a class="reference external" href="http://mailto:pytorch-marketing&#64;fb.com/">pytorch-marketing&#64;fb.com</a>
+<a class="reference external" href="mailto:marketing&#37;&#52;&#48;pytorch&#46;org">marketing<span>&#64;</span>pytorch<span>&#46;</span>org</a>
 for marketing support.</p>
-</div>
-</div>
+</section>
+</section>
 
 
              </article>
@@ -561,10 +739,10 @@ for marketing support.</p>
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
-        <a href="persons_of_interest.html" class="btn btn-neutral float-right" title="PyTorch Governance | Persons of Interest" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
+        <a href="persons_of_interest.html" class="btn btn-neutral float-right" title="PyTorch Governance | Maintainers" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
       
       
-        <a href="contribution_guide.html" class="btn btn-neutral" title="PyTorch Contribution Guide" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+        <a href="design.html" class="btn btn-neutral" title="PyTorch Design Philosophy" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -596,17 +774,23 @@ for marketing support.</p>
           <div class="pytorch-right-menu" id="pytorch-right-menu">
             <div class="pytorch-side-scroll" id="pytorch-side-scroll-right">
               <ul>
-<li><a class="reference internal" href="#">PyTorch Governance</a><ul>
-<li><a class="reference internal" href="#governance-philosophy-and-guiding-tenets">Governance Philosophy and Guiding Tenets</a></li>
-<li><a class="reference internal" href="#key-people-and-their-functions">Key people and their functions</a><ul>
-<li><a class="reference internal" href="#project-maintainers">Project Maintainers</a></li>
-<li><a class="reference internal" href="#core-developers">Core Developers</a></li>
-<li><a class="reference internal" href="#moderators">Moderators</a></li>
+<li><a class="reference internal" href="#">PyTorch Governance | Mechanics</a><ul>
+<li><a class="reference internal" href="#summary">Summary</a></li>
+<li><a class="reference internal" href="#module-maintainers">Module Maintainers</a></li>
+<li><a class="reference internal" href="#core-maintainers">Core Maintainers</a></li>
+<li><a class="reference internal" href="#lead-core-maintainer-bdfl">Lead Core Maintainer (BDFL)</a></li>
+<li><a class="reference internal" href="#nominating-confirming-and-removing-maintainers">Nominating, Confirming and Removing Maintainers</a><ul>
+<li><a class="reference internal" href="#the-principles">The Principles</a></li>
+<li><a class="reference internal" href="#the-process-for-nomination">The Process for Nomination</a></li>
+<li><a class="reference internal" href="#the-process-for-removal">The Process for Removal</a></li>
+<li><a class="reference internal" href="#nominating-core-maintainers">Nominating Core Maintainers</a></li>
+<li><a class="reference internal" href="#removing-the-lead-core-maintainer-and-nominating-a-new-lead-core-maintainer">Removing the Lead Core Maintainer and Nominating a New Lead Core Maintainer</a></li>
 </ul>
 </li>
+<li><a class="reference internal" href="#add-remove-and-re-scope-modules-and-projects">Add, Remove, and Re-Scope Modules and Projects</a></li>
 <li><a class="reference internal" href="#decision-making">Decision Making</a><ul>
 <li><a class="reference internal" href="#uncontroversial-changes">Uncontroversial Changes</a></li>
-<li><a class="reference internal" href="#controversial-decision-process">Controversial decision process</a></li>
+<li><a class="reference internal" href="#controversial-decision-process">Controversial Decision Process</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#faq">FAQ</a></li>
@@ -627,8 +811,10 @@ for marketing support.</p>
 
      
        <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
+         <script data-url_root="../" id="documentation_options" src="../_static/documentation_options.js"></script>
          <script src="../_static/jquery.js"></script>
          <script src="../_static/underscore.js"></script>
+         <script src="../_static/_sphinx_javascript_frameworks_compat.js"></script>
          <script src="../_static/doctools.js"></script>
          <script src="../_static/clipboard.min.js"></script>
          <script src="../_static/copybutton.js"></script>
@@ -648,7 +834,7 @@ for marketing support.</p>
   </script>
  
 <script script type="text/javascript">
-  var collapsedSections = ['Notes', 'Language Bindings', 'Libraries', 'Community'];
+  var collapsedSections = ['Developer Notes', 'Language Bindings', 'Libraries', 'Community'];
 </script>
 
 <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>

--- a/docs/1.12/community/governance.html
+++ b/docs/1.12/community/governance.html
@@ -241,15 +241,6 @@
 
           
 
-<div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/governance.html">
-    You are viewing unstable developer preview docs.
-    Click here to view docs for latest stable release.
-  </a>
-</div>
-
-
-            
             
               
             

--- a/docs/1.12/community/persons_of_interest.html
+++ b/docs/1.12/community/persons_of_interest.html
@@ -241,15 +241,6 @@
 
           
 
-<div>
-  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/persons_of_interest.html">
-    You are viewing unstable developer preview docs.
-    Click here to view docs for latest stable release.
-  </a>
-</div>
-
-
-            
             
               
             

--- a/docs/1.12/community/persons_of_interest.html
+++ b/docs/1.12/community/persons_of_interest.html
@@ -6,10 +6,11 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+  <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>PyTorch Governance | Persons of Interest &mdash; PyTorch 1.12 documentation</title>
+  <title>PyTorch Governance | Maintainers &mdash; PyTorch master documentation</title>
   
 
   
@@ -29,16 +30,25 @@
 
   <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <!-- <link rel="stylesheet" href="../_static/pygments.css" type="text/css" /> -->
+  <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <link rel="stylesheet" href="../_static/copybutton.css" type="text/css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-beta/dist/katex.min.css" type="text/css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" type="text/css" />
   <link rel="stylesheet" href="../_static/katex-math.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/panels-main.c949a650a448cc0ae9fd3441c0e17fb0.css" type="text/css" />
-  <link rel="stylesheet" href="../_static/panels-variables.06eb56fa6e07937060861dad626602ad.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/sphinx-dropdown.css" type="text/css" />
+  <link rel="stylesheet" href="../_static/panels-bootstrap.min.css" type="text/css" />
   <link rel="stylesheet" href="../_static/css/jit.css" type="text/css" />
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
-    <link rel="prev" title="PyTorch Governance" href="governance.html" />
+    <link rel="next" title="CUDA Automatic Mixed Precision examples" href="../notes/amp_examples.html" />
+    <link rel="prev" title="PyTorch Governance | Mechanics" href="governance.html" />
+
+<!--
+  Search engines should not index the master version of documentation.
+  Stable documentation are built without release == 'master'.
+-->
+<meta name="robots" content="noindex">
 
 
   <!-- Google Analytics -->
@@ -211,7 +221,7 @@
           <div class="pytorch-left-menu-search">
             
     <div class="version">
-      <a href='https://pytorch.org/docs/versions.html'>1.12 &#x25BC</a>
+      <a href='https://pytorch.org/docs/versions.html'>master (1.13.0a0+gitca3b2bf ) &#x25BC</a>
     </div>
     
 
@@ -231,13 +241,28 @@
 
           
 
+<div>
+  <a style="color:#F05732" href="https://pytorch.org/docs/stable/community/persons_of_interest.html">
+    You are viewing unstable developer preview docs.
+    Click here to view docs for latest stable release.
+  </a>
+</div>
+
 
             
             
               
             
             
-              <p class="caption"><span class="caption-text">Notes</span></p>
+              <p class="caption" role="heading"><span class="caption-text">Community</span></p>
+<ul class="current">
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
+</ul>
+<p class="caption" role="heading"><span class="caption-text">Developer Notes</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../notes/amp_examples.html">CUDA Automatic Mixed Precision examples</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/autograd.html">Autograd mechanics</a></li>
@@ -258,13 +283,13 @@
 <li class="toctree-l1"><a class="reference internal" href="../notes/serialization.html">Serialization semantics</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../notes/windows.html">Windows FAQ</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Language Bindings</span></p>
+<p class="caption" role="heading"><span class="caption-text">Language Bindings</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../cpp_index.html">C++</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/javadoc/">Javadoc</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../deploy.html">torch::deploy</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Python API</span></p>
+<p class="caption" role="heading"><span class="caption-text">Python API</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="../torch.html">torch</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../nn.html">torch.nn</a></li>
@@ -303,6 +328,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../quantization.html">Quantization</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../rpc.html">Distributed RPC Framework</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../random.html">torch.random</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../masked.html">torch.masked</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../nested.html">torch.nested</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../sparse.html">torch.sparse</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../storage.html">torch.Storage</a></li>
@@ -312,6 +338,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../checkpoint.html">torch.utils.checkpoint</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../cpp_extension.html">torch.utils.cpp_extension</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../data.html">torch.utils.data</a></li>
+<li class="toctree-l1"><a class="reference internal" href="../jit_utils.html">torch.utils.jit</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../dlpack.html">torch.utils.dlpack</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../mobile_optimizer.html">torch.utils.mobile_optimizer</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../model_zoo.html">torch.utils.model_zoo</a></li>
@@ -321,7 +348,7 @@
 <li class="toctree-l1"><a class="reference internal" href="../name_inference.html">Named Tensors operator coverage</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../config_mod.html">torch.__config__</a></li>
 </ul>
-<p class="caption"><span class="caption-text">Libraries</span></p>
+<p class="caption" role="heading"><span class="caption-text">Libraries</span></p>
 <ul>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/audio/stable">torchaudio</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/data">TorchData</a></li>
@@ -330,12 +357,6 @@
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/text/stable">torchtext</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://pytorch.org/vision/stable">torchvision</a></li>
 <li class="toctree-l1"><a class="reference external" href="http://pytorch.org/xla/">PyTorch on XLA Devices</a></li>
-</ul>
-<p class="caption"><span class="caption-text">Community</span></p>
-<ul class="current">
-<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">PyTorch Governance | Persons of Interest</a></li>
 </ul>
 
             
@@ -377,7 +398,7 @@
       </li>
 
         
-      <li>PyTorch Governance | Persons of Interest</li>
+      <li>PyTorch Governance | Maintainers</li>
     
     
       <li class="pytorch-breadcrumbs-aside">
@@ -409,184 +430,249 @@
             <div role="main" class="main-content" itemscope="itemscope" itemtype="http://schema.org/Article">
              <article itemprop="articleBody" id="pytorch-article" class="pytorch-article">
               
-  <div class="section" id="pytorch-governance-persons-of-interest">
-<h1>PyTorch Governance | Persons of Interest<a class="headerlink" href="#pytorch-governance-persons-of-interest" title="Permalink to this headline">¶</a></h1>
-<div class="section" id="general-maintainers">
-<h2>General Maintainers<a class="headerlink" href="#general-maintainers" title="Permalink to this headline">¶</a></h2>
+  <section id="pytorch-governance-maintainers">
+<h1>PyTorch Governance | Maintainers<a class="headerlink" href="#pytorch-governance-maintainers" title="Permalink to this heading">¶</a></h1>
+<section id="responsibilities">
+<h2>Responsibilities<a class="headerlink" href="#responsibilities" title="Permalink to this heading">¶</a></h2>
+<ul class="simple">
+<li><p>Triage and fix high priority issues assigned to the module or library</p></li>
+<li><p>Triage, review, and land high priority pull requests assigned to the module or library</p></li>
+<li><p>Answer module or library questions on <a class="reference external" href="https://discuss.pytorch.org/">discuss.pytorch.org</a>
+and <a class="reference external" href="dev-discuss.pytorch.org">dev-discuss.pytorch.org</a></p></li>
+<li><p>Maintain public user and development documentation</p></li>
+<li><p>Run meetings and share minutes plus roadmap on a half or quarterly basis</p></li>
+</ul>
+</section>
+<section id="lead-core-maintainer-bdfl">
+<h2>Lead Core Maintainer (BDFL)<a class="headerlink" href="#lead-core-maintainer-bdfl" title="Permalink to this heading">¶</a></h2>
+<ul class="simple">
+<li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
+</ul>
+</section>
+<section id="core-maintainers">
+<h2>Core Maintainers<a class="headerlink" href="#core-maintainers" title="Permalink to this heading">¶</a></h2>
 <ul class="simple">
 <li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
 <li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
 <li><p>Greg Chanan (<a class="reference external" href="https://github.com/gchanan">gchanan</a>)</p></li>
 <li><p>Dmytro Dzhulgakov (<a class="reference external" href="https://github.com/dzhulgakov">dzhulgakov</a>)</p></li>
-<li><p>(emeritus) Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
-<li><p>(emeritus) Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="module-level-maintainers">
-<h2>Module-level maintainers<a class="headerlink" href="#module-level-maintainers" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="torch-nn">
-<h3>torch.nn<a class="headerlink" href="#torch-nn" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="module-level-maintainers">
+<h2>Module-level maintainers<a class="headerlink" href="#module-level-maintainers" title="Permalink to this heading">¶</a></h2>
+<section id="nn-apis-torch-nn">
+<h3>NN APIs (torch.nn)<a class="headerlink" href="#nn-apis-torch-nn" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Greg Chanan (<a class="reference external" href="https://github.com/gchanan">gchanan</a>)</p></li>
 <li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
 <li><p>Joel Schlosser (<a class="reference external" href="https://github.com/jbschlosser">jbschlosser</a>)</p></li>
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/albanD">albanD</a>)</p></li>
 <li><p>(emeritus) Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
 <li><p>(emeritus) Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torch-optim">
-<h3>torch.optim<a class="headerlink" href="#torch-optim" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="optimizers-torch-optim">
+<h3>Optimizers (torch.optim)<a class="headerlink" href="#optimizers-torch-optim" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/albanD">albanD</a>)</p></li>
+<li><p>Joel Schlosser (<a class="reference external" href="https://github.com/jbschlosser">jbschlosser</a>)</p></li>
 <li><p>Soumith Chintala (<a class="reference external" href="https://github.com/soumith">soumith</a>)</p></li>
-<li><p>Ilqar Ramazanli (<a class="reference external" href="https://github.com/iramazanli">iramazanli</a>)</p></li>
+<li><p>(emeritus) Ilqar Ramazanli (<a class="reference external" href="https://github.com/iramazanli">iramazanli</a>)</p></li>
 <li><p>(emeritus) Vincent Quenneville-Belair (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torch-autograd">
-<h3>torch.autograd<a class="headerlink" href="#torch-autograd" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="autograd-torch-autograd">
+<h3>Autograd (torch.autograd)<a class="headerlink" href="#autograd-torch-autograd" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
 <li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
+<li><p>Jeffrey Wan (<a class="reference external" href="https://github.com/soulitzer">soulitzer</a>)</p></li>
 <li><p>(emeritus) Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="jit-torchscript-fx">
-<h3>JIT / TorchScript / FX<a class="headerlink" href="#jit-torchscript-fx" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="compilers-jit-torchscript-fx-torchdynamo">
+<h3>Compilers (JIT / TorchScript / FX / TorchDynamo)<a class="headerlink" href="#compilers-jit-torchscript-fx-torchdynamo" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
+<li><p>Elias Ellison (<a class="reference external" href="https://github.com/eellison">eellison</a>)</p></li>
 <li><p>Michael Suo (<a class="reference external" href="https://github.com/suo">suo</a>)</p></li>
 <li><p>Yanan Cao (<a class="reference external" href="https://github.com/gmagogsfm">gmagogsfm</a>)</p></li>
 <li><p>James Reed (<a class="reference external" href="https://github.com/jamesr66a">jamesr66a</a>)</p></li>
+<li><p>Jason Ansel (<a class="reference external" href="https://github.com/jansel">jansel</a>)</p></li>
 <li><p>(emeritus) Zach Devito (<a class="reference external" href="https://github.com/zdevito">zdevito</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="distributions-rng">
-<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="distributions-rng">
+<h3>Distributions &amp; RNG<a class="headerlink" href="#distributions-rng" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Fritz Obermeyer (<a class="reference external" href="https://github.com/fritzo">fritzo</a>)</p></li>
 <li><p>Neeraj Pradhan (<a class="reference external" href="https://github.com/neerajprad">neerajprad</a>)</p></li>
 <li><p>Alican Bozkurt (<a class="reference external" href="https://github.com/alicanb">alicanb</a>)</p></li>
-<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+<li><p>(emeritus) Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="distributed">
-<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="distributed">
+<h3>Distributed<a class="headerlink" href="#distributed" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Shen Li (<a class="reference external" href="https://github.com/mrshenli">mrshenli</a>)</p></li>
 <li><p>Pritam Damania (<a class="reference external" href="https://github.com/pritamdamania87">pritamdamania87</a>)</p></li>
+<li><p>Yanli Zhao (<a class="reference external" href="https://github.com/zhaojuanmao">zhaojuanmao</a>)</p></li>
+<li><p>Rohan Varma (<a class="reference external" href="https://github.com/rohan-varma">rohan-varma</a>)</p></li>
+<li><p>Wanchao Liang (<a class="reference external" href="https://github.com/wanchaol">wanchaol</a>)</p></li>
+<li><p>Junjie Wang (<a class="reference external" href="https://github.com/fduwjj">fduwjj</a>)</p></li>
+<li><p>Howard Huang (<a class="reference external" href="https://github.com/H-Huang">H-Huang</a>)</p></li>
+<li><p>Tristan Rice (<a class="reference external" href="https://github.com/d4l3k">d4l3k</a>)</p></li>
+<li><p>Alisson Azzolini (<a class="reference external" href="https://github.com/aazzolini">aazzolini</a>)</p></li>
+<li><p>Ke Wen (<a class="reference external" href="https://github.com/kwen2501">kwen2501</a>)</p></li>
+<li><p>James Reed (<a class="reference external" href="https://github.com/jamesr66a">jamesr66a</a>)</p></li>
+<li><p>(emeritus) Kiuk Chung (<a class="reference external" href="https://github.com/kiukchung">kiukchung</a>)</p></li>
 <li><p>(emeritus) Pieter Noordhuis (<a class="reference external" href="https://github.com/pietern">pietern</a>)</p></li>
+<li><p>(emeritus) Mingzhe Li (<a class="reference external" href="https://github.com/mingzhe09088">mingzhe09088</a>)</p></li>
+<li><p>(emeritus) Omkar Salpekar (<a class="reference external" href="https://github.com/osalpekar">osalpekar</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="multiprocessing-and-dataloaders">
-<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="multiprocessing-and-dataloaders">
+<h3>Multiprocessing and DataLoaders<a class="headerlink" href="#multiprocessing-and-dataloaders" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
 <li><p>Simon Wang (<a class="reference external" href="https://github.com/SsnL">SsnL</a>)</p></li>
 <li><p>(emeritus) Adam Paszke (<a class="reference external" href="https://github.com/apaszke">apaszke</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torch-linalg-linear-algebra">
-<h3>torch.linalg / Linear Algebra<a class="headerlink" href="#torch-linalg-linear-algebra" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="linear-algebra-torch-linalg">
+<h3>Linear Algebra (torch.linalg)<a class="headerlink" href="#linear-algebra-torch-linalg" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Mike Ruberry (<a class="reference external" href="https://github.com/mruberry">mruberry</a>)</p></li>
-<li><p>Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
+<li><p>Mario Lezcano (<a class="reference external" href="https://github.com/Lezcano">Lezcano</a>)</p></li>
 <li><p>Ivan Yashchuk (<a class="reference external" href="https://github.com/IvanYashchuk">IvanYashchuk</a>)</p></li>
+<li><p>(emeritus) Vishwak Srinivasan (<a class="reference external" href="https://github.com/vishwakftw">vishwakftw</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torch-fft">
-<h3>torch.fft<a class="headerlink" href="#torch-fft" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="sparse-torch-sparse">
+<h3>Sparse (torch.sparse)<a class="headerlink" href="#sparse-torch-sparse" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Pearu Peterson (<a class="reference external" href="https://github.com/pearu">pearu</a>)</p></li>
+<li><p>Nikita Vedeneev (<a class="reference external" href="https://github.com/nikitaved">nikitaved</a>)</p></li>
+<li><p>Ivan Yashchuk (<a class="reference external" href="https://github.com/IvanYashchuk">IvanYashchuk</a>)</p></li>
+<li><p>Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
+</ul>
+</section>
+<section id="fast-fourier-transform-torch-fft">
+<h3>Fast Fourier Transform (torch.fft)<a class="headerlink" href="#fast-fourier-transform-torch-fft" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Mike Ruberry (<a class="reference external" href="https://github.com/mruberry">mruberry</a>)</p></li>
 <li><p>Peter Bell (<a class="reference external" href="https://github.com/peterbell10">peterbell10</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="cpu-performance-simd">
-<h3>CPU Performance / SIMD<a class="headerlink" href="#cpu-performance-simd" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="cpu-performance-simd">
+<h3>CPU Performance / SIMD<a class="headerlink" href="#cpu-performance-simd" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
+<li><p>Mingfei Ma (<a class="reference external" href="https://github.com/mingfeima">mingfeima</a>)</p></li>
 <li><p>(emeritus) Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
 <li><p>(emeritus) Sam Gross (<a class="reference external" href="https://github.com/colesbury">colesbury</a>)</p></li>
 <li><p>(emeritus) Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
 <li><p>(emeritus) Ilia Cherniavskii (<a class="reference external" href="https://github.com/ilia-cher">ilia-cher</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="cuda">
-<h3>CUDA<a class="headerlink" href="#cuda" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="nvidia-cuda">
+<h3>NVIDIA / CUDA<a class="headerlink" href="#nvidia-cuda" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
 <li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
 <li><p>Piotr Bialecki (<a class="reference external" href="https://github.com/ptrblck">ptrblck</a>)</p></li>
+<li><p>Christian Sarofeen (<a class="reference external" href="https://github.com/csarofeen">csarofeen</a>)</p></li>
+<li><p>Andrew Tulloch (<a class="reference external" href="https://github.com/ajtulloch">ajtulloch</a>)</p></li>
 <li><p>(emeritus) Xiaoqiang Zheng (<a class="reference external" href="https://github.com/zheng-xq">zheng-xq</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="mkldnn">
-<h3>MKLDNN<a class="headerlink" href="#mkldnn" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="nvfuser">
+<h3>NVFuser<a class="headerlink" href="#nvfuser" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Christian Sarofeen (<a class="reference external" href="https://github.com/csarofeen">csarofeen</a>)</p></li>
+<li><p>Alex Jann (<a class="reference external" href="https://github.com/jjsjann123">jjsjann123</a>)</p></li>
+<li><p>Piotr Bialecki (<a class="reference external" href="https://github.com/ptrblck">ptrblck</a>)</p></li>
+<li><p>Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
+</ul>
+</section>
+<section id="intel-mkldnn">
+<h3>Intel / MKLDNN<a class="headerlink" href="#intel-mkldnn" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
 <li><p>Jianhui Li (<a class="reference external" href="https://github.com/Jianhui-Li">Jianhui-Li</a>)</p></li>
+<li><p>Mingfei Ma (<a class="reference external" href="https://github.com/mingfeima">mingfeima</a>)</p></li>
 <li><p>(emeritus) Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
 <li><p>(emeritus) Yinghai Lu (<a class="reference external" href="https://github.com/yinghai">yinghai</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="amd-rocm-hip">
-<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="amd-rocm-hip">
+<h3>AMD/ROCm/HIP<a class="headerlink" href="#amd-rocm-hip" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Peng Sun (<a class="reference external" href="https://github.com/sunway513">sunway513</a>)</p></li>
 <li><p>Jithun Nair (<a class="reference external" href="https://github.com/jithunnair-amd">jithunnair-amd</a>)</p></li>
 <li><p>Jeff Daily (<a class="reference external" href="https://github.com/jeffdaily">jeffdaily</a>)</p></li>
 <li><p>(emeritus) Junjie Bai (<a class="reference external" href="https://github.com/bddppq">bddppq</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="build-ci">
-<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="build-ci">
+<h3>Build + CI<a class="headerlink" href="#build-ci" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Nikita Shulga (<a class="reference external" href="https://github.com/malfet">malfet</a>)</p></li>
 <li><p>Eli Uriegas (<a class="reference external" href="https://github.com/seemethere">seemethere</a>)</p></li>
-<li><p>Zhuojie Zhou (<a class="reference external" href="https://github.com/zhouzhuojie">zhouzhuojie</a>)</p></li>
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
+<li><p>Mikey Dagitses (<a class="reference external" href="https://github.com/dagitses">dagitses</a>)</p></li>
+<li><p>Omkar Salpekar (<a class="reference external" href="https://github.com/osalpekar">osalpekar</a>)</p></li>
+<li><p>Zain Rizvi (<a class="reference external" href="https://github.com/ZainRizvi">ZainRizvi</a>)</p></li>
+<li><p>Nirav Mehta (<a class="reference external" href="https://github.com/mehtanirav">mehtanirav</a>)</p></li>
+<li><p>Andrey Talman (<a class="reference external" href="https://github.com/atalman">atalman</a>)</p></li>
+<li><p>(emeritus) Zhuojie Zhou (<a class="reference external" href="https://github.com/zhouzhuojie">zhouzhuojie</a>)</p></li>
 <li><p>(emeritus) Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
 <li><p>(emeritus) Karl Ostmo (<a class="reference external" href="https://github.com/kostmo">kostmo</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="performance-tools">
-<h3>Performance Tools<a class="headerlink" href="#performance-tools" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="performance-tools">
+<h3>Performance Tools<a class="headerlink" href="#performance-tools" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Victor Bittorf (<a class="reference external" href="https://github.com/bitfort">bitfort</a>)</p></li>
-<li><p>Gisle Dankel (<a class="reference external" href="https://github.com/gdankel">gdankel</a>)</p></li>
+<li><p>Adnan Aziz (<a class="reference external" href="https://github.com/adnanaziz">adnanaziz</a>)</p></li>
+<li><p>CK Luk (<a class="reference external" href="https://github.com/ckluk">ckluk</a>)</p></li>
 <li><p>Taylor Robie (<a class="reference external" href="https://github.com/robieta">robieta</a>)</p></li>
 <li><p>Xu Zhao (<a class="reference external" href="https://github.com/xuzhao9">xuzhao9</a>)</p></li>
 <li><p>Geeta Chauhan (<a class="reference external" href="https://github.com/chauhang">chauhang</a>)</p></li>
+<li><p>(emeritus) Victor Bittorf (<a class="reference external" href="https://github.com/bitfort">bitfort</a>)</p></li>
+<li><p>(emeritus) Gisle Dankel (<a class="reference external" href="https://github.com/gdankel">gdankel</a>)</p></li>
 <li><p>(emeritus) Natalia Gimelshein (<a class="reference external" href="https://github.com/ngimel">ngimel</a>)</p></li>
 <li><p>(emeritus) Mingzhe Li (<a class="reference external" href="https://github.com/mingzhe09088">mingzhe09088</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="c-api">
-<h3>C++ API<a class="headerlink" href="#c-api" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="c-api">
+<h3>C++ API<a class="headerlink" href="#c-api" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Joel Schlosser (<a class="reference external" href="https://github.com/jbschlosser">jbschlosser</a>)</p></li>
 <li><p>(emeritus) Will Feng (<a class="reference external" href="https://github.com/yf225">yf225</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="c10-utils-and-operator-dispatch">
-<h3>C10 utils and operator dispatch<a class="headerlink" href="#c10-utils-and-operator-dispatch" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="c10-utils-and-operator-dispatch">
+<h3>C10 utils and operator dispatch<a class="headerlink" href="#c10-utils-and-operator-dispatch" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Brian Hirsh (<a class="reference external" href="https://github.com/bdhirsh">bdhirsh</a>)</p></li>
 <li><p>Edward Yang (<a class="reference external" href="https://github.com/ezyang">ezyang</a>)</p></li>
 <li><p>Dmytro Dzhulgakov (<a class="reference external" href="https://github.com/dzhulgakov">dzhulgakov</a>)</p></li>
 <li><p>(emeritus) Sebastian Messmer (<a class="reference external" href="https://github.com/smessmer">smessmer</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="pytorch-onnx">
-<h3>PyTorch -&gt; ONNX<a class="headerlink" href="#pytorch-onnx" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="onnx-exporter">
+<h3>ONNX exporter<a class="headerlink" href="#onnx-exporter" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Bowen Bao (<a class="reference external" href="https://github.com/BowenBao">BowenBao</a>)</p></li>
-<li><p>Gary Miguel (<a class="reference external" href="https://github.com/garymm">garymm</a>)</p></li>
+<li><p>Aaron Bockover (<a class="reference external" href="https://github.com/abock">abock</a>)</p></li>
+<li><p>(emeritus) Gary Miguel (<a class="reference external" href="https://github.com/garymm">garymm</a>)</p></li>
 <li><p>(emeritus) Lara Haidar (<a class="reference external" href="https://github.com/lara-hdr">lara-hdr</a>)</p></li>
 <li><p>(emeritus) Lu Fang (<a class="reference external" href="https://github.com/houseroad">houseroad</a>)</p></li>
 <li><p>(emeritus) Negin Raoof (<a class="reference external" href="https://github.com/neginraoof">neginraoof</a>)</p></li>
 <li><p>(emeritus) Spandan Tiwari (<a class="reference external" href="https://github.com/spandantiwari">spandantiwari</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="mobile-edge">
-<h3>Mobile / Edge<a class="headerlink" href="#mobile-edge" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="mobile-edge">
+<h3>Mobile / Edge<a class="headerlink" href="#mobile-edge" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>David Reiss (<a class="reference external" href="https://github.com/dreiss">dreiss</a>)</p></li>
 <li><p>Raziel Guevara (<a class="reference external" href="https://github.com/raziel">raziel</a>)</p></li>
@@ -594,35 +680,50 @@
 <li><p>Ivan Kobzarev (<a class="reference external" href="https://github.com/IvanKobzarev">IvanKobzarev</a>)</p></li>
 <li><p>Tao Xu (<a class="reference external" href="https://github.com/xta0">xta0</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="model-compression-optimization">
-<h3>Model Compression &amp; Optimization<a class="headerlink" href="#model-compression-optimization" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="model-compression-optimization">
+<h3>Model Compression &amp; Optimization<a class="headerlink" href="#model-compression-optimization" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Raghuraman Krishnamoorthi (<a class="reference external" href="https://github.com/raghuramank100">raghuramank100</a>)</p></li>
 <li><p>Jerry Zhang (<a class="reference external" href="https://github.com/jerryzh168">jerryzh168</a>)</p></li>
 <li><p>Zafar Takhirov (<a class="reference external" href="https://github.com/z-a-f">z-a-f</a>)</p></li>
 <li><p>Supriya Rao (<a class="reference external" href="https://github.com/supriyar">supriyar</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="windows">
-<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="windows">
+<h3>Windows<a class="headerlink" href="#windows" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
-<li><p>Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
 <li><p>Guoliang Hua (<a class="reference external" href="https://github.com/nbcsm">nbcsm</a>)</p></li>
-<li><p>Teng Gao (<a class="reference external" href="https://github.com/smartcat2010">smartcat2010</a>)</p></li>
+<li><p>(emeritus) Teng Gao (<a class="reference external" href="https://github.com/gaoteng-git">gaoteng-git</a>)</p></li>
+<li><p>(emeritus) Peter Johnson (<a class="reference external" href="https://github.com/peterjc123">peterjc123</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="powerpc">
-<h3>PowerPC<a class="headerlink" href="#powerpc" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="apple-m1-mps">
+<h3>Apple M1/MPS<a class="headerlink" href="#apple-m1-mps" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Alban Desmaison (<a class="reference external" href="https://github.com/alband">alband</a>)</p></li>
+<li><p>Nikita Shulga (<a class="reference external" href="https://github.com/malfet">malfet</a>)</p></li>
+<li><p>Kulin Seth (<a class="reference external" href="https://github.com/kulinseth">kulinseth</a>)</p></li>
+<li><p>Ramin Azarmehr (<a class="reference external" href="https://github.com/razarmehr">razarmehr</a>)</p></li>
+</ul>
+</section>
+<section id="powerpc">
+<h3>PowerPC<a class="headerlink" href="#powerpc" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Alfredo Mendoza (<a class="reference external" href="https://github.com/avmgithub">avmgithub</a>)</p></li>
 </ul>
-</div>
-</div>
-<div class="section" id="library-level-maintainers">
-<h2>Library-level maintainers<a class="headerlink" href="#library-level-maintainers" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="xla">
-<h3>XLA<a class="headerlink" href="#xla" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="docs-tutorials">
+<h3>Docs / Tutorials<a class="headerlink" href="#docs-tutorials" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Svetlana Karslioglu (<a class="reference external" href="https://github.com/svekars">svekars</a>)</p></li>
+</ul>
+</section>
+</section>
+<section id="library-level-maintainers">
+<h2>Library-level maintainers<a class="headerlink" href="#library-level-maintainers" title="Permalink to this heading">¶</a></h2>
+<section id="xla">
+<h3>XLA<a class="headerlink" href="#xla" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Jack Cao (<a class="reference external" href="https://github.com/JackCaoG">JackCaoG</a>)</p></li>
 <li><p>Daniel Sohn (<a class="reference external" href="https://github.com/jysohn23">jysohn23</a>)</p></li>
@@ -633,41 +734,62 @@
 <li><p>(emeritus) Davide Libenzi (<a class="reference external" href="https://github.com/dlibenzi">dlibenzi</a>)</p></li>
 <li><p>(emeritus) Alex Suhan (<a class="reference external" href="https://github.com/asuhan">asuhan</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torchserve">
-<h3>TorchServe<a class="headerlink" href="#torchserve" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="torchserve">
+<h3>TorchServe<a class="headerlink" href="#torchserve" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Geeta Chauhan (<a class="reference external" href="https://github.com/chauhang">chauhang</a>)</p></li>
 <li><p>Manoj Rao (<a class="reference external" href="https://github.com/mycpuorg">mycpuorg</a>)</p></li>
 <li><p>Vamshi Dantu (<a class="reference external" href="https://github.com/vdantu">vdantu</a>)</p></li>
 <li><p>Dhanasekar Karuppasamy (<a class="reference external" href="https://github.com/dhanainme">dhanainme</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torchvision">
-<h3>TorchVision<a class="headerlink" href="#torchvision" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="torchvision">
+<h3>TorchVision<a class="headerlink" href="#torchvision" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Francisco Massa (<a class="reference external" href="https://github.com/fmassa">fmassa</a>)</p></li>
 <li><p>Vasilis Vryniotis (<a class="reference external" href="https://github.com/datumbox">datumbox</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torchtext">
-<h3>TorchText<a class="headerlink" href="#torchtext" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="torchtext">
+<h3>TorchText<a class="headerlink" href="#torchtext" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Parmeet Singh Bhatia (<a class="reference external" href="https://github.com/parmeet">parmeet</a>)</p></li>
 <li><p>Steven Liu (<a class="reference external" href="https://github.com/hudeven">hudeven</a>)</p></li>
 <li><p>(emeritus) Guanheng George Zhang (<a class="reference external" href="https://github.com/zhangguanheng66">zhangguanheng66</a>)</p></li>
 <li><p>(emeritus) Christian Puhrsch (<a class="reference external" href="https://github.com/cpuhrsch">cpuhrsch</a>)</p></li>
 </ul>
-</div>
-<div class="section" id="torchaudio">
-<h3>TorchAudio<a class="headerlink" href="#torchaudio" title="Permalink to this headline">¶</a></h3>
+</section>
+<section id="torchaudio">
+<h3>TorchAudio<a class="headerlink" href="#torchaudio" title="Permalink to this heading">¶</a></h3>
 <ul class="simple">
 <li><p>Moto Hira (<a class="reference external" href="https://github.com/mthrok">mthrok</a>)</p></li>
 <li><p>(emeritus) Vincent QB (<a class="reference external" href="https://github.com/vincentqb">vincentqb</a>)</p></li>
 </ul>
-</div>
-</div>
-</div>
+</section>
+<section id="torchrec">
+<h3>TorchRec<a class="headerlink" href="#torchrec" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Dmytro Ivchenko (<a class="reference external" href="https://github.com/divchenko">divchenko</a>)</p></li>
+<li><p>Colin Taylor (<a class="reference external" href="https://github.com/colin2328">colin2328</a>)</p></li>
+</ul>
+</section>
+<section id="torchx">
+<h3>TorchX<a class="headerlink" href="#torchx" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Tristan Rice (<a class="reference external" href="https://github.com/d4l3k">d4l3k</a>)</p></li>
+<li><p>Kiuk Chung (<a class="reference external" href="https://github.com/kiukchung">kiukchung</a>)</p></li>
+</ul>
+</section>
+<section id="torchdata-torcharrow">
+<h3>TorchData / TorchArrow<a class="headerlink" href="#torchdata-torcharrow" title="Permalink to this heading">¶</a></h3>
+<ul class="simple">
+<li><p>Vitaly Fedyunin (<a class="reference external" href="https://github.com/VitalyFedyunin">VitalyFedyunin</a>)</p></li>
+<li><p>Wenlei Xie (<a class="reference external" href="https://github.com/wenleix">wenleix</a>)</p></li>
+</ul>
+</section>
+</section>
+</section>
 
 
              </article>
@@ -677,8 +799,10 @@
   
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
       
+        <a href="../notes/amp_examples.html" class="btn btn-neutral float-right" title="CUDA Automatic Mixed Precision examples" accesskey="n" rel="next">Next <img src="../_static/images/chevron-right-orange.svg" class="next-page"></a>
       
-        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
+      
+        <a href="governance.html" class="btn btn-neutral" title="PyTorch Governance | Mechanics" accesskey="p" rel="prev"><img src="../_static/images/chevron-right-orange.svg" class="previous-page"> Previous</a>
       
     </div>
   
@@ -710,31 +834,37 @@
           <div class="pytorch-right-menu" id="pytorch-right-menu">
             <div class="pytorch-side-scroll" id="pytorch-side-scroll-right">
               <ul>
-<li><a class="reference internal" href="#">PyTorch Governance | Persons of Interest</a><ul>
-<li><a class="reference internal" href="#general-maintainers">General Maintainers</a></li>
+<li><a class="reference internal" href="#">PyTorch Governance | Maintainers</a><ul>
+<li><a class="reference internal" href="#responsibilities">Responsibilities</a></li>
+<li><a class="reference internal" href="#lead-core-maintainer-bdfl">Lead Core Maintainer (BDFL)</a></li>
+<li><a class="reference internal" href="#core-maintainers">Core Maintainers</a></li>
 <li><a class="reference internal" href="#module-level-maintainers">Module-level maintainers</a><ul>
-<li><a class="reference internal" href="#torch-nn">torch.nn</a></li>
-<li><a class="reference internal" href="#torch-optim">torch.optim</a></li>
-<li><a class="reference internal" href="#torch-autograd">torch.autograd</a></li>
-<li><a class="reference internal" href="#jit-torchscript-fx">JIT / TorchScript / FX</a></li>
+<li><a class="reference internal" href="#nn-apis-torch-nn">NN APIs (torch.nn)</a></li>
+<li><a class="reference internal" href="#optimizers-torch-optim">Optimizers (torch.optim)</a></li>
+<li><a class="reference internal" href="#autograd-torch-autograd">Autograd (torch.autograd)</a></li>
+<li><a class="reference internal" href="#compilers-jit-torchscript-fx-torchdynamo">Compilers (JIT / TorchScript / FX / TorchDynamo)</a></li>
 <li><a class="reference internal" href="#distributions-rng">Distributions &amp; RNG</a></li>
 <li><a class="reference internal" href="#distributed">Distributed</a></li>
 <li><a class="reference internal" href="#multiprocessing-and-dataloaders">Multiprocessing and DataLoaders</a></li>
-<li><a class="reference internal" href="#torch-linalg-linear-algebra">torch.linalg / Linear Algebra</a></li>
-<li><a class="reference internal" href="#torch-fft">torch.fft</a></li>
+<li><a class="reference internal" href="#linear-algebra-torch-linalg">Linear Algebra (torch.linalg)</a></li>
+<li><a class="reference internal" href="#sparse-torch-sparse">Sparse (torch.sparse)</a></li>
+<li><a class="reference internal" href="#fast-fourier-transform-torch-fft">Fast Fourier Transform (torch.fft)</a></li>
 <li><a class="reference internal" href="#cpu-performance-simd">CPU Performance / SIMD</a></li>
-<li><a class="reference internal" href="#cuda">CUDA</a></li>
-<li><a class="reference internal" href="#mkldnn">MKLDNN</a></li>
+<li><a class="reference internal" href="#nvidia-cuda">NVIDIA / CUDA</a></li>
+<li><a class="reference internal" href="#nvfuser">NVFuser</a></li>
+<li><a class="reference internal" href="#intel-mkldnn">Intel / MKLDNN</a></li>
 <li><a class="reference internal" href="#amd-rocm-hip">AMD/ROCm/HIP</a></li>
 <li><a class="reference internal" href="#build-ci">Build + CI</a></li>
 <li><a class="reference internal" href="#performance-tools">Performance Tools</a></li>
 <li><a class="reference internal" href="#c-api">C++ API</a></li>
 <li><a class="reference internal" href="#c10-utils-and-operator-dispatch">C10 utils and operator dispatch</a></li>
-<li><a class="reference internal" href="#pytorch-onnx">PyTorch -&gt; ONNX</a></li>
+<li><a class="reference internal" href="#onnx-exporter">ONNX exporter</a></li>
 <li><a class="reference internal" href="#mobile-edge">Mobile / Edge</a></li>
 <li><a class="reference internal" href="#model-compression-optimization">Model Compression &amp; Optimization</a></li>
 <li><a class="reference internal" href="#windows">Windows</a></li>
+<li><a class="reference internal" href="#apple-m1-mps">Apple M1/MPS</a></li>
 <li><a class="reference internal" href="#powerpc">PowerPC</a></li>
+<li><a class="reference internal" href="#docs-tutorials">Docs / Tutorials</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#library-level-maintainers">Library-level maintainers</a><ul>
@@ -743,6 +873,9 @@
 <li><a class="reference internal" href="#torchvision">TorchVision</a></li>
 <li><a class="reference internal" href="#torchtext">TorchText</a></li>
 <li><a class="reference internal" href="#torchaudio">TorchAudio</a></li>
+<li><a class="reference internal" href="#torchrec">TorchRec</a></li>
+<li><a class="reference internal" href="#torchx">TorchX</a></li>
+<li><a class="reference internal" href="#torchdata-torcharrow">TorchData / TorchArrow</a></li>
 </ul>
 </li>
 </ul>
@@ -762,8 +895,10 @@
 
      
        <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
+         <script data-url_root="../" id="documentation_options" src="../_static/documentation_options.js"></script>
          <script src="../_static/jquery.js"></script>
          <script src="../_static/underscore.js"></script>
+         <script src="../_static/_sphinx_javascript_frameworks_compat.js"></script>
          <script src="../_static/doctools.js"></script>
          <script src="../_static/clipboard.min.js"></script>
          <script src="../_static/copybutton.js"></script>
@@ -783,7 +918,7 @@
   </script>
  
 <script script type="text/javascript">
-  var collapsedSections = ['Notes', 'Language Bindings', 'Libraries', 'Community'];
+  var collapsedSections = ['Developer Notes', 'Language Bindings', 'Libraries', 'Community'];
 </script>
 
 <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/795629140/?label=txkmCPmdtosBENSssfsC&amp;guid=ON&amp;script=0"/>

--- a/docs/1.12/complex_numbers.html
+++ b/docs/1.12/complex_numbers.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/config_mod.html
+++ b/docs/1.12/config_mod.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/cpp_extension.html
+++ b/docs/1.12/cpp_extension.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/cpp_index.html
+++ b/docs/1.12/cpp_index.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/cuda.html
+++ b/docs/1.12/cuda.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/cudnn_persistent_rnn.html
+++ b/docs/1.12/cudnn_persistent_rnn.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/cudnn_rnn_determinism.html
+++ b/docs/1.12/cudnn_rnn_determinism.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/data.html
+++ b/docs/1.12/data.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/ddp_comm_hooks.html
+++ b/docs/1.12/ddp_comm_hooks.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/deploy.html
+++ b/docs/1.12/deploy.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/distributed.algorithms.join.html
+++ b/docs/1.12/distributed.algorithms.join.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/distributed.elastic.html
+++ b/docs/1.12/distributed.elastic.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/distributed.html
+++ b/docs/1.12/distributed.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/distributed.optim.html
+++ b/docs/1.12/distributed.optim.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/distributions.html
+++ b/docs/1.12/distributions.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/dlpack.html
+++ b/docs/1.12/dlpack.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/fft.html
+++ b/docs/1.12/fft.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/fsdp.html
+++ b/docs/1.12/fsdp.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/futures.html
+++ b/docs/1.12/futures.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/fx.html
+++ b/docs/1.12/fx.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/genindex.html
+++ b/docs/1.12/genindex.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/hub.html
+++ b/docs/1.12/hub.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/index.html
+++ b/docs/1.12/index.html
@@ -333,9 +333,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             
@@ -538,9 +540,11 @@ flags, and are at an early stage for feedback and testing.</p>
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 </div>
 </div>

--- a/docs/1.12/jit.html
+++ b/docs/1.12/jit.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/jit_builtin_functions.html
+++ b/docs/1.12/jit_builtin_functions.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/jit_language_reference.html
+++ b/docs/1.12/jit_language_reference.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/jit_language_reference_v2.html
+++ b/docs/1.12/jit_language_reference_v2.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/jit_python_reference.html
+++ b/docs/1.12/jit_python_reference.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/jit_unsupported.html
+++ b/docs/1.12/jit_unsupported.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/library.html
+++ b/docs/1.12/library.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/linalg.html
+++ b/docs/1.12/linalg.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/mobile_optimizer.html
+++ b/docs/1.12/mobile_optimizer.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/model_zoo.html
+++ b/docs/1.12/model_zoo.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/monitor.html
+++ b/docs/1.12/monitor.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/multiprocessing.html
+++ b/docs/1.12/multiprocessing.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/name_inference.html
+++ b/docs/1.12/name_inference.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/named_tensor.html
+++ b/docs/1.12/named_tensor.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/nested.html
+++ b/docs/1.12/nested.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/nn.functional.html
+++ b/docs/1.12/nn.functional.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/nn.html
+++ b/docs/1.12/nn.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/nn.init.html
+++ b/docs/1.12/nn.init.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/onnx.html
+++ b/docs/1.12/onnx.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/onnx_supported_aten_ops.html
+++ b/docs/1.12/onnx_supported_aten_ops.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/optim.html
+++ b/docs/1.12/optim.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/package.html
+++ b/docs/1.12/package.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/pipeline.html
+++ b/docs/1.12/pipeline.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/profiler.html
+++ b/docs/1.12/profiler.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/py-modindex.html
+++ b/docs/1.12/py-modindex.html
@@ -335,9 +335,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/quantization-accuracy-debugging.html
+++ b/docs/1.12/quantization-accuracy-debugging.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/quantization-backend-configuration.html
+++ b/docs/1.12/quantization-backend-configuration.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/quantization-support.html
+++ b/docs/1.12/quantization-support.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/quantization.html
+++ b/docs/1.12/quantization.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/random.html
+++ b/docs/1.12/random.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/rpc.html
+++ b/docs/1.12/rpc.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/search.html
+++ b/docs/1.12/search.html
@@ -332,9 +332,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/sparse.html
+++ b/docs/1.12/sparse.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/special.html
+++ b/docs/1.12/special.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/storage.html
+++ b/docs/1.12/storage.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/tensor_attributes.html
+++ b/docs/1.12/tensor_attributes.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/tensor_view.html
+++ b/docs/1.12/tensor_view.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/tensorboard.html
+++ b/docs/1.12/tensorboard.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/tensors.html
+++ b/docs/1.12/tensors.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/testing.html
+++ b/docs/1.12/testing.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/torch.ao.ns._numeric_suite.html
+++ b/docs/1.12/torch.ao.ns._numeric_suite.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/torch.ao.ns._numeric_suite_fx.html
+++ b/docs/1.12/torch.ao.ns._numeric_suite_fx.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/torch.html
+++ b/docs/1.12/torch.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/torch.overrides.html
+++ b/docs/1.12/torch.overrides.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             

--- a/docs/1.12/type_info.html
+++ b/docs/1.12/type_info.html
@@ -334,9 +334,11 @@
 </ul>
 <p class="caption"><span class="caption-text">Community</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>
-<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>
+<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>
+<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>
+<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>
+<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>
 </ul>
 
             


### PR DESCRIPTION
- Copied the actual files
- Dropped "You are viewing unstable version" warning
- Updated ToC for rest of the docs using following script:
```python
from pathlib import Path

old_community_toc="\n".join([
        '<p class="caption"><span class="caption-text">Community</span></p>',
        '<ul>',
        '<li class="toctree-l1"><a class="reference internal" href="community/contribution_guide.html">PyTorch Contribution Guide</a></li>',
        '<li class="toctree-l1"><a class="reference internal" href="community/governance.html">PyTorch Governance</a></li>',
        '<li class="toctree-l1"><a class="reference internal" href="community/persons_of_interest.html">PyTorch Governance | Persons of Interest</a></li>',
        '</ul>',
        ])

new_community_toc="\n".join([
        '<p class="caption"><span class="caption-text">Community</span></p>',
        '<ul>',
        '<li class="toctree-l1"><a class="reference internal" href="build_ci_governance.html">PyTorch Governance | Build + CI</a></li>',
        '<li class="toctree-l1"><a class="reference internal" href="contribution_guide.html">PyTorch Contribution Guide</a></li>',
        '<li class="toctree-l1"><a class="reference internal" href="design.html">PyTorch Design Philosophy</a></li>',
        '<li class="toctree-l1"><a class="reference internal" href="governance.html">PyTorch Governance | Mechanics</a></li>',
        '<li class="toctree-l1"><a class="current reference internal" href="#">PyTorch Governance | Maintainers</a></li>',
        '</ul>',
        ])

docs_stable_base_dir = Path(__file__).parent / "docs" / "1.12"
for html_path in docs_stable_base_dir.glob("**/*.html"):
    with open(html_path) as f:
        html_data = f.read()
    if old_community_toc not in html_data:
        continue
    with open(html_path, "w") as f:
        f.write(html_data.replace(old_community_toc, new_community_toc))
    print(html_path)
```