### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.13.6)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -273,4 +273,5 @@ DEPENDENCIES
 RUBY VERSION
    ruby 2.6.10p210
 
-
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
Ran `bundle update nokogiri` to upgrade `Gemfile.lock` and fix the nokogiri security vulnerability.