### PR TITLE
Fix quotation marks in Figure 4: AMP recipe

### DIFF
--- a/_posts/2022-7-19-what-every-user-should-know-about-mixed-precision-training-in-pytorch.md
+++ b/_posts/2022-7-19-what-every-user-should-know-about-mixed-precision-training-in-pytorch.md
@@ -57,7 +57,7 @@ scaler = torch.cuda.amp.GradScaler()
 for data, label in data_iter:
    optimizer.zero_grad()
    # Casts operations to mixed precision
-   with torch.amp.autocast(device_type=“cuda”, dtype=torch.float16):
+   with torch.amp.autocast(device_type="cuda", dtype=torch.float16):
       loss = model(data)
 
    # Scales the loss, and calls backward()


### PR DESCRIPTION
The original version returned a syntax error when I copied and pasted the example code.

<img width="391" alt="image" src="https://user-images.githubusercontent.com/35001605/226264954-09d7abc3-04ff-4557-8925-b76af32805a1.png">
