### PR TITLE
Add architecture extraction logic to getting started page generation

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -107,5 +107,5 @@ jobs:
           commit-message: Modify published_versions.json file
           title: '[Getting Started Page] Modify published_versions.json file'
           body: >
-            This PR is auto-generated Gettins Started page update
+            This PR is auto-generated. It updates Getting Started page
           labels: automated pr

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -169,19 +169,20 @@ def gen_install_matrix(versions) -> Dict[str, str]:
 # last verion of rocm. It will modify the acc_arch_ver_map object used
 # to update getting started page.
 def extract_arch_ver_map(release_matrix):
+    def gen_ver_list(chan, gpu_arch_type):
+        return {
+            x["desired_cuda"]: x["gpu_arch_version"]
+            for x in release_matrix[chan]["linux"]
+            if x["gpu_arch_type"] == gpu_arch_type
+        }
+
     for chan in ("nightly", "release"):
-        cuda_ver_list = {
-            x["desired_cuda"]: x["gpu_arch_version"] for x in release_matrix[chan]["linux"]
-            if x["gpu_arch_type"] == "cuda"
-        }
-        rocm_ver_list = {
-            x["desired_cuda"]: x["gpu_arch_version"] for x in release_matrix[chan]["linux"]
-            if x["gpu_arch_type"] == "rocm"
-        }
+        cuda_ver_list = gen_ver_list(chan, "cuda")
+        rocm_ver_list = gen_ver_list(chan, "rocm")
         cuda_list = sorted(cuda_ver_list.values())[-2:]
+        acc_arch_ver_map[chan]["rocm5.x"] = ("rocm", max(rocm_ver_list.values()))
         for cuda_ver, label in zip(cuda_list, ["cuda.x", "cuda.y"]):
             acc_arch_ver_map[chan][label] = ("cuda", cuda_ver)
-        acc_arch_ver_map[chan]["rocm5.x"] = ("rocm", max(rocm_ver_list.values()))
 
 
 def main():


### PR DESCRIPTION
1. Add architecture extraction logic to getting started page generation
This should automatically pick up two latest cuda version and last rocm version from release matrix and use these version in updating the page.

2. Fix wording in auto generated PR