### PR TITLE
Fix typos in python versions

### DIFF
--- a/_posts/2023-03-15-pytorch-2.0-release.md
+++ b/_posts/2023-03-15-pytorch-2.0-release.md
@@ -64,7 +64,7 @@ Summary:
    </td>
    <td> 
 
-<a href="#deprecation-of-cuda-116-and-python-17-support-for-pytorch-20">Python 1.8 (deprecating Python 1.7)</a>
+<a href="#deprecation-of-cuda-116-and-python-17-support-for-pytorch-20">Python 3.8 (deprecating Python 3.7)</a>
    </td>
   </tr>
   <tr>
@@ -513,7 +513,7 @@ For the latest and greatest news about dynamic shapes support on master, check o
 ## Highlights/Performance Improvements
 
 
-### [Deprecation of Cuda 11.6 and Python 1.7 support](https://pytorch.org/blog/deprecation-cuda-python-support/) for PyTorch 2.0
+### [Deprecation of Cuda 11.6 and Python 3.7 support](https://pytorch.org/blog/deprecation-cuda-python-support/) for PyTorch 2.0
 
 If you are still using or depending on CUDA 11.6 or Python 3.7 builds, we strongly recommend moving to at least CUDA 11.7 and Python 3.8, as it would be the minimum versions required for PyTorch 2.0. For more detail, please refer to the [Release Compatibility Matrix for PyTorch](https://github.com/pytorch/pytorch/blob/master/RELEASE.md#release-compatibility-matrix) releases.
 

--- a/_posts/2023-03-15-pytorch-2.0-release.md
+++ b/_posts/2023-03-15-pytorch-2.0-release.md
@@ -48,7 +48,7 @@ Summary:
    </td>
    <td>
 
-<a href="#deprecation-of-cuda-116-and-python-17-support-for-pytorch-20">CUDA support for 11.7 & 11.8 (deprecating CUDA 11.6) </a>
+<a href="#deprecation-of-cuda-116-and-python-37-support-for-pytorch-20">CUDA support for 11.7 & 11.8 (deprecating CUDA 11.6) </a>
    </td>
   </tr>
   <tr>
@@ -64,7 +64,7 @@ Summary:
    </td>
    <td> 
 
-<a href="#deprecation-of-cuda-116-and-python-17-support-for-pytorch-20">Python 3.8 (deprecating Python 3.7)</a>
+<a href="#deprecation-of-cuda-116-and-python-37-support-for-pytorch-20">Python 3.8 (deprecating Python 3.7)</a>
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
Fix typos in python versions

  - python 1.7 -> 3.7
  - python 1.8 -> 3.8
