### PR TITLE
Pass token by correct name

### DIFF
--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -57,7 +57,7 @@ git add -A
 # now commit, ignoring branch master doesn't seem to work, so trying skip
 git commit --allow-empty -m "Deploy to GitHub Pages on master [ci skip]"
 # and push, but send any output to /dev/null to hide anything sensitive
-git push --force --quiet https://pytorchbot:$PYTORCHBOT_TOKEN@github.com/pytorch/pytorch.github.io.git master
+git push --force --quiet https://pytorchbot:$SECRET_PYTORCHBOT_TOKEN@github.com/pytorch/pytorch.github.io.git master
 # go back to where we started and remove the master git repo we made and used
 # for deployment
 cd ..


### PR DESCRIPTION
I don't know why but https://github.com/pytorch/test-infra/blob/ed7237ab9f23fa1b2f29699cf75d85b4a2a590a5/.github/scripts/run_docker_with_env_secrets.py#L47 prepends `SECRET_` in front of the token

IMO this workflow needs better UX to error out on undefined secrets...