### PR TITLE
robots.txt: disallow non-latest docs torchx/torchelastic

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -14,3 +14,12 @@ Disallow: /docs/1.7.*
 Disallow: /docs/1.8.*
 Disallow: /docs/1.9.*
 Disallow: /docs/master/
+
+# libraries: torchx
+Disallow: /torchx/*/
+Allow: /torchx/latest/
+Allow: /torchx/main/
+
+# libraries: torchelastic
+Disallow: /elastic/*/
+Allow: /elastic/latest/


### PR DESCRIPTION
This disables versioned pages for the docs from being indexed in search engines.

There's a lot of old versioned pages that have been indexed by Google such as https://pytorch.org/elastic/0.1.0rc2/overview.html when the new location is in core for torchelastic. This prevents users from being confused by old documentation pages.

The pattern of Disallow: *, Allow: foo works per https://technicalseo.com/tools/robots-txt/

Test plan:

Use https://technicalseo.com/tools/robots-txt/

* https://pytorch.org/torchelastic/latest/index.html
* https://pytorch.org/elastic/0.1.0rc2/overview.html
* https://pytorch.org/torchx/latest/
* https://pytorch.org/torchx/main/
* https://pytorch.org/torchx/0.2.0/
* https://pytorch.org/torchx/versions.html