### PR TITLE
Add LTS to previous versions

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -377,6 +377,61 @@ pip install torch==1.9.0+cu102 torchvision==0.10.0+cu102 torchaudio==0.9.0 -f ht
 pip install torch==1.9.0+cpu torchvision==0.10.0+cpu torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
+### v1.8.2 with LTS support
+
+#### Conda
+
+##### OSX
+
+macOS is currently not supported for LTS.
+
+##### Linux and Windows
+
+```
+# CUDA 10.2
+# NOTE: PyTorch LTS version 1.8.2 is only supported for Python <= 3.8.
+conda install pytorch torchvision torchaudio cudatoolkit=10.2 -c pytorch-lts
+
+# CUDA 11.1 (Linux) 
+# NOTE: 'nvidia' channel is required for cudatoolkit 11.1 <br> <b>NOTE:</b> Pytorch LTS version 1.8.2 is only supported for Python <= 3.8.
+conda install pytorch torchvision torchaudio cudatoolkit=11.1 -c pytorch-lts -c nvidia
+
+# CUDA 11.1 (Windows)
+# 'conda-forge' channel is required for cudatoolkit 11.1 <br> <b>NOTE:</b> Pytorch LTS version 1.8.2 is only supported for Python <= 3.8.
+conda install pytorch torchvision torchaudio cudatoolkit=11.1 -c pytorch-lts -c conda-forge
+
+# CPU Only
+# Pytorch LTS version 1.8.2 is only supported for Python <= 3.8.
+conda install pytorch torchvision torchaudio cpuonly -c pytorch-lts
+
+# ROCM5.x
+
+Not supported in LTS.
+```
+
+#### Wheel
+
+##### OSX 
+
+macOS is currently not supported in LTS.
+
+##### Linux and Windows
+
+```
+# CUDA 10.2
+pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu102
+
+# CUDA 11.1
+pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cu111
+
+# CPU Only
+pip3 install torch==1.8.2 torchvision==0.9.2 torchaudio==0.8.2 --extra-index-url https://download.pytorch.org/whl/lts/1.8/cpu
+
+# ROCM5.x
+
+Not supported in LTS.
+```
+
 ### v1.8.1
 
 #### Conda

--- a/_posts/2022-11-10-pytorch-enterprise-support-update.md
+++ b/_posts/2022-11-10-pytorch-enterprise-support-update.md
@@ -9,7 +9,7 @@ On May 25, 2021, we announced the [PyTorch Enterprise Support Program](https://p
 
 The program enabled Program certified service providers to develop and offer tailored enterprise-grade support to their customers through contribution of hotfixes and other improvements requested by PyTorch enterprise users who were developing models in production at scale for mission-critical applications. However, as we evaluate community feedback, we found ongoing ESP support was not necessary at this time and will immediately divert these resources to other areas to improve the user experience for the entire community.
 
-Today, we are removing the PyTorch long-term support (LTS 1.8.2) download link from the “Get Started” page from the “[Start Locally](https://pytorch.org/get-started/locally/)” download option in order to simplify the user experience. One can download previous versions of PyTorch starting from the first public release until the latest one. Please note that it is only supported for Python while it is being deprecated. If there are any updates to ESP/LTS, we will update future blogs.
+Today, we are removing the PyTorch long-term support (LTS 1.8.2) download link from the “Get Started” page from the “[Start Locally](https://pytorch.org/get-started/locally/)” download option in order to simplify the user experience. One can download PyTorch v1.8.2 with LTS support in [previous versions](/get-started/previous-versions/#v182-with-lts-support). Please note that it is only supported for Python while it is being deprecated. If there are any updates to ESP/LTS, we will update future blogs.
 
 <p align="center">
   <img src="/assets/images/Pytorch-Enterprise-Support-Img1.png" width="70%">


### PR DESCRIPTION
- Add commands that explain how to install PyTorch 1.8.2 with LTS.
- Update the blog to point to the 1.8.2 with LTS section. 