### PR TITLE
Release 2.0 update getting started page generator

### DIFF
--- a/_includes/quick-start-module.js
+++ b/_includes/quick-start-module.js
@@ -18,7 +18,7 @@ var default_selected_os = getAnchorSelectedOS() || getDefaultSelectedOS();
 var opts = {
   cuda: getPreferredCuda(default_selected_os),
   os: default_selected_os,
-  pm: 'conda',
+  pm: 'pip',
   language: 'python',
   ptbuild: 'stable',
 };

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -35,15 +35,15 @@ MACOS = "macos"
 acc_arch_ver_default = {
     "nightly": {
         "accnone": ("cpu", ""),
-        "cuda.x": ("cuda", "11.6"),
-        "cuda.y": ("cuda", "11.7"),
-        "rocm5.x": ("rocm", "5.2")
+        "cuda.x": ("cuda", "11.7"),
+        "cuda.y": ("cuda", "11.8"),
+        "rocm5.x": ("rocm", "5.4.2")
         },
     "release": {
         "accnone": ("cpu", ""),
-        "cuda.x": ("cuda", "11.6"),
-        "cuda.y": ("cuda", "11.7"),
-        "rocm5.x": ("rocm", "5.2")
+        "cuda.x": ("cuda", "11.7"),
+        "cuda.y": ("cuda", "11.8"),
+        "rocm5.x": ("rocm", "5.4.2")
         }
     }
 


### PR DESCRIPTION
Update getting started page template to make pip option be selected by default
Update default cuda/rocm version (optional since latest ones are selected anyways)  

Please note, the  the page update PR will be generated automatically: https://github.com/pytorch/pytorch.github.io/wiki/Automation-of-Getting-Started-page-generation