### PR TITLE
Tune macos installation instructions

### DIFF
--- a/published_versions.json
+++ b/published_versions.json
@@ -123,18 +123,21 @@
           },
           "cuda.x": {
             "note": null,
+            "default": true,
             "versions": {
               "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip"
             }
           },
           "cuda.y": {
             "note": null,
+            "default": true,
             "versions": {
               "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip"
             }
           },
           "rocm5.x": {
             "note": null,
+            "default": true,
             "versions": {
               "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-latest.zip"
             }
@@ -322,18 +325,21 @@
           },
           "cuda.x": {
             "note": null,
+            "default": true,
             "versions": {
               "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip"
             }
           },
           "cuda.y": {
             "note": null,
+            "default": true,
             "versions": {
               "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.13.0.zip"
             }
           },
           "rocm5.x": {
             "note": "<b>NOTE:</b> ROCm is not available on MacOS",
+            "default": true,
             "versions": null
           }
         }

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -57,7 +57,7 @@ LIBTORCH_DWNL_INSTR = {
         CXX11_ABI: "Download here (cxx11 ABI):",
         RELEASE: "Download here (Release version):",
         DEBUG: "Download here (Debug version):",
-        MACOS: "Download default libtorch here (ROCm and CUDA not supported):",
+        MACOS: "Download default libtorch here (ROCm and CUDA are not supported):",
     }
 
 def load_json_from_basedir(filename: str):


### PR DESCRIPTION
Tune macos installation instructions.
This will make sure for cuda/rocm configuration default CPU is picked