### PR TITLE
Make release validation always run after nightly validation

### DIFF
--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -25,7 +25,6 @@ jobs:
       ref: main
   validate-release-binaries:
     uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
-    needs: validate-nightly-binaries
     with:
       os: all
       channel: "release"

--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -24,7 +24,9 @@ jobs:
       channel: "nightly"
       ref: main
   validate-release-binaries:
+    if: always()
     uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
+    needs: validate-nightly-binaries
     with:
       os: all
       channel: "release"


### PR DESCRIPTION
Make  release validation  to always run after nightly. One bug I noticed putting release after nightly validation, if nightly fails, release validation will not run at all. This makes release to always run after nightly.
