### PR TITLE
Fix nbconvert dependency error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: yarn install --cache-folder ~/.cache/yarn
       - run:
           name: Notedown Install
-          command: sudo apt update && sudo apt install python3-pip && sudo -H pip3 install pyrsistent==0.16 notedown pyyaml -Iv nbformat==5.1.0
+          command: sudo apt update && sudo apt install python3-pip && sudo -H pip3 install pyrsistent==0.16 notedown pyyaml -Iv nbformat==5.7
       - save_cache:
           key: pytorch-yarn-{{ checksum "yarn.lock" }}
           paths:


### PR DESCRIPTION
The last build was failing with the following error: 
```
pkg_resources.ContextualVersionConflict: (nbformat 5.1.0 (/usr/local/lib/python3.8/dist-packages), Requirement.parse('nbformat>=5.7'), {'nbconvert'})
```
Updating the `nbformat` dependency to resolve
