### PR TITLE
Bring back CCI job until GHA Push Issue Resolved

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: cimg/ruby:2.7-node
+    steps:
+      - run:
+          name: Checkout
+          command: |
+            git init
+            git remote add origin https://github.com/pytorch/pytorch.github.io
+            git fetch --depth 1
+            git checkout site
+      - restore_cache:
+          keys:
+            - pytorch-gem-cache-{{ checksum "Gemfile.lock" }}
+            - pytorch-gem-cache-
+      - run:
+          name: Bundle Install
+          command: |
+            bundle config set --local path 'vendor/bundle'
+            bundle install
+      - save_cache:
+          key: pytorch-gem-cache-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - restore_cache:
+          keys:
+            - pytorch-yarn-{{ checksum "yarn.lock" }}
+            - pytorch-yarn-
+      - run:
+          name: Yarn Install
+          command: yarn install --cache-folder ~/.cache/yarn
+      - run:
+          name: Notedown Install
+          command: sudo apt update && sudo apt install python3-pip && sudo -H pip3 install pyrsistent==0.16 notedown pyyaml -Iv nbformat==5.7
+      - save_cache:
+          key: pytorch-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Configure CircleCI Bot
+          command: |
+            git config --global user.email "facebook-circleci-bot@users.noreply.github.com"
+            git config --global user.name "Website Deployment Script"
+      - run:
+          name: Build Jekyll site and push to master
+          command: ./scripts/deploy-site.sh build
+
+workflows:
+  version: 2
+  workflow-build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: site


### PR DESCRIPTION
The GHA job fails due to auth issues when pushing to the master branch (which is picked up by github pages to render the website). Bringing back the CCI job until the GHA issue is fixed.