### PR TITLE
Remove 2.0 docs from Google Search indexing

### DIFF
--- a/docs/2.0/_dynamo.html
+++ b/docs/2.0/_dynamo.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/_modules/index.html
+++ b/docs/2.0/_modules/index.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch.html
+++ b/docs/2.0/_modules/torch.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/__config__.html
+++ b/docs/2.0/_modules/torch/__config__.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_dynamo.html
+++ b/docs/2.0/_modules/torch/_dynamo.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_dynamo/backends/registry.html
+++ b/docs/2.0/_modules/torch/_dynamo/backends/registry.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_dynamo/eval_frame.html
+++ b/docs/2.0/_modules/torch/_dynamo/eval_frame.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_jit_internal.html
+++ b/docs/2.0/_modules/torch/_jit_internal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_lobpcg.html
+++ b/docs/2.0/_modules/torch/_lobpcg.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_lowrank.html
+++ b/docs/2.0/_modules/torch/_lowrank.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_tensor.html
+++ b/docs/2.0/_modules/torch/_tensor.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_tensor_str.html
+++ b/docs/2.0/_modules/torch/_tensor_str.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/_utils.html
+++ b/docs/2.0/_modules/torch/_utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/amp/autocast_mode.html
+++ b/docs/2.0/_modules/torch/amp/autocast_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/modules/fused.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/modules/fused.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/qat/modules/conv_fused.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/qat/modules/conv_fused.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/qat/modules/linear_relu.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/qat/modules/linear_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/dynamic/modules/linear_relu.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/dynamic/modules/linear_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/bn_relu.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/bn_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/conv_relu.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/conv_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/linear_relu.html
+++ b/docs/2.0/_modules/torch/ao/nn/intrinsic/quantized/modules/linear_relu.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/qat/dynamic/modules/linear.html
+++ b/docs/2.0/_modules/torch/ao/nn/qat/dynamic/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/qat/modules/conv.html
+++ b/docs/2.0/_modules/torch/ao/nn/qat/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/qat/modules/linear.html
+++ b/docs/2.0/_modules/torch/ao/nn/qat/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantizable/modules/activation.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantizable/modules/activation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantizable/modules/rnn.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantizable/modules/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/dynamic/modules/linear.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/dynamic/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/dynamic/modules/rnn.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/dynamic/modules/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/functional.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/activation.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/activation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/batchnorm.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/batchnorm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/conv.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/embedding_ops.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/embedding_ops.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/functional_modules.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/functional_modules.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/linear.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/nn/quantized/modules/normalization.html
+++ b/docs/2.0/_modules/torch/ao/nn/quantized/modules/normalization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/ns/_numeric_suite.html
+++ b/docs/2.0/_modules/torch/ao/ns/_numeric_suite.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/ns/_numeric_suite_fx.html
+++ b/docs/2.0/_modules/torch/ao/ns/_numeric_suite_fx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/ns/fx/utils.html
+++ b/docs/2.0/_modules/torch/ao/ns/fx/utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization.html
+++ b/docs/2.0/_modules/torch/ao/quantization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/backend_config/backend_config.html
+++ b/docs/2.0/_modules/torch/ao/quantization/backend_config/backend_config.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/fake_quantize.html
+++ b/docs/2.0/_modules/torch/ao/quantization/fake_quantize.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/fuse_modules.html
+++ b/docs/2.0/_modules/torch/ao/quantization/fuse_modules.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/fx/custom_config.html
+++ b/docs/2.0/_modules/torch/ao/quantization/fx/custom_config.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/observer.html
+++ b/docs/2.0/_modules/torch/ao/quantization/observer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/qconfig.html
+++ b/docs/2.0/_modules/torch/ao/quantization/qconfig.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/qconfig_mapping.html
+++ b/docs/2.0/_modules/torch/ao/quantization/qconfig_mapping.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/quantize.html
+++ b/docs/2.0/_modules/torch/ao/quantization/quantize.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/quantize_fx.html
+++ b/docs/2.0/_modules/torch/ao/quantization/quantize_fx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/ao/quantization/stubs.html
+++ b/docs/2.0/_modules/torch/ao/quantization/stubs.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd.html
+++ b/docs/2.0/_modules/torch/autograd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/anomaly_mode.html
+++ b/docs/2.0/_modules/torch/autograd/anomaly_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/forward_ad.html
+++ b/docs/2.0/_modules/torch/autograd/forward_ad.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/function.html
+++ b/docs/2.0/_modules/torch/autograd/function.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/functional.html
+++ b/docs/2.0/_modules/torch/autograd/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/grad_mode.html
+++ b/docs/2.0/_modules/torch/autograd/grad_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/gradcheck.html
+++ b/docs/2.0/_modules/torch/autograd/gradcheck.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/graph.html
+++ b/docs/2.0/_modules/torch/autograd/graph.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/autograd/profiler.html
+++ b/docs/2.0/_modules/torch/autograd/profiler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/cuda.html
+++ b/docs/2.0/_modules/torch/backends/cuda.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/cudnn.html
+++ b/docs/2.0/_modules/torch/backends/cudnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/mkl.html
+++ b/docs/2.0/_modules/torch/backends/mkl.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/mkldnn.html
+++ b/docs/2.0/_modules/torch/backends/mkldnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/mps.html
+++ b/docs/2.0/_modules/torch/backends/mps.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/openmp.html
+++ b/docs/2.0/_modules/torch/backends/openmp.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/backends/opt_einsum.html
+++ b/docs/2.0/_modules/torch/backends/opt_einsum.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cpu/amp/autocast_mode.html
+++ b/docs/2.0/_modules/torch/cpu/amp/autocast_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda.html
+++ b/docs/2.0/_modules/torch/cuda.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/_sanitizer.html
+++ b/docs/2.0/_modules/torch/cuda/_sanitizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/amp/autocast_mode.html
+++ b/docs/2.0/_modules/torch/cuda/amp/autocast_mode.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/amp/grad_scaler.html
+++ b/docs/2.0/_modules/torch/cuda/amp/grad_scaler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/graphs.html
+++ b/docs/2.0/_modules/torch/cuda/graphs.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/jiterator.html
+++ b/docs/2.0/_modules/torch/cuda/jiterator.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/memory.html
+++ b/docs/2.0/_modules/torch/cuda/memory.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/nvtx.html
+++ b/docs/2.0/_modules/torch/cuda/nvtx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/random.html
+++ b/docs/2.0/_modules/torch/cuda/random.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/cuda/streams.html
+++ b/docs/2.0/_modules/torch/cuda/streams.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed.html
+++ b/docs/2.0/_modules/torch/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/debugging_hooks.html
+++ b/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/debugging_hooks.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.html
+++ b/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.html
+++ b/docs/2.0/_modules/torch/distributed/algorithms/ddp_comm_hooks/powerSGD_hook.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/algorithms/join.html
+++ b/docs/2.0/_modules/torch/distributed/algorithms/join.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/autograd.html
+++ b/docs/2.0/_modules/torch/distributed/autograd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/default_planner.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/default_planner.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/filesystem.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/filesystem.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/planner.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/planner.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/state_dict_loader.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/state_dict_loader.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/state_dict_saver.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/state_dict_saver.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/checkpoint/storage.html
+++ b/docs/2.0/_modules/torch/distributed/checkpoint/storage.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/distributed_c10d.html
+++ b/docs/2.0/_modules/torch/distributed/distributed_c10d.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/agent/server/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/agent/server/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/agent/server/local_elastic_agent.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/agent/server/local_elastic_agent.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/events.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/events.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/events/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/events/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/events/handlers.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/events/handlers.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/metrics/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/metrics/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/multiprocessing.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/multiprocessing.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/errors.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/errors.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/errors/error_handler.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/multiprocessing/errors/error_handler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/dynamic_rendezvous.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/dynamic_rendezvous.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_rendezvous.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_rendezvous.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_rendezvous_backend.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_server.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_server.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_store.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/rendezvous/etcd_store.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/timer/api.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/timer/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/timer/file_based_local_timer.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/timer/file_based_local_timer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/elastic/timer/local_timer.html
+++ b/docs/2.0/_modules/torch/distributed/elastic/timer/local_timer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/fsdp/api.html
+++ b/docs/2.0/_modules/torch/distributed/fsdp/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/fsdp/fully_sharded_data_parallel.html
+++ b/docs/2.0/_modules/torch/distributed/fsdp/fully_sharded_data_parallel.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/nn/api/remote_module.html
+++ b/docs/2.0/_modules/torch/distributed/nn/api/remote_module.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/optim/optimizer.html
+++ b/docs/2.0/_modules/torch/distributed/optim/optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/optim/post_localSGD_optimizer.html
+++ b/docs/2.0/_modules/torch/distributed/optim/post_localSGD_optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/optim/zero_redundancy_optimizer.html
+++ b/docs/2.0/_modules/torch/distributed/optim/zero_redundancy_optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/pipeline/sync/pipe.html
+++ b/docs/2.0/_modules/torch/distributed/pipeline/sync/pipe.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/pipeline/sync/skip/skippable.html
+++ b/docs/2.0/_modules/torch/distributed/pipeline/sync/skip/skippable.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/rpc.html
+++ b/docs/2.0/_modules/torch/distributed/rpc.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/rpc/api.html
+++ b/docs/2.0/_modules/torch/distributed/rpc/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/rpc/backend_registry.html
+++ b/docs/2.0/_modules/torch/distributed/rpc/backend_registry.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/rpc/functions.html
+++ b/docs/2.0/_modules/torch/distributed/rpc/functions.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/rpc/options.html
+++ b/docs/2.0/_modules/torch/distributed/rpc/options.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/tensor/parallel/api.html
+++ b/docs/2.0/_modules/torch/distributed/tensor/parallel/api.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/tensor/parallel/fsdp.html
+++ b/docs/2.0/_modules/torch/distributed/tensor/parallel/fsdp.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/tensor/parallel/multihead_attention_tp.html
+++ b/docs/2.0/_modules/torch/distributed/tensor/parallel/multihead_attention_tp.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributed/tensor/parallel/style.html
+++ b/docs/2.0/_modules/torch/distributed/tensor/parallel/style.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/bernoulli.html
+++ b/docs/2.0/_modules/torch/distributions/bernoulli.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/beta.html
+++ b/docs/2.0/_modules/torch/distributions/beta.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/binomial.html
+++ b/docs/2.0/_modules/torch/distributions/binomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/categorical.html
+++ b/docs/2.0/_modules/torch/distributions/categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/cauchy.html
+++ b/docs/2.0/_modules/torch/distributions/cauchy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/chi2.html
+++ b/docs/2.0/_modules/torch/distributions/chi2.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/constraint_registry.html
+++ b/docs/2.0/_modules/torch/distributions/constraint_registry.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/constraints.html
+++ b/docs/2.0/_modules/torch/distributions/constraints.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/continuous_bernoulli.html
+++ b/docs/2.0/_modules/torch/distributions/continuous_bernoulli.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/dirichlet.html
+++ b/docs/2.0/_modules/torch/distributions/dirichlet.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/distribution.html
+++ b/docs/2.0/_modules/torch/distributions/distribution.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/exp_family.html
+++ b/docs/2.0/_modules/torch/distributions/exp_family.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/exponential.html
+++ b/docs/2.0/_modules/torch/distributions/exponential.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/fishersnedecor.html
+++ b/docs/2.0/_modules/torch/distributions/fishersnedecor.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/gamma.html
+++ b/docs/2.0/_modules/torch/distributions/gamma.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/geometric.html
+++ b/docs/2.0/_modules/torch/distributions/geometric.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/gumbel.html
+++ b/docs/2.0/_modules/torch/distributions/gumbel.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/half_cauchy.html
+++ b/docs/2.0/_modules/torch/distributions/half_cauchy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/half_normal.html
+++ b/docs/2.0/_modules/torch/distributions/half_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/independent.html
+++ b/docs/2.0/_modules/torch/distributions/independent.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/kl.html
+++ b/docs/2.0/_modules/torch/distributions/kl.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/kumaraswamy.html
+++ b/docs/2.0/_modules/torch/distributions/kumaraswamy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/laplace.html
+++ b/docs/2.0/_modules/torch/distributions/laplace.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/lkj_cholesky.html
+++ b/docs/2.0/_modules/torch/distributions/lkj_cholesky.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/log_normal.html
+++ b/docs/2.0/_modules/torch/distributions/log_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/lowrank_multivariate_normal.html
+++ b/docs/2.0/_modules/torch/distributions/lowrank_multivariate_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/mixture_same_family.html
+++ b/docs/2.0/_modules/torch/distributions/mixture_same_family.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/multinomial.html
+++ b/docs/2.0/_modules/torch/distributions/multinomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/multivariate_normal.html
+++ b/docs/2.0/_modules/torch/distributions/multivariate_normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/negative_binomial.html
+++ b/docs/2.0/_modules/torch/distributions/negative_binomial.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/normal.html
+++ b/docs/2.0/_modules/torch/distributions/normal.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/one_hot_categorical.html
+++ b/docs/2.0/_modules/torch/distributions/one_hot_categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/pareto.html
+++ b/docs/2.0/_modules/torch/distributions/pareto.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/poisson.html
+++ b/docs/2.0/_modules/torch/distributions/poisson.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/relaxed_bernoulli.html
+++ b/docs/2.0/_modules/torch/distributions/relaxed_bernoulli.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/relaxed_categorical.html
+++ b/docs/2.0/_modules/torch/distributions/relaxed_categorical.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/studentT.html
+++ b/docs/2.0/_modules/torch/distributions/studentT.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/transformed_distribution.html
+++ b/docs/2.0/_modules/torch/distributions/transformed_distribution.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/transforms.html
+++ b/docs/2.0/_modules/torch/distributions/transforms.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/uniform.html
+++ b/docs/2.0/_modules/torch/distributions/uniform.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/utils.html
+++ b/docs/2.0/_modules/torch/distributions/utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/von_mises.html
+++ b/docs/2.0/_modules/torch/distributions/von_mises.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/weibull.html
+++ b/docs/2.0/_modules/torch/distributions/weibull.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/distributions/wishart.html
+++ b/docs/2.0/_modules/torch/distributions/wishart.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/func.html
+++ b/docs/2.0/_modules/torch/func.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/functional.html
+++ b/docs/2.0/_modules/torch/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/futures.html
+++ b/docs/2.0/_modules/torch/futures.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/_symbolic_trace.html
+++ b/docs/2.0/_modules/torch/fx/_symbolic_trace.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/graph.html
+++ b/docs/2.0/_modules/torch/fx/graph.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/graph_module.html
+++ b/docs/2.0/_modules/torch/fx/graph_module.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/interpreter.html
+++ b/docs/2.0/_modules/torch/fx/interpreter.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/node.html
+++ b/docs/2.0/_modules/torch/fx/node.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/proxy.html
+++ b/docs/2.0/_modules/torch/fx/proxy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/fx/subgraph_rewriter.html
+++ b/docs/2.0/_modules/torch/fx/subgraph_rewriter.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/hub.html
+++ b/docs/2.0/_modules/torch/hub.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit.html
+++ b/docs/2.0/_modules/torch/jit.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_async.html
+++ b/docs/2.0/_modules/torch/jit/_async.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_freeze.html
+++ b/docs/2.0/_modules/torch/jit/_freeze.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_fuser.html
+++ b/docs/2.0/_modules/torch/jit/_fuser.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_script.html
+++ b/docs/2.0/_modules/torch/jit/_script.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_serialization.html
+++ b/docs/2.0/_modules/torch/jit/_serialization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/jit/_trace.html
+++ b/docs/2.0/_modules/torch/jit/_trace.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/library.html
+++ b/docs/2.0/_modules/torch/library.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/monitor.html
+++ b/docs/2.0/_modules/torch/monitor.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/mps.html
+++ b/docs/2.0/_modules/torch/mps.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/multiprocessing.html
+++ b/docs/2.0/_modules/torch/multiprocessing.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/multiprocessing/spawn.html
+++ b/docs/2.0/_modules/torch/multiprocessing/spawn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nested.html
+++ b/docs/2.0/_modules/torch/nested.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/functional.html
+++ b/docs/2.0/_modules/torch/nn/functional.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/init.html
+++ b/docs/2.0/_modules/torch/nn/init.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/activation.html
+++ b/docs/2.0/_modules/torch/nn/modules/activation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/adaptive.html
+++ b/docs/2.0/_modules/torch/nn/modules/adaptive.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/batchnorm.html
+++ b/docs/2.0/_modules/torch/nn/modules/batchnorm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/channelshuffle.html
+++ b/docs/2.0/_modules/torch/nn/modules/channelshuffle.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/container.html
+++ b/docs/2.0/_modules/torch/nn/modules/container.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/conv.html
+++ b/docs/2.0/_modules/torch/nn/modules/conv.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/distance.html
+++ b/docs/2.0/_modules/torch/nn/modules/distance.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/dropout.html
+++ b/docs/2.0/_modules/torch/nn/modules/dropout.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/flatten.html
+++ b/docs/2.0/_modules/torch/nn/modules/flatten.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/fold.html
+++ b/docs/2.0/_modules/torch/nn/modules/fold.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/instancenorm.html
+++ b/docs/2.0/_modules/torch/nn/modules/instancenorm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/lazy.html
+++ b/docs/2.0/_modules/torch/nn/modules/lazy.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/linear.html
+++ b/docs/2.0/_modules/torch/nn/modules/linear.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/loss.html
+++ b/docs/2.0/_modules/torch/nn/modules/loss.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/module.html
+++ b/docs/2.0/_modules/torch/nn/modules/module.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/normalization.html
+++ b/docs/2.0/_modules/torch/nn/modules/normalization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/padding.html
+++ b/docs/2.0/_modules/torch/nn/modules/padding.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/pixelshuffle.html
+++ b/docs/2.0/_modules/torch/nn/modules/pixelshuffle.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/pooling.html
+++ b/docs/2.0/_modules/torch/nn/modules/pooling.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/rnn.html
+++ b/docs/2.0/_modules/torch/nn/modules/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/sparse.html
+++ b/docs/2.0/_modules/torch/nn/modules/sparse.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/transformer.html
+++ b/docs/2.0/_modules/torch/nn/modules/transformer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/modules/upsampling.html
+++ b/docs/2.0/_modules/torch/nn/modules/upsampling.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/parallel/comm.html
+++ b/docs/2.0/_modules/torch/nn/parallel/comm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/parallel/data_parallel.html
+++ b/docs/2.0/_modules/torch/nn/parallel/data_parallel.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/parallel/distributed.html
+++ b/docs/2.0/_modules/torch/nn/parallel/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/parameter.html
+++ b/docs/2.0/_modules/torch/nn/parameter.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/clip_grad.html
+++ b/docs/2.0/_modules/torch/nn/utils/clip_grad.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/convert_parameters.html
+++ b/docs/2.0/_modules/torch/nn/utils/convert_parameters.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/init.html
+++ b/docs/2.0/_modules/torch/nn/utils/init.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/parametrizations.html
+++ b/docs/2.0/_modules/torch/nn/utils/parametrizations.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/parametrize.html
+++ b/docs/2.0/_modules/torch/nn/utils/parametrize.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/prune.html
+++ b/docs/2.0/_modules/torch/nn/utils/prune.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/rnn.html
+++ b/docs/2.0/_modules/torch/nn/utils/rnn.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/spectral_norm.html
+++ b/docs/2.0/_modules/torch/nn/utils/spectral_norm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/stateless.html
+++ b/docs/2.0/_modules/torch/nn/utils/stateless.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/nn/utils/weight_norm.html
+++ b/docs/2.0/_modules/torch/nn/utils/weight_norm.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx.html
+++ b/docs/2.0/_modules/torch/onnx.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx/_internal/diagnostics/_diagnostic.html
+++ b/docs/2.0/_modules/torch/onnx/_internal/diagnostics/_diagnostic.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx/_internal/diagnostics/infra/engine.html
+++ b/docs/2.0/_modules/torch/onnx/_internal/diagnostics/infra/engine.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx/_type_utils.html
+++ b/docs/2.0/_modules/torch/onnx/_type_utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx/utils.html
+++ b/docs/2.0/_modules/torch/onnx/utils.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/onnx/verification.html
+++ b/docs/2.0/_modules/torch/onnx/verification.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/adadelta.html
+++ b/docs/2.0/_modules/torch/optim/adadelta.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/adagrad.html
+++ b/docs/2.0/_modules/torch/optim/adagrad.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/adam.html
+++ b/docs/2.0/_modules/torch/optim/adam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/adamax.html
+++ b/docs/2.0/_modules/torch/optim/adamax.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/adamw.html
+++ b/docs/2.0/_modules/torch/optim/adamw.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/asgd.html
+++ b/docs/2.0/_modules/torch/optim/asgd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/lbfgs.html
+++ b/docs/2.0/_modules/torch/optim/lbfgs.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/lr_scheduler.html
+++ b/docs/2.0/_modules/torch/optim/lr_scheduler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/nadam.html
+++ b/docs/2.0/_modules/torch/optim/nadam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/optimizer.html
+++ b/docs/2.0/_modules/torch/optim/optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/radam.html
+++ b/docs/2.0/_modules/torch/optim/radam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/rmsprop.html
+++ b/docs/2.0/_modules/torch/optim/rmsprop.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/rprop.html
+++ b/docs/2.0/_modules/torch/optim/rprop.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/sgd.html
+++ b/docs/2.0/_modules/torch/optim/sgd.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/optim/sparse_adam.html
+++ b/docs/2.0/_modules/torch/optim/sparse_adam.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/overrides.html
+++ b/docs/2.0/_modules/torch/overrides.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/package/file_structure_representation.html
+++ b/docs/2.0/_modules/torch/package/file_structure_representation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/package/package_exporter.html
+++ b/docs/2.0/_modules/torch/package/package_exporter.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/package/package_importer.html
+++ b/docs/2.0/_modules/torch/package/package_importer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/profiler/itt.html
+++ b/docs/2.0/_modules/torch/profiler/itt.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/profiler/profiler.html
+++ b/docs/2.0/_modules/torch/profiler/profiler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/quasirandom.html
+++ b/docs/2.0/_modules/torch/quasirandom.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/random.html
+++ b/docs/2.0/_modules/torch/random.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/serialization.html
+++ b/docs/2.0/_modules/torch/serialization.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/signal/windows/windows.html
+++ b/docs/2.0/_modules/torch/signal/windows/windows.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/sparse.html
+++ b/docs/2.0/_modules/torch/sparse.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/storage.html
+++ b/docs/2.0/_modules/torch/storage.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/testing/_comparison.html
+++ b/docs/2.0/_modules/torch/testing/_comparison.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/testing/_creation.html
+++ b/docs/2.0/_modules/torch/testing/_creation.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/benchmark/utils/common.html
+++ b/docs/2.0/_modules/torch/utils/benchmark/utils/common.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/benchmark/utils/timer.html
+++ b/docs/2.0/_modules/torch/utils/benchmark/utils/timer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.html
+++ b/docs/2.0/_modules/torch/utils/benchmark/utils/valgrind_wrapper/timer_interface.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/checkpoint.html
+++ b/docs/2.0/_modules/torch/utils/checkpoint.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/cpp_extension.html
+++ b/docs/2.0/_modules/torch/utils/cpp_extension.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/_utils/collate.html
+++ b/docs/2.0/_modules/torch/utils/data/_utils/collate.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/_utils/worker.html
+++ b/docs/2.0/_modules/torch/utils/data/_utils/worker.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/dataloader.html
+++ b/docs/2.0/_modules/torch/utils/data/dataloader.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/dataset.html
+++ b/docs/2.0/_modules/torch/utils/data/dataset.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/distributed.html
+++ b/docs/2.0/_modules/torch/utils/data/distributed.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/data/sampler.html
+++ b/docs/2.0/_modules/torch/utils/data/sampler.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/dlpack.html
+++ b/docs/2.0/_modules/torch/utils/dlpack.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/mobile_optimizer.html
+++ b/docs/2.0/_modules/torch/utils/mobile_optimizer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/torch/utils/tensorboard/writer.html
+++ b/docs/2.0/_modules/torch/utils/tensorboard/writer.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/_modules/typing.html
+++ b/docs/2.0/_modules/typing.html
@@ -6,6 +6,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/amp.html
+++ b/docs/2.0/amp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/autograd.html
+++ b/docs/2.0/autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/backends.html
+++ b/docs/2.0/backends.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/benchmark_utils.html
+++ b/docs/2.0/benchmark_utils.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/bottleneck.html
+++ b/docs/2.0/bottleneck.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/checkpoint.html
+++ b/docs/2.0/checkpoint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/community/build_ci_governance.html
+++ b/docs/2.0/community/build_ci_governance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/community/contribution_guide.html
+++ b/docs/2.0/community/contribution_guide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/community/design.html
+++ b/docs/2.0/community/design.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/community/governance.html
+++ b/docs/2.0/community/governance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/community/persons_of_interest.html
+++ b/docs/2.0/community/persons_of_interest.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/complex_numbers.html
+++ b/docs/2.0/complex_numbers.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/config_mod.html
+++ b/docs/2.0/config_mod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cpp_extension.html
+++ b/docs/2.0/cpp_extension.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cpp_index.html
+++ b/docs/2.0/cpp_index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cuda._sanitizer.html
+++ b/docs/2.0/cuda._sanitizer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cuda.html
+++ b/docs/2.0/cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cudnn_persistent_rnn.html
+++ b/docs/2.0/cudnn_persistent_rnn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/cudnn_rnn_determinism.html
+++ b/docs/2.0/cudnn_rnn_determinism.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/data.html
+++ b/docs/2.0/data.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/ddp_comm_hooks.html
+++ b/docs/2.0/ddp_comm_hooks.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/deploy.html
+++ b/docs/2.0/deploy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.algorithms.join.html
+++ b/docs/2.0/distributed.algorithms.join.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.checkpoint.html
+++ b/docs/2.0/distributed.checkpoint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.elastic.html
+++ b/docs/2.0/distributed.elastic.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.html
+++ b/docs/2.0/distributed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.optim.html
+++ b/docs/2.0/distributed.optim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributed.tensor.parallel.html
+++ b/docs/2.0/distributed.tensor.parallel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/distributions.html
+++ b/docs/2.0/distributions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dlpack.html
+++ b/docs/2.0/dlpack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/custom-backends.html
+++ b/docs/2.0/dynamo/custom-backends.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/deep-dive.html
+++ b/docs/2.0/dynamo/deep-dive.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/faq.html
+++ b/docs/2.0/dynamo/faq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/get-started.html
+++ b/docs/2.0/dynamo/get-started.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/guards-overview.html
+++ b/docs/2.0/dynamo/guards-overview.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/index.html
+++ b/docs/2.0/dynamo/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/installation.html
+++ b/docs/2.0/dynamo/installation.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/dynamo/troubleshooting.html
+++ b/docs/2.0/dynamo/troubleshooting.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/agent.html
+++ b/docs/2.0/elastic/agent.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/customization.html
+++ b/docs/2.0/elastic/customization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/errors.html
+++ b/docs/2.0/elastic/errors.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/events.html
+++ b/docs/2.0/elastic/events.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/examples.html
+++ b/docs/2.0/elastic/examples.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/kubernetes.html
+++ b/docs/2.0/elastic/kubernetes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/metrics.html
+++ b/docs/2.0/elastic/metrics.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/multiprocessing.html
+++ b/docs/2.0/elastic/multiprocessing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/quickstart.html
+++ b/docs/2.0/elastic/quickstart.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/rendezvous.html
+++ b/docs/2.0/elastic/rendezvous.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/run.html
+++ b/docs/2.0/elastic/run.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/timer.html
+++ b/docs/2.0/elastic/timer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/elastic/train_script.html
+++ b/docs/2.0/elastic/train_script.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/fft.html
+++ b/docs/2.0/fft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/fsdp.html
+++ b/docs/2.0/fsdp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.api.html
+++ b/docs/2.0/func.api.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.batch_norm.html
+++ b/docs/2.0/func.batch_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.html
+++ b/docs/2.0/func.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.migrating.html
+++ b/docs/2.0/func.migrating.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.ux_limitations.html
+++ b/docs/2.0/func.ux_limitations.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/func.whirlwind_tour.html
+++ b/docs/2.0/func.whirlwind_tour.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/futures.html
+++ b/docs/2.0/futures.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/fx.html
+++ b/docs/2.0/fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/DIAGSYS0001:arg-format-too-verbose.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/DIAGSYS0001:arg-format-too-verbose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0001:fx-tracer-success.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0001:fx-tracer-success.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0002:fx-tracer-failure.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0002:fx-tracer-failure.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0003:fx-frontend-aotautograd.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0003:fx-frontend-aotautograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0004:fx-pass-convert-neg-to-sigmoid.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0004:fx-pass-convert-neg-to-sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0005:fx-ir-add-node.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0005:fx-ir-add-node.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0006:atenlib-symbolic-function.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0006:atenlib-symbolic-function.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0007:atenlib-fx-to-onnx.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0007:atenlib-fx-to-onnx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0008:fx-node-to-onnx.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0008:fx-node-to-onnx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/FXE0009:fx-frontend-dynamo-make-fx.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/FXE0009:fx-frontend-dynamo-make-fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/POE0001:node-missing-onnx-shape-inference.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/POE0001:node-missing-onnx-shape-inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/POE0002:missing-custom-symbolic-function.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/POE0002:missing-custom-symbolic-function.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/POE0003:missing-standard-symbolic-function.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/POE0003:missing-standard-symbolic-function.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/onnx_diagnostics_rules/POE0004:operator-supported-in-newer-opset-version.html
+++ b/docs/2.0/generated/onnx_diagnostics_rules/POE0004:operator-supported-in-newer-opset-version.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Generator.html
+++ b/docs/2.0/generated/torch.Generator.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.abs.html
+++ b/docs/2.0/generated/torch.Tensor.abs.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.abs_.html
+++ b/docs/2.0/generated/torch.Tensor.abs_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.absolute.html
+++ b/docs/2.0/generated/torch.Tensor.absolute.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.absolute_.html
+++ b/docs/2.0/generated/torch.Tensor.absolute_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.acos.html
+++ b/docs/2.0/generated/torch.Tensor.acos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.acos_.html
+++ b/docs/2.0/generated/torch.Tensor.acos_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.acosh.html
+++ b/docs/2.0/generated/torch.Tensor.acosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.acosh_.html
+++ b/docs/2.0/generated/torch.Tensor.acosh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.add.html
+++ b/docs/2.0/generated/torch.Tensor.add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.add_.html
+++ b/docs/2.0/generated/torch.Tensor.add_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addbmm.html
+++ b/docs/2.0/generated/torch.Tensor.addbmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addbmm_.html
+++ b/docs/2.0/generated/torch.Tensor.addbmm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addcdiv.html
+++ b/docs/2.0/generated/torch.Tensor.addcdiv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addcdiv_.html
+++ b/docs/2.0/generated/torch.Tensor.addcdiv_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addcmul.html
+++ b/docs/2.0/generated/torch.Tensor.addcmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addcmul_.html
+++ b/docs/2.0/generated/torch.Tensor.addcmul_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addmm.html
+++ b/docs/2.0/generated/torch.Tensor.addmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addmm_.html
+++ b/docs/2.0/generated/torch.Tensor.addmm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addmv.html
+++ b/docs/2.0/generated/torch.Tensor.addmv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addmv_.html
+++ b/docs/2.0/generated/torch.Tensor.addmv_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addr.html
+++ b/docs/2.0/generated/torch.Tensor.addr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.addr_.html
+++ b/docs/2.0/generated/torch.Tensor.addr_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.adjoint.html
+++ b/docs/2.0/generated/torch.Tensor.adjoint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.all.html
+++ b/docs/2.0/generated/torch.Tensor.all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.allclose.html
+++ b/docs/2.0/generated/torch.Tensor.allclose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.amax.html
+++ b/docs/2.0/generated/torch.Tensor.amax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.amin.html
+++ b/docs/2.0/generated/torch.Tensor.amin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.aminmax.html
+++ b/docs/2.0/generated/torch.Tensor.aminmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.angle.html
+++ b/docs/2.0/generated/torch.Tensor.angle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.any.html
+++ b/docs/2.0/generated/torch.Tensor.any.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.apply_.html
+++ b/docs/2.0/generated/torch.Tensor.apply_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arccos.html
+++ b/docs/2.0/generated/torch.Tensor.arccos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arccos_.html
+++ b/docs/2.0/generated/torch.Tensor.arccos_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arccosh.html
+++ b/docs/2.0/generated/torch.Tensor.arccosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arccosh_.html
+++ b/docs/2.0/generated/torch.Tensor.arccosh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arcsin.html
+++ b/docs/2.0/generated/torch.Tensor.arcsin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arcsin_.html
+++ b/docs/2.0/generated/torch.Tensor.arcsin_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arcsinh.html
+++ b/docs/2.0/generated/torch.Tensor.arcsinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arcsinh_.html
+++ b/docs/2.0/generated/torch.Tensor.arcsinh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctan.html
+++ b/docs/2.0/generated/torch.Tensor.arctan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctan2.html
+++ b/docs/2.0/generated/torch.Tensor.arctan2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctan2_.html
+++ b/docs/2.0/generated/torch.Tensor.arctan2_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctan_.html
+++ b/docs/2.0/generated/torch.Tensor.arctan_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctanh.html
+++ b/docs/2.0/generated/torch.Tensor.arctanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.arctanh_.html
+++ b/docs/2.0/generated/torch.Tensor.arctanh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.argmax.html
+++ b/docs/2.0/generated/torch.Tensor.argmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.argmin.html
+++ b/docs/2.0/generated/torch.Tensor.argmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.argsort.html
+++ b/docs/2.0/generated/torch.Tensor.argsort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.argwhere.html
+++ b/docs/2.0/generated/torch.Tensor.argwhere.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.as_strided.html
+++ b/docs/2.0/generated/torch.Tensor.as_strided.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.as_subclass.html
+++ b/docs/2.0/generated/torch.Tensor.as_subclass.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.asin.html
+++ b/docs/2.0/generated/torch.Tensor.asin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.asin_.html
+++ b/docs/2.0/generated/torch.Tensor.asin_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.asinh.html
+++ b/docs/2.0/generated/torch.Tensor.asinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.asinh_.html
+++ b/docs/2.0/generated/torch.Tensor.asinh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atan.html
+++ b/docs/2.0/generated/torch.Tensor.atan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atan2.html
+++ b/docs/2.0/generated/torch.Tensor.atan2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atan2_.html
+++ b/docs/2.0/generated/torch.Tensor.atan2_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atan_.html
+++ b/docs/2.0/generated/torch.Tensor.atan_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atanh.html
+++ b/docs/2.0/generated/torch.Tensor.atanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.atanh_.html
+++ b/docs/2.0/generated/torch.Tensor.atanh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.backward.html
+++ b/docs/2.0/generated/torch.Tensor.backward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.baddbmm.html
+++ b/docs/2.0/generated/torch.Tensor.baddbmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.baddbmm_.html
+++ b/docs/2.0/generated/torch.Tensor.baddbmm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bernoulli.html
+++ b/docs/2.0/generated/torch.Tensor.bernoulli.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bernoulli_.html
+++ b/docs/2.0/generated/torch.Tensor.bernoulli_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bfloat16.html
+++ b/docs/2.0/generated/torch.Tensor.bfloat16.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bincount.html
+++ b/docs/2.0/generated/torch.Tensor.bincount.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_and.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_and.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_and_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_and_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_left_shift.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_left_shift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_left_shift_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_left_shift_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_not.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_not.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_not_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_not_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_or.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_or.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_or_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_or_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_right_shift.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_right_shift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_right_shift_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_right_shift_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_xor.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_xor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bitwise_xor_.html
+++ b/docs/2.0/generated/torch.Tensor.bitwise_xor_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bmm.html
+++ b/docs/2.0/generated/torch.Tensor.bmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.bool.html
+++ b/docs/2.0/generated/torch.Tensor.bool.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.broadcast_to.html
+++ b/docs/2.0/generated/torch.Tensor.broadcast_to.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.byte.html
+++ b/docs/2.0/generated/torch.Tensor.byte.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cauchy_.html
+++ b/docs/2.0/generated/torch.Tensor.cauchy_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ccol_indices.html
+++ b/docs/2.0/generated/torch.Tensor.ccol_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cdouble.html
+++ b/docs/2.0/generated/torch.Tensor.cdouble.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ceil.html
+++ b/docs/2.0/generated/torch.Tensor.ceil.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ceil_.html
+++ b/docs/2.0/generated/torch.Tensor.ceil_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cfloat.html
+++ b/docs/2.0/generated/torch.Tensor.cfloat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.chalf.html
+++ b/docs/2.0/generated/torch.Tensor.chalf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.char.html
+++ b/docs/2.0/generated/torch.Tensor.char.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cholesky.html
+++ b/docs/2.0/generated/torch.Tensor.cholesky.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cholesky_inverse.html
+++ b/docs/2.0/generated/torch.Tensor.cholesky_inverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cholesky_solve.html
+++ b/docs/2.0/generated/torch.Tensor.cholesky_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.chunk.html
+++ b/docs/2.0/generated/torch.Tensor.chunk.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.clamp.html
+++ b/docs/2.0/generated/torch.Tensor.clamp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.clamp_.html
+++ b/docs/2.0/generated/torch.Tensor.clamp_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.clip.html
+++ b/docs/2.0/generated/torch.Tensor.clip.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.clip_.html
+++ b/docs/2.0/generated/torch.Tensor.clip_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.clone.html
+++ b/docs/2.0/generated/torch.Tensor.clone.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.coalesce.html
+++ b/docs/2.0/generated/torch.Tensor.coalesce.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.col_indices.html
+++ b/docs/2.0/generated/torch.Tensor.col_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.conj.html
+++ b/docs/2.0/generated/torch.Tensor.conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.conj_physical.html
+++ b/docs/2.0/generated/torch.Tensor.conj_physical.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.conj_physical_.html
+++ b/docs/2.0/generated/torch.Tensor.conj_physical_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.contiguous.html
+++ b/docs/2.0/generated/torch.Tensor.contiguous.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.copy_.html
+++ b/docs/2.0/generated/torch.Tensor.copy_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.copysign.html
+++ b/docs/2.0/generated/torch.Tensor.copysign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.copysign_.html
+++ b/docs/2.0/generated/torch.Tensor.copysign_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.corrcoef.html
+++ b/docs/2.0/generated/torch.Tensor.corrcoef.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cos.html
+++ b/docs/2.0/generated/torch.Tensor.cos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cos_.html
+++ b/docs/2.0/generated/torch.Tensor.cos_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cosh.html
+++ b/docs/2.0/generated/torch.Tensor.cosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cosh_.html
+++ b/docs/2.0/generated/torch.Tensor.cosh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.count_nonzero.html
+++ b/docs/2.0/generated/torch.Tensor.count_nonzero.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cov.html
+++ b/docs/2.0/generated/torch.Tensor.cov.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cpu.html
+++ b/docs/2.0/generated/torch.Tensor.cpu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cross.html
+++ b/docs/2.0/generated/torch.Tensor.cross.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.crow_indices.html
+++ b/docs/2.0/generated/torch.Tensor.crow_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cuda.html
+++ b/docs/2.0/generated/torch.Tensor.cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cummax.html
+++ b/docs/2.0/generated/torch.Tensor.cummax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cummin.html
+++ b/docs/2.0/generated/torch.Tensor.cummin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cumprod.html
+++ b/docs/2.0/generated/torch.Tensor.cumprod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cumprod_.html
+++ b/docs/2.0/generated/torch.Tensor.cumprod_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cumsum.html
+++ b/docs/2.0/generated/torch.Tensor.cumsum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.cumsum_.html
+++ b/docs/2.0/generated/torch.Tensor.cumsum_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.data_ptr.html
+++ b/docs/2.0/generated/torch.Tensor.data_ptr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.deg2rad.html
+++ b/docs/2.0/generated/torch.Tensor.deg2rad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dense_dim.html
+++ b/docs/2.0/generated/torch.Tensor.dense_dim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dequantize.html
+++ b/docs/2.0/generated/torch.Tensor.dequantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.det.html
+++ b/docs/2.0/generated/torch.Tensor.det.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.detach.html
+++ b/docs/2.0/generated/torch.Tensor.detach.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.detach_.html
+++ b/docs/2.0/generated/torch.Tensor.detach_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.device.html
+++ b/docs/2.0/generated/torch.Tensor.device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diag.html
+++ b/docs/2.0/generated/torch.Tensor.diag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diag_embed.html
+++ b/docs/2.0/generated/torch.Tensor.diag_embed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diagflat.html
+++ b/docs/2.0/generated/torch.Tensor.diagflat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diagonal.html
+++ b/docs/2.0/generated/torch.Tensor.diagonal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diagonal_scatter.html
+++ b/docs/2.0/generated/torch.Tensor.diagonal_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.diff.html
+++ b/docs/2.0/generated/torch.Tensor.diff.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.digamma.html
+++ b/docs/2.0/generated/torch.Tensor.digamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.digamma_.html
+++ b/docs/2.0/generated/torch.Tensor.digamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dim.html
+++ b/docs/2.0/generated/torch.Tensor.dim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dist.html
+++ b/docs/2.0/generated/torch.Tensor.dist.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.div.html
+++ b/docs/2.0/generated/torch.Tensor.div.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.div_.html
+++ b/docs/2.0/generated/torch.Tensor.div_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.divide.html
+++ b/docs/2.0/generated/torch.Tensor.divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.divide_.html
+++ b/docs/2.0/generated/torch.Tensor.divide_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dot.html
+++ b/docs/2.0/generated/torch.Tensor.dot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.double.html
+++ b/docs/2.0/generated/torch.Tensor.double.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.dsplit.html
+++ b/docs/2.0/generated/torch.Tensor.dsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.element_size.html
+++ b/docs/2.0/generated/torch.Tensor.element_size.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.eq.html
+++ b/docs/2.0/generated/torch.Tensor.eq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.eq_.html
+++ b/docs/2.0/generated/torch.Tensor.eq_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.equal.html
+++ b/docs/2.0/generated/torch.Tensor.equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erf.html
+++ b/docs/2.0/generated/torch.Tensor.erf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erf_.html
+++ b/docs/2.0/generated/torch.Tensor.erf_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erfc.html
+++ b/docs/2.0/generated/torch.Tensor.erfc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erfc_.html
+++ b/docs/2.0/generated/torch.Tensor.erfc_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erfinv.html
+++ b/docs/2.0/generated/torch.Tensor.erfinv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.erfinv_.html
+++ b/docs/2.0/generated/torch.Tensor.erfinv_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.exp.html
+++ b/docs/2.0/generated/torch.Tensor.exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.exp_.html
+++ b/docs/2.0/generated/torch.Tensor.exp_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.expand.html
+++ b/docs/2.0/generated/torch.Tensor.expand.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.expand_as.html
+++ b/docs/2.0/generated/torch.Tensor.expand_as.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.expm1.html
+++ b/docs/2.0/generated/torch.Tensor.expm1.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.expm1_.html
+++ b/docs/2.0/generated/torch.Tensor.expm1_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.exponential_.html
+++ b/docs/2.0/generated/torch.Tensor.exponential_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fill_.html
+++ b/docs/2.0/generated/torch.Tensor.fill_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fill_diagonal_.html
+++ b/docs/2.0/generated/torch.Tensor.fill_diagonal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fix.html
+++ b/docs/2.0/generated/torch.Tensor.fix.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fix_.html
+++ b/docs/2.0/generated/torch.Tensor.fix_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.flatten.html
+++ b/docs/2.0/generated/torch.Tensor.flatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.flip.html
+++ b/docs/2.0/generated/torch.Tensor.flip.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fliplr.html
+++ b/docs/2.0/generated/torch.Tensor.fliplr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.flipud.html
+++ b/docs/2.0/generated/torch.Tensor.flipud.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.float.html
+++ b/docs/2.0/generated/torch.Tensor.float.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.float_power.html
+++ b/docs/2.0/generated/torch.Tensor.float_power.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.float_power_.html
+++ b/docs/2.0/generated/torch.Tensor.float_power_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.floor.html
+++ b/docs/2.0/generated/torch.Tensor.floor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.floor_.html
+++ b/docs/2.0/generated/torch.Tensor.floor_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.floor_divide.html
+++ b/docs/2.0/generated/torch.Tensor.floor_divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.floor_divide_.html
+++ b/docs/2.0/generated/torch.Tensor.floor_divide_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fmax.html
+++ b/docs/2.0/generated/torch.Tensor.fmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fmin.html
+++ b/docs/2.0/generated/torch.Tensor.fmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fmod.html
+++ b/docs/2.0/generated/torch.Tensor.fmod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.fmod_.html
+++ b/docs/2.0/generated/torch.Tensor.fmod_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.frac.html
+++ b/docs/2.0/generated/torch.Tensor.frac.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.frac_.html
+++ b/docs/2.0/generated/torch.Tensor.frac_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.frexp.html
+++ b/docs/2.0/generated/torch.Tensor.frexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.gather.html
+++ b/docs/2.0/generated/torch.Tensor.gather.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.gcd.html
+++ b/docs/2.0/generated/torch.Tensor.gcd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.gcd_.html
+++ b/docs/2.0/generated/torch.Tensor.gcd_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ge.html
+++ b/docs/2.0/generated/torch.Tensor.ge.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ge_.html
+++ b/docs/2.0/generated/torch.Tensor.ge_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.geometric_.html
+++ b/docs/2.0/generated/torch.Tensor.geometric_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.geqrf.html
+++ b/docs/2.0/generated/torch.Tensor.geqrf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ger.html
+++ b/docs/2.0/generated/torch.Tensor.ger.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.get_device.html
+++ b/docs/2.0/generated/torch.Tensor.get_device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.grad.html
+++ b/docs/2.0/generated/torch.Tensor.grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.greater.html
+++ b/docs/2.0/generated/torch.Tensor.greater.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.greater_.html
+++ b/docs/2.0/generated/torch.Tensor.greater_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.greater_equal.html
+++ b/docs/2.0/generated/torch.Tensor.greater_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.greater_equal_.html
+++ b/docs/2.0/generated/torch.Tensor.greater_equal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.gt.html
+++ b/docs/2.0/generated/torch.Tensor.gt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.gt_.html
+++ b/docs/2.0/generated/torch.Tensor.gt_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.half.html
+++ b/docs/2.0/generated/torch.Tensor.half.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.hardshrink.html
+++ b/docs/2.0/generated/torch.Tensor.hardshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.heaviside.html
+++ b/docs/2.0/generated/torch.Tensor.heaviside.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.histc.html
+++ b/docs/2.0/generated/torch.Tensor.histc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.histogram.html
+++ b/docs/2.0/generated/torch.Tensor.histogram.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.hsplit.html
+++ b/docs/2.0/generated/torch.Tensor.hsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.hypot.html
+++ b/docs/2.0/generated/torch.Tensor.hypot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.hypot_.html
+++ b/docs/2.0/generated/torch.Tensor.hypot_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.i0.html
+++ b/docs/2.0/generated/torch.Tensor.i0.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.i0_.html
+++ b/docs/2.0/generated/torch.Tensor.i0_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.igamma.html
+++ b/docs/2.0/generated/torch.Tensor.igamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.igamma_.html
+++ b/docs/2.0/generated/torch.Tensor.igamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.igammac.html
+++ b/docs/2.0/generated/torch.Tensor.igammac.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.igammac_.html
+++ b/docs/2.0/generated/torch.Tensor.igammac_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.imag.html
+++ b/docs/2.0/generated/torch.Tensor.imag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_add.html
+++ b/docs/2.0/generated/torch.Tensor.index_add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_add_.html
+++ b/docs/2.0/generated/torch.Tensor.index_add_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_copy.html
+++ b/docs/2.0/generated/torch.Tensor.index_copy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_copy_.html
+++ b/docs/2.0/generated/torch.Tensor.index_copy_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_fill.html
+++ b/docs/2.0/generated/torch.Tensor.index_fill.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_fill_.html
+++ b/docs/2.0/generated/torch.Tensor.index_fill_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_put.html
+++ b/docs/2.0/generated/torch.Tensor.index_put.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_put_.html
+++ b/docs/2.0/generated/torch.Tensor.index_put_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_reduce.html
+++ b/docs/2.0/generated/torch.Tensor.index_reduce.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_reduce_.html
+++ b/docs/2.0/generated/torch.Tensor.index_reduce_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.index_select.html
+++ b/docs/2.0/generated/torch.Tensor.index_select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.indices.html
+++ b/docs/2.0/generated/torch.Tensor.indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.inner.html
+++ b/docs/2.0/generated/torch.Tensor.inner.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.int.html
+++ b/docs/2.0/generated/torch.Tensor.int.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.int_repr.html
+++ b/docs/2.0/generated/torch.Tensor.int_repr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.inverse.html
+++ b/docs/2.0/generated/torch.Tensor.inverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_coalesced.html
+++ b/docs/2.0/generated/torch.Tensor.is_coalesced.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_complex.html
+++ b/docs/2.0/generated/torch.Tensor.is_complex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_conj.html
+++ b/docs/2.0/generated/torch.Tensor.is_conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_contiguous.html
+++ b/docs/2.0/generated/torch.Tensor.is_contiguous.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_cuda.html
+++ b/docs/2.0/generated/torch.Tensor.is_cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_floating_point.html
+++ b/docs/2.0/generated/torch.Tensor.is_floating_point.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_inference.html
+++ b/docs/2.0/generated/torch.Tensor.is_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_leaf.html
+++ b/docs/2.0/generated/torch.Tensor.is_leaf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_meta.html
+++ b/docs/2.0/generated/torch.Tensor.is_meta.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_pinned.html
+++ b/docs/2.0/generated/torch.Tensor.is_pinned.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_quantized.html
+++ b/docs/2.0/generated/torch.Tensor.is_quantized.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_set_to.html
+++ b/docs/2.0/generated/torch.Tensor.is_set_to.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_shared.html
+++ b/docs/2.0/generated/torch.Tensor.is_shared.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_signed.html
+++ b/docs/2.0/generated/torch.Tensor.is_signed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_sparse.html
+++ b/docs/2.0/generated/torch.Tensor.is_sparse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.is_sparse_csr.html
+++ b/docs/2.0/generated/torch.Tensor.is_sparse_csr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isclose.html
+++ b/docs/2.0/generated/torch.Tensor.isclose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isfinite.html
+++ b/docs/2.0/generated/torch.Tensor.isfinite.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isinf.html
+++ b/docs/2.0/generated/torch.Tensor.isinf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isnan.html
+++ b/docs/2.0/generated/torch.Tensor.isnan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isneginf.html
+++ b/docs/2.0/generated/torch.Tensor.isneginf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isposinf.html
+++ b/docs/2.0/generated/torch.Tensor.isposinf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.isreal.html
+++ b/docs/2.0/generated/torch.Tensor.isreal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.istft.html
+++ b/docs/2.0/generated/torch.Tensor.istft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.item.html
+++ b/docs/2.0/generated/torch.Tensor.item.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.kthvalue.html
+++ b/docs/2.0/generated/torch.Tensor.kthvalue.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lcm.html
+++ b/docs/2.0/generated/torch.Tensor.lcm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lcm_.html
+++ b/docs/2.0/generated/torch.Tensor.lcm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ldexp.html
+++ b/docs/2.0/generated/torch.Tensor.ldexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ldexp_.html
+++ b/docs/2.0/generated/torch.Tensor.ldexp_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.le.html
+++ b/docs/2.0/generated/torch.Tensor.le.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.le_.html
+++ b/docs/2.0/generated/torch.Tensor.le_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lerp.html
+++ b/docs/2.0/generated/torch.Tensor.lerp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lerp_.html
+++ b/docs/2.0/generated/torch.Tensor.lerp_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.less.html
+++ b/docs/2.0/generated/torch.Tensor.less.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.less_.html
+++ b/docs/2.0/generated/torch.Tensor.less_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.less_equal.html
+++ b/docs/2.0/generated/torch.Tensor.less_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.less_equal_.html
+++ b/docs/2.0/generated/torch.Tensor.less_equal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lgamma.html
+++ b/docs/2.0/generated/torch.Tensor.lgamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lgamma_.html
+++ b/docs/2.0/generated/torch.Tensor.lgamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log.html
+++ b/docs/2.0/generated/torch.Tensor.log.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log10.html
+++ b/docs/2.0/generated/torch.Tensor.log10.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log10_.html
+++ b/docs/2.0/generated/torch.Tensor.log10_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log1p.html
+++ b/docs/2.0/generated/torch.Tensor.log1p.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log1p_.html
+++ b/docs/2.0/generated/torch.Tensor.log1p_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log2.html
+++ b/docs/2.0/generated/torch.Tensor.log2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log2_.html
+++ b/docs/2.0/generated/torch.Tensor.log2_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log_.html
+++ b/docs/2.0/generated/torch.Tensor.log_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.log_normal_.html
+++ b/docs/2.0/generated/torch.Tensor.log_normal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logaddexp.html
+++ b/docs/2.0/generated/torch.Tensor.logaddexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logaddexp2.html
+++ b/docs/2.0/generated/torch.Tensor.logaddexp2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logcumsumexp.html
+++ b/docs/2.0/generated/torch.Tensor.logcumsumexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logdet.html
+++ b/docs/2.0/generated/torch.Tensor.logdet.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_and.html
+++ b/docs/2.0/generated/torch.Tensor.logical_and.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_and_.html
+++ b/docs/2.0/generated/torch.Tensor.logical_and_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_not.html
+++ b/docs/2.0/generated/torch.Tensor.logical_not.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_not_.html
+++ b/docs/2.0/generated/torch.Tensor.logical_not_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_or.html
+++ b/docs/2.0/generated/torch.Tensor.logical_or.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_or_.html
+++ b/docs/2.0/generated/torch.Tensor.logical_or_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_xor.html
+++ b/docs/2.0/generated/torch.Tensor.logical_xor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logical_xor_.html
+++ b/docs/2.0/generated/torch.Tensor.logical_xor_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logit.html
+++ b/docs/2.0/generated/torch.Tensor.logit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logit_.html
+++ b/docs/2.0/generated/torch.Tensor.logit_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.logsumexp.html
+++ b/docs/2.0/generated/torch.Tensor.logsumexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.long.html
+++ b/docs/2.0/generated/torch.Tensor.long.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lt.html
+++ b/docs/2.0/generated/torch.Tensor.lt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lt_.html
+++ b/docs/2.0/generated/torch.Tensor.lt_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lu.html
+++ b/docs/2.0/generated/torch.Tensor.lu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.lu_solve.html
+++ b/docs/2.0/generated/torch.Tensor.lu_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.map_.html
+++ b/docs/2.0/generated/torch.Tensor.map_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.masked_fill.html
+++ b/docs/2.0/generated/torch.Tensor.masked_fill.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.masked_fill_.html
+++ b/docs/2.0/generated/torch.Tensor.masked_fill_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.masked_scatter.html
+++ b/docs/2.0/generated/torch.Tensor.masked_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.masked_scatter_.html
+++ b/docs/2.0/generated/torch.Tensor.masked_scatter_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.masked_select.html
+++ b/docs/2.0/generated/torch.Tensor.masked_select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.matmul.html
+++ b/docs/2.0/generated/torch.Tensor.matmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.matrix_exp.html
+++ b/docs/2.0/generated/torch.Tensor.matrix_exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.matrix_power.html
+++ b/docs/2.0/generated/torch.Tensor.matrix_power.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.max.html
+++ b/docs/2.0/generated/torch.Tensor.max.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.maximum.html
+++ b/docs/2.0/generated/torch.Tensor.maximum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mean.html
+++ b/docs/2.0/generated/torch.Tensor.mean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.median.html
+++ b/docs/2.0/generated/torch.Tensor.median.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.min.html
+++ b/docs/2.0/generated/torch.Tensor.min.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.minimum.html
+++ b/docs/2.0/generated/torch.Tensor.minimum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mm.html
+++ b/docs/2.0/generated/torch.Tensor.mm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mode.html
+++ b/docs/2.0/generated/torch.Tensor.mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.moveaxis.html
+++ b/docs/2.0/generated/torch.Tensor.moveaxis.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.movedim.html
+++ b/docs/2.0/generated/torch.Tensor.movedim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.msort.html
+++ b/docs/2.0/generated/torch.Tensor.msort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mul.html
+++ b/docs/2.0/generated/torch.Tensor.mul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mul_.html
+++ b/docs/2.0/generated/torch.Tensor.mul_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.multinomial.html
+++ b/docs/2.0/generated/torch.Tensor.multinomial.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.multiply.html
+++ b/docs/2.0/generated/torch.Tensor.multiply.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.multiply_.html
+++ b/docs/2.0/generated/torch.Tensor.multiply_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mv.html
+++ b/docs/2.0/generated/torch.Tensor.mv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mvlgamma.html
+++ b/docs/2.0/generated/torch.Tensor.mvlgamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.mvlgamma_.html
+++ b/docs/2.0/generated/torch.Tensor.mvlgamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nan_to_num.html
+++ b/docs/2.0/generated/torch.Tensor.nan_to_num.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nan_to_num_.html
+++ b/docs/2.0/generated/torch.Tensor.nan_to_num_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nanmean.html
+++ b/docs/2.0/generated/torch.Tensor.nanmean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nanmedian.html
+++ b/docs/2.0/generated/torch.Tensor.nanmedian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nanquantile.html
+++ b/docs/2.0/generated/torch.Tensor.nanquantile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nansum.html
+++ b/docs/2.0/generated/torch.Tensor.nansum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.narrow.html
+++ b/docs/2.0/generated/torch.Tensor.narrow.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.narrow_copy.html
+++ b/docs/2.0/generated/torch.Tensor.narrow_copy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ndim.html
+++ b/docs/2.0/generated/torch.Tensor.ndim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ndimension.html
+++ b/docs/2.0/generated/torch.Tensor.ndimension.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ne.html
+++ b/docs/2.0/generated/torch.Tensor.ne.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ne_.html
+++ b/docs/2.0/generated/torch.Tensor.ne_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.neg.html
+++ b/docs/2.0/generated/torch.Tensor.neg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.neg_.html
+++ b/docs/2.0/generated/torch.Tensor.neg_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.negative.html
+++ b/docs/2.0/generated/torch.Tensor.negative.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.negative_.html
+++ b/docs/2.0/generated/torch.Tensor.negative_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nelement.html
+++ b/docs/2.0/generated/torch.Tensor.nelement.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.new_empty.html
+++ b/docs/2.0/generated/torch.Tensor.new_empty.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.new_full.html
+++ b/docs/2.0/generated/torch.Tensor.new_full.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.new_ones.html
+++ b/docs/2.0/generated/torch.Tensor.new_ones.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.new_tensor.html
+++ b/docs/2.0/generated/torch.Tensor.new_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.new_zeros.html
+++ b/docs/2.0/generated/torch.Tensor.new_zeros.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nextafter.html
+++ b/docs/2.0/generated/torch.Tensor.nextafter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nextafter_.html
+++ b/docs/2.0/generated/torch.Tensor.nextafter_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.nonzero.html
+++ b/docs/2.0/generated/torch.Tensor.nonzero.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.norm.html
+++ b/docs/2.0/generated/torch.Tensor.norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.normal_.html
+++ b/docs/2.0/generated/torch.Tensor.normal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.not_equal.html
+++ b/docs/2.0/generated/torch.Tensor.not_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.not_equal_.html
+++ b/docs/2.0/generated/torch.Tensor.not_equal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.numel.html
+++ b/docs/2.0/generated/torch.Tensor.numel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.numpy.html
+++ b/docs/2.0/generated/torch.Tensor.numpy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.orgqr.html
+++ b/docs/2.0/generated/torch.Tensor.orgqr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ormqr.html
+++ b/docs/2.0/generated/torch.Tensor.ormqr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.outer.html
+++ b/docs/2.0/generated/torch.Tensor.outer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.permute.html
+++ b/docs/2.0/generated/torch.Tensor.permute.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.pin_memory.html
+++ b/docs/2.0/generated/torch.Tensor.pin_memory.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.pinverse.html
+++ b/docs/2.0/generated/torch.Tensor.pinverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.polygamma.html
+++ b/docs/2.0/generated/torch.Tensor.polygamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.polygamma_.html
+++ b/docs/2.0/generated/torch.Tensor.polygamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.positive.html
+++ b/docs/2.0/generated/torch.Tensor.positive.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.pow.html
+++ b/docs/2.0/generated/torch.Tensor.pow.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.pow_.html
+++ b/docs/2.0/generated/torch.Tensor.pow_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.prod.html
+++ b/docs/2.0/generated/torch.Tensor.prod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.put_.html
+++ b/docs/2.0/generated/torch.Tensor.put_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.q_per_channel_axis.html
+++ b/docs/2.0/generated/torch.Tensor.q_per_channel_axis.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.q_per_channel_scales.html
+++ b/docs/2.0/generated/torch.Tensor.q_per_channel_scales.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.q_per_channel_zero_points.html
+++ b/docs/2.0/generated/torch.Tensor.q_per_channel_zero_points.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.q_scale.html
+++ b/docs/2.0/generated/torch.Tensor.q_scale.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.q_zero_point.html
+++ b/docs/2.0/generated/torch.Tensor.q_zero_point.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.qr.html
+++ b/docs/2.0/generated/torch.Tensor.qr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.qscheme.html
+++ b/docs/2.0/generated/torch.Tensor.qscheme.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.quantile.html
+++ b/docs/2.0/generated/torch.Tensor.quantile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.rad2deg.html
+++ b/docs/2.0/generated/torch.Tensor.rad2deg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.random_.html
+++ b/docs/2.0/generated/torch.Tensor.random_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.ravel.html
+++ b/docs/2.0/generated/torch.Tensor.ravel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.real.html
+++ b/docs/2.0/generated/torch.Tensor.real.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.reciprocal.html
+++ b/docs/2.0/generated/torch.Tensor.reciprocal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.reciprocal_.html
+++ b/docs/2.0/generated/torch.Tensor.reciprocal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.record_stream.html
+++ b/docs/2.0/generated/torch.Tensor.record_stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.register_hook.html
+++ b/docs/2.0/generated/torch.Tensor.register_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.remainder.html
+++ b/docs/2.0/generated/torch.Tensor.remainder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.remainder_.html
+++ b/docs/2.0/generated/torch.Tensor.remainder_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.renorm.html
+++ b/docs/2.0/generated/torch.Tensor.renorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.renorm_.html
+++ b/docs/2.0/generated/torch.Tensor.renorm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.repeat.html
+++ b/docs/2.0/generated/torch.Tensor.repeat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.repeat_interleave.html
+++ b/docs/2.0/generated/torch.Tensor.repeat_interleave.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.requires_grad.html
+++ b/docs/2.0/generated/torch.Tensor.requires_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.requires_grad_.html
+++ b/docs/2.0/generated/torch.Tensor.requires_grad_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.reshape.html
+++ b/docs/2.0/generated/torch.Tensor.reshape.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.reshape_as.html
+++ b/docs/2.0/generated/torch.Tensor.reshape_as.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.resize_.html
+++ b/docs/2.0/generated/torch.Tensor.resize_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.resize_as_.html
+++ b/docs/2.0/generated/torch.Tensor.resize_as_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.resolve_conj.html
+++ b/docs/2.0/generated/torch.Tensor.resolve_conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.resolve_neg.html
+++ b/docs/2.0/generated/torch.Tensor.resolve_neg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.retain_grad.html
+++ b/docs/2.0/generated/torch.Tensor.retain_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.retains_grad.html
+++ b/docs/2.0/generated/torch.Tensor.retains_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.roll.html
+++ b/docs/2.0/generated/torch.Tensor.roll.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.rot90.html
+++ b/docs/2.0/generated/torch.Tensor.rot90.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.round.html
+++ b/docs/2.0/generated/torch.Tensor.round.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.round_.html
+++ b/docs/2.0/generated/torch.Tensor.round_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.row_indices.html
+++ b/docs/2.0/generated/torch.Tensor.row_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.rsqrt.html
+++ b/docs/2.0/generated/torch.Tensor.rsqrt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.rsqrt_.html
+++ b/docs/2.0/generated/torch.Tensor.rsqrt_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter.html
+++ b/docs/2.0/generated/torch.Tensor.scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter_.html
+++ b/docs/2.0/generated/torch.Tensor.scatter_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter_add.html
+++ b/docs/2.0/generated/torch.Tensor.scatter_add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter_add_.html
+++ b/docs/2.0/generated/torch.Tensor.scatter_add_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter_reduce.html
+++ b/docs/2.0/generated/torch.Tensor.scatter_reduce.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.scatter_reduce_.html
+++ b/docs/2.0/generated/torch.Tensor.scatter_reduce_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.select.html
+++ b/docs/2.0/generated/torch.Tensor.select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.select_scatter.html
+++ b/docs/2.0/generated/torch.Tensor.select_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.set_.html
+++ b/docs/2.0/generated/torch.Tensor.set_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sgn.html
+++ b/docs/2.0/generated/torch.Tensor.sgn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sgn_.html
+++ b/docs/2.0/generated/torch.Tensor.sgn_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.share_memory_.html
+++ b/docs/2.0/generated/torch.Tensor.share_memory_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.short.html
+++ b/docs/2.0/generated/torch.Tensor.short.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sigmoid.html
+++ b/docs/2.0/generated/torch.Tensor.sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sigmoid_.html
+++ b/docs/2.0/generated/torch.Tensor.sigmoid_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sign.html
+++ b/docs/2.0/generated/torch.Tensor.sign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sign_.html
+++ b/docs/2.0/generated/torch.Tensor.sign_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.signbit.html
+++ b/docs/2.0/generated/torch.Tensor.signbit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sin.html
+++ b/docs/2.0/generated/torch.Tensor.sin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sin_.html
+++ b/docs/2.0/generated/torch.Tensor.sin_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sinc.html
+++ b/docs/2.0/generated/torch.Tensor.sinc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sinc_.html
+++ b/docs/2.0/generated/torch.Tensor.sinc_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sinh.html
+++ b/docs/2.0/generated/torch.Tensor.sinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sinh_.html
+++ b/docs/2.0/generated/torch.Tensor.sinh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.size.html
+++ b/docs/2.0/generated/torch.Tensor.size.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.slice_scatter.html
+++ b/docs/2.0/generated/torch.Tensor.slice_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.slogdet.html
+++ b/docs/2.0/generated/torch.Tensor.slogdet.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.smm.html
+++ b/docs/2.0/generated/torch.Tensor.smm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.softmax.html
+++ b/docs/2.0/generated/torch.Tensor.softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sort.html
+++ b/docs/2.0/generated/torch.Tensor.sort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sparse_dim.html
+++ b/docs/2.0/generated/torch.Tensor.sparse_dim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sparse_mask.html
+++ b/docs/2.0/generated/torch.Tensor.sparse_mask.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sparse_resize_.html
+++ b/docs/2.0/generated/torch.Tensor.sparse_resize_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sparse_resize_and_clear_.html
+++ b/docs/2.0/generated/torch.Tensor.sparse_resize_and_clear_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.split.html
+++ b/docs/2.0/generated/torch.Tensor.split.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sqrt.html
+++ b/docs/2.0/generated/torch.Tensor.sqrt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sqrt_.html
+++ b/docs/2.0/generated/torch.Tensor.sqrt_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.square.html
+++ b/docs/2.0/generated/torch.Tensor.square.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.square_.html
+++ b/docs/2.0/generated/torch.Tensor.square_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.squeeze.html
+++ b/docs/2.0/generated/torch.Tensor.squeeze.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.squeeze_.html
+++ b/docs/2.0/generated/torch.Tensor.squeeze_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sspaddmm.html
+++ b/docs/2.0/generated/torch.Tensor.sspaddmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.std.html
+++ b/docs/2.0/generated/torch.Tensor.std.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.stft.html
+++ b/docs/2.0/generated/torch.Tensor.stft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.storage.html
+++ b/docs/2.0/generated/torch.Tensor.storage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.storage_offset.html
+++ b/docs/2.0/generated/torch.Tensor.storage_offset.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.storage_type.html
+++ b/docs/2.0/generated/torch.Tensor.storage_type.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.stride.html
+++ b/docs/2.0/generated/torch.Tensor.stride.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sub.html
+++ b/docs/2.0/generated/torch.Tensor.sub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sub_.html
+++ b/docs/2.0/generated/torch.Tensor.sub_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.subtract.html
+++ b/docs/2.0/generated/torch.Tensor.subtract.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.subtract_.html
+++ b/docs/2.0/generated/torch.Tensor.subtract_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sum.html
+++ b/docs/2.0/generated/torch.Tensor.sum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.sum_to_size.html
+++ b/docs/2.0/generated/torch.Tensor.sum_to_size.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.svd.html
+++ b/docs/2.0/generated/torch.Tensor.svd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.swapaxes.html
+++ b/docs/2.0/generated/torch.Tensor.swapaxes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.swapdims.html
+++ b/docs/2.0/generated/torch.Tensor.swapdims.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.t.html
+++ b/docs/2.0/generated/torch.Tensor.t.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.t_.html
+++ b/docs/2.0/generated/torch.Tensor.t_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.take.html
+++ b/docs/2.0/generated/torch.Tensor.take.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.take_along_dim.html
+++ b/docs/2.0/generated/torch.Tensor.take_along_dim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tan.html
+++ b/docs/2.0/generated/torch.Tensor.tan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tan_.html
+++ b/docs/2.0/generated/torch.Tensor.tan_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tanh.html
+++ b/docs/2.0/generated/torch.Tensor.tanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tanh_.html
+++ b/docs/2.0/generated/torch.Tensor.tanh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tensor_split.html
+++ b/docs/2.0/generated/torch.Tensor.tensor_split.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tile.html
+++ b/docs/2.0/generated/torch.Tensor.tile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to.html
+++ b/docs/2.0/generated/torch.Tensor.to.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_dense.html
+++ b/docs/2.0/generated/torch.Tensor.to_dense.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_mkldnn.html
+++ b/docs/2.0/generated/torch.Tensor.to_mkldnn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse_bsc.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse_bsc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse_bsr.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse_bsr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse_coo.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse_coo.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse_csc.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse_csc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.to_sparse_csr.html
+++ b/docs/2.0/generated/torch.Tensor.to_sparse_csr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tolist.html
+++ b/docs/2.0/generated/torch.Tensor.tolist.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.topk.html
+++ b/docs/2.0/generated/torch.Tensor.topk.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.trace.html
+++ b/docs/2.0/generated/torch.Tensor.trace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.transpose.html
+++ b/docs/2.0/generated/torch.Tensor.transpose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.transpose_.html
+++ b/docs/2.0/generated/torch.Tensor.transpose_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.triangular_solve.html
+++ b/docs/2.0/generated/torch.Tensor.triangular_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tril.html
+++ b/docs/2.0/generated/torch.Tensor.tril.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.tril_.html
+++ b/docs/2.0/generated/torch.Tensor.tril_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.triu.html
+++ b/docs/2.0/generated/torch.Tensor.triu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.triu_.html
+++ b/docs/2.0/generated/torch.Tensor.triu_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.true_divide.html
+++ b/docs/2.0/generated/torch.Tensor.true_divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.true_divide_.html
+++ b/docs/2.0/generated/torch.Tensor.true_divide_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.trunc.html
+++ b/docs/2.0/generated/torch.Tensor.trunc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.trunc_.html
+++ b/docs/2.0/generated/torch.Tensor.trunc_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.type.html
+++ b/docs/2.0/generated/torch.Tensor.type.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.type_as.html
+++ b/docs/2.0/generated/torch.Tensor.type_as.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unbind.html
+++ b/docs/2.0/generated/torch.Tensor.unbind.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unflatten.html
+++ b/docs/2.0/generated/torch.Tensor.unflatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unfold.html
+++ b/docs/2.0/generated/torch.Tensor.unfold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.uniform_.html
+++ b/docs/2.0/generated/torch.Tensor.uniform_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unique.html
+++ b/docs/2.0/generated/torch.Tensor.unique.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unique_consecutive.html
+++ b/docs/2.0/generated/torch.Tensor.unique_consecutive.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unsqueeze.html
+++ b/docs/2.0/generated/torch.Tensor.unsqueeze.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.unsqueeze_.html
+++ b/docs/2.0/generated/torch.Tensor.unsqueeze_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.untyped_storage.html
+++ b/docs/2.0/generated/torch.Tensor.untyped_storage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.values.html
+++ b/docs/2.0/generated/torch.Tensor.values.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.var.html
+++ b/docs/2.0/generated/torch.Tensor.var.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.vdot.html
+++ b/docs/2.0/generated/torch.Tensor.vdot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.view.html
+++ b/docs/2.0/generated/torch.Tensor.view.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.view_as.html
+++ b/docs/2.0/generated/torch.Tensor.view_as.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.vsplit.html
+++ b/docs/2.0/generated/torch.Tensor.vsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.where.html
+++ b/docs/2.0/generated/torch.Tensor.where.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.xlogy.html
+++ b/docs/2.0/generated/torch.Tensor.xlogy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.xlogy_.html
+++ b/docs/2.0/generated/torch.Tensor.xlogy_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.Tensor.zero_.html
+++ b/docs/2.0/generated/torch.Tensor.zero_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._assert.html
+++ b/docs/2.0/generated/torch._assert.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_abs.html
+++ b/docs/2.0/generated/torch._foreach_abs.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_abs_.html
+++ b/docs/2.0/generated/torch._foreach_abs_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_acos.html
+++ b/docs/2.0/generated/torch._foreach_acos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_acos_.html
+++ b/docs/2.0/generated/torch._foreach_acos_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_asin.html
+++ b/docs/2.0/generated/torch._foreach_asin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_asin_.html
+++ b/docs/2.0/generated/torch._foreach_asin_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_atan.html
+++ b/docs/2.0/generated/torch._foreach_atan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_atan_.html
+++ b/docs/2.0/generated/torch._foreach_atan_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_ceil.html
+++ b/docs/2.0/generated/torch._foreach_ceil.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_ceil_.html
+++ b/docs/2.0/generated/torch._foreach_ceil_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_cos.html
+++ b/docs/2.0/generated/torch._foreach_cos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_cos_.html
+++ b/docs/2.0/generated/torch._foreach_cos_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_cosh.html
+++ b/docs/2.0/generated/torch._foreach_cosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_cosh_.html
+++ b/docs/2.0/generated/torch._foreach_cosh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_erf.html
+++ b/docs/2.0/generated/torch._foreach_erf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_erf_.html
+++ b/docs/2.0/generated/torch._foreach_erf_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_erfc.html
+++ b/docs/2.0/generated/torch._foreach_erfc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_erfc_.html
+++ b/docs/2.0/generated/torch._foreach_erfc_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_exp.html
+++ b/docs/2.0/generated/torch._foreach_exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_exp_.html
+++ b/docs/2.0/generated/torch._foreach_exp_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_expm1.html
+++ b/docs/2.0/generated/torch._foreach_expm1.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_expm1_.html
+++ b/docs/2.0/generated/torch._foreach_expm1_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_floor.html
+++ b/docs/2.0/generated/torch._foreach_floor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_floor_.html
+++ b/docs/2.0/generated/torch._foreach_floor_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_frac.html
+++ b/docs/2.0/generated/torch._foreach_frac.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_frac_.html
+++ b/docs/2.0/generated/torch._foreach_frac_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_lgamma.html
+++ b/docs/2.0/generated/torch._foreach_lgamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_lgamma_.html
+++ b/docs/2.0/generated/torch._foreach_lgamma_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log.html
+++ b/docs/2.0/generated/torch._foreach_log.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log10.html
+++ b/docs/2.0/generated/torch._foreach_log10.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log10_.html
+++ b/docs/2.0/generated/torch._foreach_log10_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log1p.html
+++ b/docs/2.0/generated/torch._foreach_log1p.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log1p_.html
+++ b/docs/2.0/generated/torch._foreach_log1p_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log2.html
+++ b/docs/2.0/generated/torch._foreach_log2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log2_.html
+++ b/docs/2.0/generated/torch._foreach_log2_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_log_.html
+++ b/docs/2.0/generated/torch._foreach_log_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_neg.html
+++ b/docs/2.0/generated/torch._foreach_neg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_neg_.html
+++ b/docs/2.0/generated/torch._foreach_neg_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_reciprocal.html
+++ b/docs/2.0/generated/torch._foreach_reciprocal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_reciprocal_.html
+++ b/docs/2.0/generated/torch._foreach_reciprocal_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_round.html
+++ b/docs/2.0/generated/torch._foreach_round.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_round_.html
+++ b/docs/2.0/generated/torch._foreach_round_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sigmoid.html
+++ b/docs/2.0/generated/torch._foreach_sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sigmoid_.html
+++ b/docs/2.0/generated/torch._foreach_sigmoid_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sin.html
+++ b/docs/2.0/generated/torch._foreach_sin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sin_.html
+++ b/docs/2.0/generated/torch._foreach_sin_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sinh.html
+++ b/docs/2.0/generated/torch._foreach_sinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sinh_.html
+++ b/docs/2.0/generated/torch._foreach_sinh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sqrt.html
+++ b/docs/2.0/generated/torch._foreach_sqrt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_sqrt_.html
+++ b/docs/2.0/generated/torch._foreach_sqrt_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_tan.html
+++ b/docs/2.0/generated/torch._foreach_tan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_tan_.html
+++ b/docs/2.0/generated/torch._foreach_tan_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_trunc.html
+++ b/docs/2.0/generated/torch._foreach_trunc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_trunc_.html
+++ b/docs/2.0/generated/torch._foreach_trunc_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch._foreach_zero_.html
+++ b/docs/2.0/generated/torch._foreach_zero_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.abs.html
+++ b/docs/2.0/generated/torch.abs.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.absolute.html
+++ b/docs/2.0/generated/torch.absolute.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.acos.html
+++ b/docs/2.0/generated/torch.acos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.acosh.html
+++ b/docs/2.0/generated/torch.acosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.add.html
+++ b/docs/2.0/generated/torch.add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addbmm.html
+++ b/docs/2.0/generated/torch.addbmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addcdiv.html
+++ b/docs/2.0/generated/torch.addcdiv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addcmul.html
+++ b/docs/2.0/generated/torch.addcmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addmm.html
+++ b/docs/2.0/generated/torch.addmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addmv.html
+++ b/docs/2.0/generated/torch.addmv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.addr.html
+++ b/docs/2.0/generated/torch.addr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.adjoint.html
+++ b/docs/2.0/generated/torch.adjoint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.all.html
+++ b/docs/2.0/generated/torch.all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.allclose.html
+++ b/docs/2.0/generated/torch.allclose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.amax.html
+++ b/docs/2.0/generated/torch.amax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.amin.html
+++ b/docs/2.0/generated/torch.amin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.aminmax.html
+++ b/docs/2.0/generated/torch.aminmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.angle.html
+++ b/docs/2.0/generated/torch.angle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.any.html
+++ b/docs/2.0/generated/torch.any.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.BNReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.BNReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.BNReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.BNReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBn3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvBnReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.ConvReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.LinearReLU.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.LinearReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBn3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvBnReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.ConvReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.LinearReLU.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.LinearReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.freeze_bn_stats.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.freeze_bn_stats.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.qat.update_bn_stats.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.qat.update_bn_stats.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.BNReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.BNReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.BNReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.BNReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU1d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU2d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU3d.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.ConvReLU3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.LinearReLU.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.LinearReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.dynamic.LinearReLU.html
+++ b/docs/2.0/generated/torch.ao.nn.intrinsic.quantized.dynamic.LinearReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.qat.Conv2d.html
+++ b/docs/2.0/generated/torch.ao.nn.qat.Conv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.qat.Conv3d.html
+++ b/docs/2.0/generated/torch.ao.nn.qat.Conv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.qat.Linear.html
+++ b/docs/2.0/generated/torch.ao.nn.qat.Linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.qat.dynamic.Linear.html
+++ b/docs/2.0/generated/torch.ao.nn.qat.dynamic.Linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantizable.LSTM.html
+++ b/docs/2.0/generated/torch.ao.nn.quantizable.LSTM.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantizable.MultiheadAttention.html
+++ b/docs/2.0/generated/torch.ao.nn.quantizable.MultiheadAttention.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.BatchNorm2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.BatchNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.BatchNorm3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.BatchNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Conv1d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Conv1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Conv2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Conv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Conv3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Conv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose1d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.ConvTranspose3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.ELU.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.ELU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Embedding.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Embedding.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.EmbeddingBag.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.EmbeddingBag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.FXFloatFunctional.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.FXFloatFunctional.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.FloatFunctional.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.FloatFunctional.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.GroupNorm.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.GroupNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Hardswish.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Hardswish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm1d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.InstanceNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.LayerNorm.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.LayerNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.LeakyReLU.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.LeakyReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Linear.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.QFunctional.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.QFunctional.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.ReLU6.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.ReLU6.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.Sigmoid.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.Sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.GRU.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.GRU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.GRUCell.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.GRUCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.LSTM.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.LSTM.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.LSTMCell.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.LSTMCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.Linear.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.Linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.dynamic.RNNCell.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.dynamic.RNNCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.adaptive_avg_pool2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.adaptive_avg_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.adaptive_avg_pool3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.adaptive_avg_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.avg_pool2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.avg_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.avg_pool3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.avg_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.celu.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.celu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.clamp.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.clamp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.conv1d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.conv1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.conv2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.conv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.conv3d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.conv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.elu.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.elu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.hardsigmoid.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.hardsigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.hardswish.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.hardswish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.hardtanh.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.hardtanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.interpolate.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.interpolate.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.leaky_relu.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.leaky_relu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.linear.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.max_pool1d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.max_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.max_pool2d.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.max_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.threshold.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.threshold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample_bilinear.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample_bilinear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample_nearest.html
+++ b/docs/2.0/generated/torch.ao.nn.quantized.functional.upsample_nearest.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.DeQuantStub.html
+++ b/docs/2.0/generated/torch.ao.quantization.DeQuantStub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.QuantStub.html
+++ b/docs/2.0/generated/torch.ao.quantization.QuantStub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.QuantWrapper.html
+++ b/docs/2.0/generated/torch.ao.quantization.QuantWrapper.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.add_quant_dequant.html
+++ b/docs/2.0/generated/torch.ao.quantization.add_quant_dequant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.backend_config.BackendConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.backend_config.BackendConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.backend_config.BackendPatternConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.backend_config.BackendPatternConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.backend_config.DTypeConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.backend_config.DTypeConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.backend_config.DTypeWithConstraints.html
+++ b/docs/2.0/generated/torch.ao.quantization.backend_config.DTypeWithConstraints.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.backend_config.ObservationType.html
+++ b/docs/2.0/generated/torch.ao.quantization.backend_config.ObservationType.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.convert.html
+++ b/docs/2.0/generated/torch.ao.quantization.convert.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.default_eval_fn.html
+++ b/docs/2.0/generated/torch.ao.quantization.default_eval_fn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.FakeQuantize.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.FakeQuantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.FakeQuantizeBase.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.FakeQuantizeBase.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.FixedQParamsFakeQuantize.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.FixedQParamsFakeQuantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.FusedMovingAvgObsFakeQuantize.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.FusedMovingAvgObsFakeQuantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_act_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_act_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_per_channel_wt_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_per_channel_wt_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_wt_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_fused_wt_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_histogram_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_histogram_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_per_channel_weight_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_per_channel_weight_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_weight_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.default_weight_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.disable_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.disable_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.disable_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.disable_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.enable_fake_quant.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.enable_fake_quant.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fake_quantize.enable_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.fake_quantize.enable_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fuse_modules.html
+++ b/docs/2.0/generated/torch.ao.quantization.fuse_modules.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fx.custom_config.ConvertCustomConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.fx.custom_config.ConvertCustomConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fx.custom_config.FuseCustomConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.fx.custom_config.FuseCustomConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fx.custom_config.PrepareCustomConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.fx.custom_config.PrepareCustomConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.fx.custom_config.StandaloneModuleConfigEntry.html
+++ b/docs/2.0/generated/torch.ao.quantization.fx.custom_config.StandaloneModuleConfigEntry.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.HistogramObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.HistogramObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.MinMaxObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.MinMaxObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.MovingAverageMinMaxObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.MovingAverageMinMaxObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.MovingAveragePerChannelMinMaxObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.MovingAveragePerChannelMinMaxObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.NoopObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.NoopObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.ObserverBase.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.ObserverBase.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.PerChannelMinMaxObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.PerChannelMinMaxObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.PlaceholderObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.PlaceholderObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.RecordingObserver.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.RecordingObserver.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_debug_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_debug_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_dynamic_quant_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_dynamic_quant_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_float_qparams_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_float_qparams_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_histogram_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_histogram_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_per_channel_weight_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_per_channel_weight_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_placeholder_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_placeholder_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.default_weight_observer.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.default_weight_observer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.get_observer_state_dict.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.get_observer_state_dict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.observer.load_observer_state_dict.html
+++ b/docs/2.0/generated/torch.ao.quantization.observer.load_observer_state_dict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.prepare.html
+++ b/docs/2.0/generated/torch.ao.quantization.prepare.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.prepare_qat.html
+++ b/docs/2.0/generated/torch.ao.quantization.prepare_qat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.propagate_qconfig_.html
+++ b/docs/2.0/generated/torch.ao.quantization.propagate_qconfig_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.QConfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.QConfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_activation_only_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_activation_only_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_debug_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_debug_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_dynamic_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_dynamic_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_per_channel_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_per_channel_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_qat_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_qat_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_qat_qconfig_v2.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_qat_qconfig_v2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.default_weight_only_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.default_weight_only_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.float16_dynamic_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.float16_dynamic_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.float16_static_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.float16_static_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.float_qparams_weight_only_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.float_qparams_weight_only_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig.per_channel_dynamic_qconfig.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig.per_channel_dynamic_qconfig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.QConfigMapping.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.QConfigMapping.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.get_default_qat_qconfig_mapping.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.get_default_qat_qconfig_mapping.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.get_default_qconfig_mapping.html
+++ b/docs/2.0/generated/torch.ao.quantization.qconfig_mapping.get_default_qconfig_mapping.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_dynamic.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_dynamic.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_fx.convert_fx.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_fx.convert_fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_fx.fuse_fx.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_fx.fuse_fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_fx.prepare_fx.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_fx.prepare_fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_fx.prepare_qat_fx.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_fx.prepare_qat_fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.quantize_qat.html
+++ b/docs/2.0/generated/torch.ao.quantization.quantize_qat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ao.quantization.swap_module.html
+++ b/docs/2.0/generated/torch.ao.quantization.swap_module.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arange.html
+++ b/docs/2.0/generated/torch.arange.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arccos.html
+++ b/docs/2.0/generated/torch.arccos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arccosh.html
+++ b/docs/2.0/generated/torch.arccosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arcsin.html
+++ b/docs/2.0/generated/torch.arcsin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arcsinh.html
+++ b/docs/2.0/generated/torch.arcsinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arctan.html
+++ b/docs/2.0/generated/torch.arctan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arctan2.html
+++ b/docs/2.0/generated/torch.arctan2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.arctanh.html
+++ b/docs/2.0/generated/torch.arctanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.are_deterministic_algorithms_enabled.html
+++ b/docs/2.0/generated/torch.are_deterministic_algorithms_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.argmax.html
+++ b/docs/2.0/generated/torch.argmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.argmin.html
+++ b/docs/2.0/generated/torch.argmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.argsort.html
+++ b/docs/2.0/generated/torch.argsort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.argwhere.html
+++ b/docs/2.0/generated/torch.argwhere.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.as_strided.html
+++ b/docs/2.0/generated/torch.as_strided.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.as_tensor.html
+++ b/docs/2.0/generated/torch.as_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.asarray.html
+++ b/docs/2.0/generated/torch.asarray.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.asin.html
+++ b/docs/2.0/generated/torch.asin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.asinh.html
+++ b/docs/2.0/generated/torch.asinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atan.html
+++ b/docs/2.0/generated/torch.atan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atan2.html
+++ b/docs/2.0/generated/torch.atan2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atanh.html
+++ b/docs/2.0/generated/torch.atanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atleast_1d.html
+++ b/docs/2.0/generated/torch.atleast_1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atleast_2d.html
+++ b/docs/2.0/generated/torch.atleast_2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.atleast_3d.html
+++ b/docs/2.0/generated/torch.atleast_3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.Function.backward.html
+++ b/docs/2.0/generated/torch.autograd.Function.backward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.Function.forward.html
+++ b/docs/2.0/generated/torch.autograd.Function.forward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.Function.jvp.html
+++ b/docs/2.0/generated/torch.autograd.Function.jvp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.Function.vmap.html
+++ b/docs/2.0/generated/torch.autograd.Function.vmap.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.backward.html
+++ b/docs/2.0/generated/torch.autograd.backward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.forward_ad.dual_level.html
+++ b/docs/2.0/generated/torch.autograd.forward_ad.dual_level.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.forward_ad.make_dual.html
+++ b/docs/2.0/generated/torch.autograd.forward_ad.make_dual.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.forward_ad.unpack_dual.html
+++ b/docs/2.0/generated/torch.autograd.forward_ad.unpack_dual.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.function.FunctionCtx.mark_dirty.html
+++ b/docs/2.0/generated/torch.autograd.function.FunctionCtx.mark_dirty.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.function.FunctionCtx.mark_non_differentiable.html
+++ b/docs/2.0/generated/torch.autograd.function.FunctionCtx.mark_non_differentiable.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.function.FunctionCtx.save_for_backward.html
+++ b/docs/2.0/generated/torch.autograd.function.FunctionCtx.save_for_backward.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.function.FunctionCtx.set_materialize_grads.html
+++ b/docs/2.0/generated/torch.autograd.function.FunctionCtx.set_materialize_grads.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.hessian.html
+++ b/docs/2.0/generated/torch.autograd.functional.hessian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.hvp.html
+++ b/docs/2.0/generated/torch.autograd.functional.hvp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.jacobian.html
+++ b/docs/2.0/generated/torch.autograd.functional.jacobian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.jvp.html
+++ b/docs/2.0/generated/torch.autograd.functional.jvp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.vhp.html
+++ b/docs/2.0/generated/torch.autograd.functional.vhp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.functional.vjp.html
+++ b/docs/2.0/generated/torch.autograd.functional.vjp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.grad.html
+++ b/docs/2.0/generated/torch.autograd.grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.gradcheck.html
+++ b/docs/2.0/generated/torch.autograd.gradcheck.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.gradgradcheck.html
+++ b/docs/2.0/generated/torch.autograd.gradgradcheck.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.graph.Node.metadata.html
+++ b/docs/2.0/generated/torch.autograd.graph.Node.metadata.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.graph.Node.name.html
+++ b/docs/2.0/generated/torch.autograd.graph.Node.name.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.graph.Node.next_functions.html
+++ b/docs/2.0/generated/torch.autograd.graph.Node.next_functions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.graph.Node.register_hook.html
+++ b/docs/2.0/generated/torch.autograd.graph.Node.register_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.graph.Node.register_prehook.html
+++ b/docs/2.0/generated/torch.autograd.graph.Node.register_prehook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.profiler.load_nvprof.html
+++ b/docs/2.0/generated/torch.autograd.profiler.load_nvprof.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.profiler.profile.export_chrome_trace.html
+++ b/docs/2.0/generated/torch.autograd.profiler.profile.export_chrome_trace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.profiler.profile.key_averages.html
+++ b/docs/2.0/generated/torch.autograd.profiler.profile.key_averages.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.profiler.profile.self_cpu_time_total.html
+++ b/docs/2.0/generated/torch.autograd.profiler.profile.self_cpu_time_total.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.profiler.profile.total_average.html
+++ b/docs/2.0/generated/torch.autograd.profiler.profile.total_average.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.autograd.set_multithreading_enabled.html
+++ b/docs/2.0/generated/torch.autograd.set_multithreading_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.baddbmm.html
+++ b/docs/2.0/generated/torch.baddbmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bartlett_window.html
+++ b/docs/2.0/generated/torch.bartlett_window.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bernoulli.html
+++ b/docs/2.0/generated/torch.bernoulli.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bincount.html
+++ b/docs/2.0/generated/torch.bincount.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_and.html
+++ b/docs/2.0/generated/torch.bitwise_and.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_left_shift.html
+++ b/docs/2.0/generated/torch.bitwise_left_shift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_not.html
+++ b/docs/2.0/generated/torch.bitwise_not.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_or.html
+++ b/docs/2.0/generated/torch.bitwise_or.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_right_shift.html
+++ b/docs/2.0/generated/torch.bitwise_right_shift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bitwise_xor.html
+++ b/docs/2.0/generated/torch.bitwise_xor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.blackman_window.html
+++ b/docs/2.0/generated/torch.blackman_window.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.block_diag.html
+++ b/docs/2.0/generated/torch.block_diag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bmm.html
+++ b/docs/2.0/generated/torch.bmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.broadcast_shapes.html
+++ b/docs/2.0/generated/torch.broadcast_shapes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.broadcast_tensors.html
+++ b/docs/2.0/generated/torch.broadcast_tensors.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.broadcast_to.html
+++ b/docs/2.0/generated/torch.broadcast_to.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.bucketize.html
+++ b/docs/2.0/generated/torch.bucketize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.can_cast.html
+++ b/docs/2.0/generated/torch.can_cast.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cartesian_prod.html
+++ b/docs/2.0/generated/torch.cartesian_prod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cat.html
+++ b/docs/2.0/generated/torch.cat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cdist.html
+++ b/docs/2.0/generated/torch.cdist.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ceil.html
+++ b/docs/2.0/generated/torch.ceil.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.chain_matmul.html
+++ b/docs/2.0/generated/torch.chain_matmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cholesky.html
+++ b/docs/2.0/generated/torch.cholesky.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cholesky_inverse.html
+++ b/docs/2.0/generated/torch.cholesky_inverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cholesky_solve.html
+++ b/docs/2.0/generated/torch.cholesky_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.chunk.html
+++ b/docs/2.0/generated/torch.chunk.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.clamp.html
+++ b/docs/2.0/generated/torch.clamp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.clip.html
+++ b/docs/2.0/generated/torch.clip.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.clone.html
+++ b/docs/2.0/generated/torch.clone.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.column_stack.html
+++ b/docs/2.0/generated/torch.column_stack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.combinations.html
+++ b/docs/2.0/generated/torch.combinations.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.compile.html
+++ b/docs/2.0/generated/torch.compile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.compiled_with_cxx11_abi.html
+++ b/docs/2.0/generated/torch.compiled_with_cxx11_abi.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.complex.html
+++ b/docs/2.0/generated/torch.complex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.concat.html
+++ b/docs/2.0/generated/torch.concat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.concatenate.html
+++ b/docs/2.0/generated/torch.concatenate.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.conj.html
+++ b/docs/2.0/generated/torch.conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.conj_physical.html
+++ b/docs/2.0/generated/torch.conj_physical.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.copysign.html
+++ b/docs/2.0/generated/torch.copysign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.corrcoef.html
+++ b/docs/2.0/generated/torch.corrcoef.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cos.html
+++ b/docs/2.0/generated/torch.cos.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cosh.html
+++ b/docs/2.0/generated/torch.cosh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.count_nonzero.html
+++ b/docs/2.0/generated/torch.count_nonzero.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cov.html
+++ b/docs/2.0/generated/torch.cov.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cross.html
+++ b/docs/2.0/generated/torch.cross.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.CUDAGraph.html
+++ b/docs/2.0/generated/torch.cuda.CUDAGraph.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.CUDAPluggableAllocator.html
+++ b/docs/2.0/generated/torch.cuda.CUDAPluggableAllocator.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.Event.html
+++ b/docs/2.0/generated/torch.cuda.Event.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.ExternalStream.html
+++ b/docs/2.0/generated/torch.cuda.ExternalStream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.OutOfMemoryError.html
+++ b/docs/2.0/generated/torch.cuda.OutOfMemoryError.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.Stream.html
+++ b/docs/2.0/generated/torch.cuda.Stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.StreamContext.html
+++ b/docs/2.0/generated/torch.cuda.StreamContext.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.caching_allocator_alloc.html
+++ b/docs/2.0/generated/torch.cuda.caching_allocator_alloc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.caching_allocator_delete.html
+++ b/docs/2.0/generated/torch.cuda.caching_allocator_delete.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.can_device_access_peer.html
+++ b/docs/2.0/generated/torch.cuda.can_device_access_peer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.change_current_allocator.html
+++ b/docs/2.0/generated/torch.cuda.change_current_allocator.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.comm.broadcast.html
+++ b/docs/2.0/generated/torch.cuda.comm.broadcast.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.comm.broadcast_coalesced.html
+++ b/docs/2.0/generated/torch.cuda.comm.broadcast_coalesced.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.comm.gather.html
+++ b/docs/2.0/generated/torch.cuda.comm.gather.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.comm.reduce_add.html
+++ b/docs/2.0/generated/torch.cuda.comm.reduce_add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.comm.scatter.html
+++ b/docs/2.0/generated/torch.cuda.comm.scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.current_blas_handle.html
+++ b/docs/2.0/generated/torch.cuda.current_blas_handle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.current_device.html
+++ b/docs/2.0/generated/torch.cuda.current_device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.current_stream.html
+++ b/docs/2.0/generated/torch.cuda.current_stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.default_stream.html
+++ b/docs/2.0/generated/torch.cuda.default_stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.device.html
+++ b/docs/2.0/generated/torch.cuda.device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.device_count.html
+++ b/docs/2.0/generated/torch.cuda.device_count.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.device_of.html
+++ b/docs/2.0/generated/torch.cuda.device_of.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.empty_cache.html
+++ b/docs/2.0/generated/torch.cuda.empty_cache.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_allocator_backend.html
+++ b/docs/2.0/generated/torch.cuda.get_allocator_backend.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_arch_list.html
+++ b/docs/2.0/generated/torch.cuda.get_arch_list.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_device_capability.html
+++ b/docs/2.0/generated/torch.cuda.get_device_capability.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_device_name.html
+++ b/docs/2.0/generated/torch.cuda.get_device_name.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_device_properties.html
+++ b/docs/2.0/generated/torch.cuda.get_device_properties.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_gencode_flags.html
+++ b/docs/2.0/generated/torch.cuda.get_gencode_flags.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_rng_state.html
+++ b/docs/2.0/generated/torch.cuda.get_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_rng_state_all.html
+++ b/docs/2.0/generated/torch.cuda.get_rng_state_all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.get_sync_debug_mode.html
+++ b/docs/2.0/generated/torch.cuda.get_sync_debug_mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.graph.html
+++ b/docs/2.0/generated/torch.cuda.graph.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.graph_pool_handle.html
+++ b/docs/2.0/generated/torch.cuda.graph_pool_handle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.init.html
+++ b/docs/2.0/generated/torch.cuda.init.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.initial_seed.html
+++ b/docs/2.0/generated/torch.cuda.initial_seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.ipc_collect.html
+++ b/docs/2.0/generated/torch.cuda.ipc_collect.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.is_available.html
+++ b/docs/2.0/generated/torch.cuda.is_available.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.is_current_stream_capturing.html
+++ b/docs/2.0/generated/torch.cuda.is_current_stream_capturing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.is_initialized.html
+++ b/docs/2.0/generated/torch.cuda.is_initialized.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.jiterator._create_jit_fn.html
+++ b/docs/2.0/generated/torch.cuda.jiterator._create_jit_fn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.jiterator._create_multi_output_jit_fn.html
+++ b/docs/2.0/generated/torch.cuda.jiterator._create_multi_output_jit_fn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.list_gpu_processes.html
+++ b/docs/2.0/generated/torch.cuda.list_gpu_processes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.make_graphed_callables.html
+++ b/docs/2.0/generated/torch.cuda.make_graphed_callables.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.manual_seed.html
+++ b/docs/2.0/generated/torch.cuda.manual_seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.manual_seed_all.html
+++ b/docs/2.0/generated/torch.cuda.manual_seed_all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.max_memory_allocated.html
+++ b/docs/2.0/generated/torch.cuda.max_memory_allocated.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.max_memory_cached.html
+++ b/docs/2.0/generated/torch.cuda.max_memory_cached.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.max_memory_reserved.html
+++ b/docs/2.0/generated/torch.cuda.max_memory_reserved.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.mem_get_info.html
+++ b/docs/2.0/generated/torch.cuda.mem_get_info.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_allocated.html
+++ b/docs/2.0/generated/torch.cuda.memory_allocated.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_cached.html
+++ b/docs/2.0/generated/torch.cuda.memory_cached.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_reserved.html
+++ b/docs/2.0/generated/torch.cuda.memory_reserved.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_snapshot.html
+++ b/docs/2.0/generated/torch.cuda.memory_snapshot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_stats.html
+++ b/docs/2.0/generated/torch.cuda.memory_stats.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_summary.html
+++ b/docs/2.0/generated/torch.cuda.memory_summary.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.memory_usage.html
+++ b/docs/2.0/generated/torch.cuda.memory_usage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.nvtx.mark.html
+++ b/docs/2.0/generated/torch.cuda.nvtx.mark.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.nvtx.range_pop.html
+++ b/docs/2.0/generated/torch.cuda.nvtx.range_pop.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.nvtx.range_push.html
+++ b/docs/2.0/generated/torch.cuda.nvtx.range_push.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.reset_max_memory_allocated.html
+++ b/docs/2.0/generated/torch.cuda.reset_max_memory_allocated.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.reset_max_memory_cached.html
+++ b/docs/2.0/generated/torch.cuda.reset_max_memory_cached.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.reset_peak_memory_stats.html
+++ b/docs/2.0/generated/torch.cuda.reset_peak_memory_stats.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.seed.html
+++ b/docs/2.0/generated/torch.cuda.seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.seed_all.html
+++ b/docs/2.0/generated/torch.cuda.seed_all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_device.html
+++ b/docs/2.0/generated/torch.cuda.set_device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_per_process_memory_fraction.html
+++ b/docs/2.0/generated/torch.cuda.set_per_process_memory_fraction.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_rng_state.html
+++ b/docs/2.0/generated/torch.cuda.set_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_rng_state_all.html
+++ b/docs/2.0/generated/torch.cuda.set_rng_state_all.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_stream.html
+++ b/docs/2.0/generated/torch.cuda.set_stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.set_sync_debug_mode.html
+++ b/docs/2.0/generated/torch.cuda.set_sync_debug_mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.stream.html
+++ b/docs/2.0/generated/torch.cuda.stream.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.synchronize.html
+++ b/docs/2.0/generated/torch.cuda.synchronize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cuda.utilization.html
+++ b/docs/2.0/generated/torch.cuda.utilization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cummax.html
+++ b/docs/2.0/generated/torch.cummax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cummin.html
+++ b/docs/2.0/generated/torch.cummin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cumprod.html
+++ b/docs/2.0/generated/torch.cumprod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cumsum.html
+++ b/docs/2.0/generated/torch.cumsum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.cumulative_trapezoid.html
+++ b/docs/2.0/generated/torch.cumulative_trapezoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.deg2rad.html
+++ b/docs/2.0/generated/torch.deg2rad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.dequantize.html
+++ b/docs/2.0/generated/torch.dequantize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.det.html
+++ b/docs/2.0/generated/torch.det.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diag.html
+++ b/docs/2.0/generated/torch.diag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diag_embed.html
+++ b/docs/2.0/generated/torch.diag_embed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diagflat.html
+++ b/docs/2.0/generated/torch.diagflat.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diagonal.html
+++ b/docs/2.0/generated/torch.diagonal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diagonal_scatter.html
+++ b/docs/2.0/generated/torch.diagonal_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.diff.html
+++ b/docs/2.0/generated/torch.diff.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.digamma.html
+++ b/docs/2.0/generated/torch.digamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.dist.html
+++ b/docs/2.0/generated/torch.dist.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.div.html
+++ b/docs/2.0/generated/torch.div.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.divide.html
+++ b/docs/2.0/generated/torch.divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.dot.html
+++ b/docs/2.0/generated/torch.dot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.dsplit.html
+++ b/docs/2.0/generated/torch.dsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.dstack.html
+++ b/docs/2.0/generated/torch.dstack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.einsum.html
+++ b/docs/2.0/generated/torch.einsum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.empty.html
+++ b/docs/2.0/generated/torch.empty.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.empty_like.html
+++ b/docs/2.0/generated/torch.empty_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.empty_strided.html
+++ b/docs/2.0/generated/torch.empty_strided.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.enable_grad.html
+++ b/docs/2.0/generated/torch.enable_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.eq.html
+++ b/docs/2.0/generated/torch.eq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.equal.html
+++ b/docs/2.0/generated/torch.equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.erf.html
+++ b/docs/2.0/generated/torch.erf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.erfc.html
+++ b/docs/2.0/generated/torch.erfc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.erfinv.html
+++ b/docs/2.0/generated/torch.erfinv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.exp.html
+++ b/docs/2.0/generated/torch.exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.exp2.html
+++ b/docs/2.0/generated/torch.exp2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.expm1.html
+++ b/docs/2.0/generated/torch.expm1.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.eye.html
+++ b/docs/2.0/generated/torch.eye.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fake_quantize_per_channel_affine.html
+++ b/docs/2.0/generated/torch.fake_quantize_per_channel_affine.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fake_quantize_per_tensor_affine.html
+++ b/docs/2.0/generated/torch.fake_quantize_per_tensor_affine.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.fft.html
+++ b/docs/2.0/generated/torch.fft.fft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.fft2.html
+++ b/docs/2.0/generated/torch.fft.fft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.fftfreq.html
+++ b/docs/2.0/generated/torch.fft.fftfreq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.fftn.html
+++ b/docs/2.0/generated/torch.fft.fftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.fftshift.html
+++ b/docs/2.0/generated/torch.fft.fftshift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.hfft.html
+++ b/docs/2.0/generated/torch.fft.hfft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.hfft2.html
+++ b/docs/2.0/generated/torch.fft.hfft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.hfftn.html
+++ b/docs/2.0/generated/torch.fft.hfftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ifft.html
+++ b/docs/2.0/generated/torch.fft.ifft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ifft2.html
+++ b/docs/2.0/generated/torch.fft.ifft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ifftn.html
+++ b/docs/2.0/generated/torch.fft.ifftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ifftshift.html
+++ b/docs/2.0/generated/torch.fft.ifftshift.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ihfft.html
+++ b/docs/2.0/generated/torch.fft.ihfft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ihfft2.html
+++ b/docs/2.0/generated/torch.fft.ihfft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.ihfftn.html
+++ b/docs/2.0/generated/torch.fft.ihfftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.irfft.html
+++ b/docs/2.0/generated/torch.fft.irfft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.irfft2.html
+++ b/docs/2.0/generated/torch.fft.irfft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.irfftn.html
+++ b/docs/2.0/generated/torch.fft.irfftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.rfft.html
+++ b/docs/2.0/generated/torch.fft.rfft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.rfft2.html
+++ b/docs/2.0/generated/torch.fft.rfft2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.rfftfreq.html
+++ b/docs/2.0/generated/torch.fft.rfftfreq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fft.rfftn.html
+++ b/docs/2.0/generated/torch.fft.rfftn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fix.html
+++ b/docs/2.0/generated/torch.fix.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.flatten.html
+++ b/docs/2.0/generated/torch.flatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.flip.html
+++ b/docs/2.0/generated/torch.flip.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fliplr.html
+++ b/docs/2.0/generated/torch.fliplr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.flipud.html
+++ b/docs/2.0/generated/torch.flipud.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.float_power.html
+++ b/docs/2.0/generated/torch.float_power.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.floor.html
+++ b/docs/2.0/generated/torch.floor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.floor_divide.html
+++ b/docs/2.0/generated/torch.floor_divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fmax.html
+++ b/docs/2.0/generated/torch.fmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fmin.html
+++ b/docs/2.0/generated/torch.fmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.fmod.html
+++ b/docs/2.0/generated/torch.fmod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.frac.html
+++ b/docs/2.0/generated/torch.frac.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.frexp.html
+++ b/docs/2.0/generated/torch.frexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.from_dlpack.html
+++ b/docs/2.0/generated/torch.from_dlpack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.from_numpy.html
+++ b/docs/2.0/generated/torch.from_numpy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.frombuffer.html
+++ b/docs/2.0/generated/torch.frombuffer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.full.html
+++ b/docs/2.0/generated/torch.full.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.full_like.html
+++ b/docs/2.0/generated/torch.full_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.functional_call.html
+++ b/docs/2.0/generated/torch.func.functional_call.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.functionalize.html
+++ b/docs/2.0/generated/torch.func.functionalize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.grad.html
+++ b/docs/2.0/generated/torch.func.grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.grad_and_value.html
+++ b/docs/2.0/generated/torch.func.grad_and_value.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.hessian.html
+++ b/docs/2.0/generated/torch.func.hessian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.jacfwd.html
+++ b/docs/2.0/generated/torch.func.jacfwd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.jacrev.html
+++ b/docs/2.0/generated/torch.func.jacrev.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.jvp.html
+++ b/docs/2.0/generated/torch.func.jvp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.linearize.html
+++ b/docs/2.0/generated/torch.func.linearize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.replace_all_batch_norm_modules_.html
+++ b/docs/2.0/generated/torch.func.replace_all_batch_norm_modules_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.stack_module_state.html
+++ b/docs/2.0/generated/torch.func.stack_module_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.vjp.html
+++ b/docs/2.0/generated/torch.func.vjp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.func.vmap.html
+++ b/docs/2.0/generated/torch.func.vmap.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.gather.html
+++ b/docs/2.0/generated/torch.gather.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.gcd.html
+++ b/docs/2.0/generated/torch.gcd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ge.html
+++ b/docs/2.0/generated/torch.ge.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.geqrf.html
+++ b/docs/2.0/generated/torch.geqrf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ger.html
+++ b/docs/2.0/generated/torch.ger.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_default_dtype.html
+++ b/docs/2.0/generated/torch.get_default_dtype.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_deterministic_debug_mode.html
+++ b/docs/2.0/generated/torch.get_deterministic_debug_mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_float32_matmul_precision.html
+++ b/docs/2.0/generated/torch.get_float32_matmul_precision.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_num_interop_threads.html
+++ b/docs/2.0/generated/torch.get_num_interop_threads.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_num_threads.html
+++ b/docs/2.0/generated/torch.get_num_threads.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.get_rng_state.html
+++ b/docs/2.0/generated/torch.get_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.gradient.html
+++ b/docs/2.0/generated/torch.gradient.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.greater.html
+++ b/docs/2.0/generated/torch.greater.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.greater_equal.html
+++ b/docs/2.0/generated/torch.greater_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.gt.html
+++ b/docs/2.0/generated/torch.gt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hamming_window.html
+++ b/docs/2.0/generated/torch.hamming_window.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hann_window.html
+++ b/docs/2.0/generated/torch.hann_window.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.heaviside.html
+++ b/docs/2.0/generated/torch.heaviside.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.histc.html
+++ b/docs/2.0/generated/torch.histc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.histogram.html
+++ b/docs/2.0/generated/torch.histogram.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.histogramdd.html
+++ b/docs/2.0/generated/torch.histogramdd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hsplit.html
+++ b/docs/2.0/generated/torch.hsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hspmm.html
+++ b/docs/2.0/generated/torch.hspmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hstack.html
+++ b/docs/2.0/generated/torch.hstack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.hypot.html
+++ b/docs/2.0/generated/torch.hypot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.i0.html
+++ b/docs/2.0/generated/torch.i0.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.igamma.html
+++ b/docs/2.0/generated/torch.igamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.igammac.html
+++ b/docs/2.0/generated/torch.igammac.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.imag.html
+++ b/docs/2.0/generated/torch.imag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.index_add.html
+++ b/docs/2.0/generated/torch.index_add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.index_copy.html
+++ b/docs/2.0/generated/torch.index_copy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.index_reduce.html
+++ b/docs/2.0/generated/torch.index_reduce.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.index_select.html
+++ b/docs/2.0/generated/torch.index_select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.inference_mode.html
+++ b/docs/2.0/generated/torch.inference_mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.initial_seed.html
+++ b/docs/2.0/generated/torch.initial_seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.inner.html
+++ b/docs/2.0/generated/torch.inner.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.inverse.html
+++ b/docs/2.0/generated/torch.inverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_complex.html
+++ b/docs/2.0/generated/torch.is_complex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_conj.html
+++ b/docs/2.0/generated/torch.is_conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_deterministic_algorithms_warn_only_enabled.html
+++ b/docs/2.0/generated/torch.is_deterministic_algorithms_warn_only_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_floating_point.html
+++ b/docs/2.0/generated/torch.is_floating_point.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_grad_enabled.html
+++ b/docs/2.0/generated/torch.is_grad_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_inference_mode_enabled.html
+++ b/docs/2.0/generated/torch.is_inference_mode_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_nonzero.html
+++ b/docs/2.0/generated/torch.is_nonzero.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_storage.html
+++ b/docs/2.0/generated/torch.is_storage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_tensor.html
+++ b/docs/2.0/generated/torch.is_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.is_warn_always_enabled.html
+++ b/docs/2.0/generated/torch.is_warn_always_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isclose.html
+++ b/docs/2.0/generated/torch.isclose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isfinite.html
+++ b/docs/2.0/generated/torch.isfinite.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isin.html
+++ b/docs/2.0/generated/torch.isin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isinf.html
+++ b/docs/2.0/generated/torch.isinf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isnan.html
+++ b/docs/2.0/generated/torch.isnan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isneginf.html
+++ b/docs/2.0/generated/torch.isneginf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isposinf.html
+++ b/docs/2.0/generated/torch.isposinf.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.isreal.html
+++ b/docs/2.0/generated/torch.isreal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.istft.html
+++ b/docs/2.0/generated/torch.istft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.Attribute.html
+++ b/docs/2.0/generated/torch.jit.Attribute.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.ScriptFunction.html
+++ b/docs/2.0/generated/torch.jit.ScriptFunction.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.ScriptModule.html
+++ b/docs/2.0/generated/torch.jit.ScriptModule.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.annotate.html
+++ b/docs/2.0/generated/torch.jit.annotate.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.enable_onednn_fusion.html
+++ b/docs/2.0/generated/torch.jit.enable_onednn_fusion.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.fork.html
+++ b/docs/2.0/generated/torch.jit.fork.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.freeze.html
+++ b/docs/2.0/generated/torch.jit.freeze.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.ignore.html
+++ b/docs/2.0/generated/torch.jit.ignore.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.isinstance.html
+++ b/docs/2.0/generated/torch.jit.isinstance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.load.html
+++ b/docs/2.0/generated/torch.jit.load.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.onednn_fusion_enabled.html
+++ b/docs/2.0/generated/torch.jit.onednn_fusion_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.optimize_for_inference.html
+++ b/docs/2.0/generated/torch.jit.optimize_for_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.save.html
+++ b/docs/2.0/generated/torch.jit.save.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.script.html
+++ b/docs/2.0/generated/torch.jit.script.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.script_if_tracing.html
+++ b/docs/2.0/generated/torch.jit.script_if_tracing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.set_fusion_strategy.html
+++ b/docs/2.0/generated/torch.jit.set_fusion_strategy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.strict_fusion.html
+++ b/docs/2.0/generated/torch.jit.strict_fusion.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.trace.html
+++ b/docs/2.0/generated/torch.jit.trace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.trace_module.html
+++ b/docs/2.0/generated/torch.jit.trace_module.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.unused.html
+++ b/docs/2.0/generated/torch.jit.unused.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.jit.wait.html
+++ b/docs/2.0/generated/torch.jit.wait.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.kaiser_window.html
+++ b/docs/2.0/generated/torch.kaiser_window.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.kron.html
+++ b/docs/2.0/generated/torch.kron.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.kthvalue.html
+++ b/docs/2.0/generated/torch.kthvalue.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lcm.html
+++ b/docs/2.0/generated/torch.lcm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ldexp.html
+++ b/docs/2.0/generated/torch.ldexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.le.html
+++ b/docs/2.0/generated/torch.le.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lerp.html
+++ b/docs/2.0/generated/torch.lerp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.less.html
+++ b/docs/2.0/generated/torch.less.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.less_equal.html
+++ b/docs/2.0/generated/torch.less_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lgamma.html
+++ b/docs/2.0/generated/torch.lgamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.cholesky.html
+++ b/docs/2.0/generated/torch.linalg.cholesky.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.cholesky_ex.html
+++ b/docs/2.0/generated/torch.linalg.cholesky_ex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.cond.html
+++ b/docs/2.0/generated/torch.linalg.cond.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.cross.html
+++ b/docs/2.0/generated/torch.linalg.cross.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.det.html
+++ b/docs/2.0/generated/torch.linalg.det.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.diagonal.html
+++ b/docs/2.0/generated/torch.linalg.diagonal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.eig.html
+++ b/docs/2.0/generated/torch.linalg.eig.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.eigh.html
+++ b/docs/2.0/generated/torch.linalg.eigh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.eigvals.html
+++ b/docs/2.0/generated/torch.linalg.eigvals.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.eigvalsh.html
+++ b/docs/2.0/generated/torch.linalg.eigvalsh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.householder_product.html
+++ b/docs/2.0/generated/torch.linalg.householder_product.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.inv.html
+++ b/docs/2.0/generated/torch.linalg.inv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.inv_ex.html
+++ b/docs/2.0/generated/torch.linalg.inv_ex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.ldl_factor.html
+++ b/docs/2.0/generated/torch.linalg.ldl_factor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.ldl_factor_ex.html
+++ b/docs/2.0/generated/torch.linalg.ldl_factor_ex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.ldl_solve.html
+++ b/docs/2.0/generated/torch.linalg.ldl_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.lstsq.html
+++ b/docs/2.0/generated/torch.linalg.lstsq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.lu.html
+++ b/docs/2.0/generated/torch.linalg.lu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.lu_factor.html
+++ b/docs/2.0/generated/torch.linalg.lu_factor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.lu_factor_ex.html
+++ b/docs/2.0/generated/torch.linalg.lu_factor_ex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.lu_solve.html
+++ b/docs/2.0/generated/torch.linalg.lu_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.matmul.html
+++ b/docs/2.0/generated/torch.linalg.matmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.matrix_exp.html
+++ b/docs/2.0/generated/torch.linalg.matrix_exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.matrix_norm.html
+++ b/docs/2.0/generated/torch.linalg.matrix_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.matrix_power.html
+++ b/docs/2.0/generated/torch.linalg.matrix_power.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.matrix_rank.html
+++ b/docs/2.0/generated/torch.linalg.matrix_rank.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.multi_dot.html
+++ b/docs/2.0/generated/torch.linalg.multi_dot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.norm.html
+++ b/docs/2.0/generated/torch.linalg.norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.pinv.html
+++ b/docs/2.0/generated/torch.linalg.pinv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.qr.html
+++ b/docs/2.0/generated/torch.linalg.qr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.slogdet.html
+++ b/docs/2.0/generated/torch.linalg.slogdet.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.solve.html
+++ b/docs/2.0/generated/torch.linalg.solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.solve_ex.html
+++ b/docs/2.0/generated/torch.linalg.solve_ex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.solve_triangular.html
+++ b/docs/2.0/generated/torch.linalg.solve_triangular.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.svd.html
+++ b/docs/2.0/generated/torch.linalg.svd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.svdvals.html
+++ b/docs/2.0/generated/torch.linalg.svdvals.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.tensorinv.html
+++ b/docs/2.0/generated/torch.linalg.tensorinv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.tensorsolve.html
+++ b/docs/2.0/generated/torch.linalg.tensorsolve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.vander.html
+++ b/docs/2.0/generated/torch.linalg.vander.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.vecdot.html
+++ b/docs/2.0/generated/torch.linalg.vecdot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linalg.vector_norm.html
+++ b/docs/2.0/generated/torch.linalg.vector_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.linspace.html
+++ b/docs/2.0/generated/torch.linspace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.load.html
+++ b/docs/2.0/generated/torch.load.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lobpcg.html
+++ b/docs/2.0/generated/torch.lobpcg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.log.html
+++ b/docs/2.0/generated/torch.log.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.log10.html
+++ b/docs/2.0/generated/torch.log10.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.log1p.html
+++ b/docs/2.0/generated/torch.log1p.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.log2.html
+++ b/docs/2.0/generated/torch.log2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logaddexp.html
+++ b/docs/2.0/generated/torch.logaddexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logaddexp2.html
+++ b/docs/2.0/generated/torch.logaddexp2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logcumsumexp.html
+++ b/docs/2.0/generated/torch.logcumsumexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logdet.html
+++ b/docs/2.0/generated/torch.logdet.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logical_and.html
+++ b/docs/2.0/generated/torch.logical_and.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logical_not.html
+++ b/docs/2.0/generated/torch.logical_not.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logical_or.html
+++ b/docs/2.0/generated/torch.logical_or.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logical_xor.html
+++ b/docs/2.0/generated/torch.logical_xor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logit.html
+++ b/docs/2.0/generated/torch.logit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logspace.html
+++ b/docs/2.0/generated/torch.logspace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.logsumexp.html
+++ b/docs/2.0/generated/torch.logsumexp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lt.html
+++ b/docs/2.0/generated/torch.lt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lu.html
+++ b/docs/2.0/generated/torch.lu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lu_solve.html
+++ b/docs/2.0/generated/torch.lu_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.lu_unpack.html
+++ b/docs/2.0/generated/torch.lu_unpack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.manual_seed.html
+++ b/docs/2.0/generated/torch.manual_seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.masked_select.html
+++ b/docs/2.0/generated/torch.masked_select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.matmul.html
+++ b/docs/2.0/generated/torch.matmul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.matrix_exp.html
+++ b/docs/2.0/generated/torch.matrix_exp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.matrix_power.html
+++ b/docs/2.0/generated/torch.matrix_power.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.max.html
+++ b/docs/2.0/generated/torch.max.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.maximum.html
+++ b/docs/2.0/generated/torch.maximum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mean.html
+++ b/docs/2.0/generated/torch.mean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.median.html
+++ b/docs/2.0/generated/torch.median.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.meshgrid.html
+++ b/docs/2.0/generated/torch.meshgrid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.min.html
+++ b/docs/2.0/generated/torch.min.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.minimum.html
+++ b/docs/2.0/generated/torch.minimum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mm.html
+++ b/docs/2.0/generated/torch.mm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mode.html
+++ b/docs/2.0/generated/torch.mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.moveaxis.html
+++ b/docs/2.0/generated/torch.moveaxis.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.movedim.html
+++ b/docs/2.0/generated/torch.movedim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.current_allocated_memory.html
+++ b/docs/2.0/generated/torch.mps.current_allocated_memory.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.driver_allocated_memory.html
+++ b/docs/2.0/generated/torch.mps.driver_allocated_memory.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.empty_cache.html
+++ b/docs/2.0/generated/torch.mps.empty_cache.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.get_rng_state.html
+++ b/docs/2.0/generated/torch.mps.get_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.manual_seed.html
+++ b/docs/2.0/generated/torch.mps.manual_seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.seed.html
+++ b/docs/2.0/generated/torch.mps.seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.set_per_process_memory_fraction.html
+++ b/docs/2.0/generated/torch.mps.set_per_process_memory_fraction.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.set_rng_state.html
+++ b/docs/2.0/generated/torch.mps.set_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mps.synchronize.html
+++ b/docs/2.0/generated/torch.mps.synchronize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.msort.html
+++ b/docs/2.0/generated/torch.msort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mul.html
+++ b/docs/2.0/generated/torch.mul.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.multinomial.html
+++ b/docs/2.0/generated/torch.multinomial.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.multiply.html
+++ b/docs/2.0/generated/torch.multiply.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mv.html
+++ b/docs/2.0/generated/torch.mv.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.mvlgamma.html
+++ b/docs/2.0/generated/torch.mvlgamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nan_to_num.html
+++ b/docs/2.0/generated/torch.nan_to_num.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nanmean.html
+++ b/docs/2.0/generated/torch.nanmean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nanmedian.html
+++ b/docs/2.0/generated/torch.nanmedian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nanquantile.html
+++ b/docs/2.0/generated/torch.nanquantile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nansum.html
+++ b/docs/2.0/generated/torch.nansum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.narrow.html
+++ b/docs/2.0/generated/torch.narrow.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.narrow_copy.html
+++ b/docs/2.0/generated/torch.narrow_copy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ne.html
+++ b/docs/2.0/generated/torch.ne.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.neg.html
+++ b/docs/2.0/generated/torch.neg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.negative.html
+++ b/docs/2.0/generated/torch.negative.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nextafter.html
+++ b/docs/2.0/generated/torch.nextafter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveAvgPool1d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveAvgPool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveAvgPool2d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveAvgPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveAvgPool3d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveAvgPool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveLogSoftmaxWithLoss.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveLogSoftmaxWithLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveMaxPool1d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveMaxPool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveMaxPool2d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveMaxPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AdaptiveMaxPool3d.html
+++ b/docs/2.0/generated/torch.nn.AdaptiveMaxPool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AlphaDropout.html
+++ b/docs/2.0/generated/torch.nn.AlphaDropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AvgPool1d.html
+++ b/docs/2.0/generated/torch.nn.AvgPool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AvgPool2d.html
+++ b/docs/2.0/generated/torch.nn.AvgPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.AvgPool3d.html
+++ b/docs/2.0/generated/torch.nn.AvgPool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.BCELoss.html
+++ b/docs/2.0/generated/torch.nn.BCELoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.BCEWithLogitsLoss.html
+++ b/docs/2.0/generated/torch.nn.BCEWithLogitsLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.BatchNorm1d.html
+++ b/docs/2.0/generated/torch.nn.BatchNorm1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.BatchNorm2d.html
+++ b/docs/2.0/generated/torch.nn.BatchNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.BatchNorm3d.html
+++ b/docs/2.0/generated/torch.nn.BatchNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Bilinear.html
+++ b/docs/2.0/generated/torch.nn.Bilinear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.CELU.html
+++ b/docs/2.0/generated/torch.nn.CELU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.CTCLoss.html
+++ b/docs/2.0/generated/torch.nn.CTCLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ChannelShuffle.html
+++ b/docs/2.0/generated/torch.nn.ChannelShuffle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConstantPad1d.html
+++ b/docs/2.0/generated/torch.nn.ConstantPad1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConstantPad2d.html
+++ b/docs/2.0/generated/torch.nn.ConstantPad2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConstantPad3d.html
+++ b/docs/2.0/generated/torch.nn.ConstantPad3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Conv1d.html
+++ b/docs/2.0/generated/torch.nn.Conv1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Conv2d.html
+++ b/docs/2.0/generated/torch.nn.Conv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Conv3d.html
+++ b/docs/2.0/generated/torch.nn.Conv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConvTranspose1d.html
+++ b/docs/2.0/generated/torch.nn.ConvTranspose1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConvTranspose2d.html
+++ b/docs/2.0/generated/torch.nn.ConvTranspose2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ConvTranspose3d.html
+++ b/docs/2.0/generated/torch.nn.ConvTranspose3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.CosineEmbeddingLoss.html
+++ b/docs/2.0/generated/torch.nn.CosineEmbeddingLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.CosineSimilarity.html
+++ b/docs/2.0/generated/torch.nn.CosineSimilarity.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.CrossEntropyLoss.html
+++ b/docs/2.0/generated/torch.nn.CrossEntropyLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.DataParallel.html
+++ b/docs/2.0/generated/torch.nn.DataParallel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Dropout.html
+++ b/docs/2.0/generated/torch.nn.Dropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Dropout1d.html
+++ b/docs/2.0/generated/torch.nn.Dropout1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Dropout2d.html
+++ b/docs/2.0/generated/torch.nn.Dropout2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Dropout3d.html
+++ b/docs/2.0/generated/torch.nn.Dropout3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ELU.html
+++ b/docs/2.0/generated/torch.nn.ELU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Embedding.html
+++ b/docs/2.0/generated/torch.nn.Embedding.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.EmbeddingBag.html
+++ b/docs/2.0/generated/torch.nn.EmbeddingBag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.FeatureAlphaDropout.html
+++ b/docs/2.0/generated/torch.nn.FeatureAlphaDropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Flatten.html
+++ b/docs/2.0/generated/torch.nn.Flatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Fold.html
+++ b/docs/2.0/generated/torch.nn.Fold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.FractionalMaxPool2d.html
+++ b/docs/2.0/generated/torch.nn.FractionalMaxPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.FractionalMaxPool3d.html
+++ b/docs/2.0/generated/torch.nn.FractionalMaxPool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GELU.html
+++ b/docs/2.0/generated/torch.nn.GELU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GLU.html
+++ b/docs/2.0/generated/torch.nn.GLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GRU.html
+++ b/docs/2.0/generated/torch.nn.GRU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GRUCell.html
+++ b/docs/2.0/generated/torch.nn.GRUCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GaussianNLLLoss.html
+++ b/docs/2.0/generated/torch.nn.GaussianNLLLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.GroupNorm.html
+++ b/docs/2.0/generated/torch.nn.GroupNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Hardshrink.html
+++ b/docs/2.0/generated/torch.nn.Hardshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Hardsigmoid.html
+++ b/docs/2.0/generated/torch.nn.Hardsigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Hardswish.html
+++ b/docs/2.0/generated/torch.nn.Hardswish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Hardtanh.html
+++ b/docs/2.0/generated/torch.nn.Hardtanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.HingeEmbeddingLoss.html
+++ b/docs/2.0/generated/torch.nn.HingeEmbeddingLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.HuberLoss.html
+++ b/docs/2.0/generated/torch.nn.HuberLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Identity.html
+++ b/docs/2.0/generated/torch.nn.Identity.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.InstanceNorm1d.html
+++ b/docs/2.0/generated/torch.nn.InstanceNorm1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.InstanceNorm2d.html
+++ b/docs/2.0/generated/torch.nn.InstanceNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.InstanceNorm3d.html
+++ b/docs/2.0/generated/torch.nn.InstanceNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.KLDivLoss.html
+++ b/docs/2.0/generated/torch.nn.KLDivLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.L1Loss.html
+++ b/docs/2.0/generated/torch.nn.L1Loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LPPool1d.html
+++ b/docs/2.0/generated/torch.nn.LPPool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LPPool2d.html
+++ b/docs/2.0/generated/torch.nn.LPPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LSTM.html
+++ b/docs/2.0/generated/torch.nn.LSTM.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LSTMCell.html
+++ b/docs/2.0/generated/torch.nn.LSTMCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LayerNorm.html
+++ b/docs/2.0/generated/torch.nn.LayerNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyBatchNorm1d.html
+++ b/docs/2.0/generated/torch.nn.LazyBatchNorm1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyBatchNorm2d.html
+++ b/docs/2.0/generated/torch.nn.LazyBatchNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyBatchNorm3d.html
+++ b/docs/2.0/generated/torch.nn.LazyBatchNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConv1d.html
+++ b/docs/2.0/generated/torch.nn.LazyConv1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConv2d.html
+++ b/docs/2.0/generated/torch.nn.LazyConv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConv3d.html
+++ b/docs/2.0/generated/torch.nn.LazyConv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConvTranspose1d.html
+++ b/docs/2.0/generated/torch.nn.LazyConvTranspose1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConvTranspose2d.html
+++ b/docs/2.0/generated/torch.nn.LazyConvTranspose2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyConvTranspose3d.html
+++ b/docs/2.0/generated/torch.nn.LazyConvTranspose3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyInstanceNorm1d.html
+++ b/docs/2.0/generated/torch.nn.LazyInstanceNorm1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyInstanceNorm2d.html
+++ b/docs/2.0/generated/torch.nn.LazyInstanceNorm2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyInstanceNorm3d.html
+++ b/docs/2.0/generated/torch.nn.LazyInstanceNorm3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LazyLinear.html
+++ b/docs/2.0/generated/torch.nn.LazyLinear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LeakyReLU.html
+++ b/docs/2.0/generated/torch.nn.LeakyReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Linear.html
+++ b/docs/2.0/generated/torch.nn.Linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LocalResponseNorm.html
+++ b/docs/2.0/generated/torch.nn.LocalResponseNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LogSigmoid.html
+++ b/docs/2.0/generated/torch.nn.LogSigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.LogSoftmax.html
+++ b/docs/2.0/generated/torch.nn.LogSoftmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MSELoss.html
+++ b/docs/2.0/generated/torch.nn.MSELoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MarginRankingLoss.html
+++ b/docs/2.0/generated/torch.nn.MarginRankingLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxPool1d.html
+++ b/docs/2.0/generated/torch.nn.MaxPool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxPool2d.html
+++ b/docs/2.0/generated/torch.nn.MaxPool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxPool3d.html
+++ b/docs/2.0/generated/torch.nn.MaxPool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxUnpool1d.html
+++ b/docs/2.0/generated/torch.nn.MaxUnpool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxUnpool2d.html
+++ b/docs/2.0/generated/torch.nn.MaxUnpool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MaxUnpool3d.html
+++ b/docs/2.0/generated/torch.nn.MaxUnpool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Mish.html
+++ b/docs/2.0/generated/torch.nn.Mish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Module.html
+++ b/docs/2.0/generated/torch.nn.Module.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ModuleDict.html
+++ b/docs/2.0/generated/torch.nn.ModuleDict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ModuleList.html
+++ b/docs/2.0/generated/torch.nn.ModuleList.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MultiLabelMarginLoss.html
+++ b/docs/2.0/generated/torch.nn.MultiLabelMarginLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MultiLabelSoftMarginLoss.html
+++ b/docs/2.0/generated/torch.nn.MultiLabelSoftMarginLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MultiMarginLoss.html
+++ b/docs/2.0/generated/torch.nn.MultiMarginLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.MultiheadAttention.html
+++ b/docs/2.0/generated/torch.nn.MultiheadAttention.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.NLLLoss.html
+++ b/docs/2.0/generated/torch.nn.NLLLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.PReLU.html
+++ b/docs/2.0/generated/torch.nn.PReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.PairwiseDistance.html
+++ b/docs/2.0/generated/torch.nn.PairwiseDistance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ParameterDict.html
+++ b/docs/2.0/generated/torch.nn.ParameterDict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ParameterList.html
+++ b/docs/2.0/generated/torch.nn.ParameterList.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.PixelShuffle.html
+++ b/docs/2.0/generated/torch.nn.PixelShuffle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.PixelUnshuffle.html
+++ b/docs/2.0/generated/torch.nn.PixelUnshuffle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.PoissonNLLLoss.html
+++ b/docs/2.0/generated/torch.nn.PoissonNLLLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.RNN.html
+++ b/docs/2.0/generated/torch.nn.RNN.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.RNNBase.html
+++ b/docs/2.0/generated/torch.nn.RNNBase.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.RNNCell.html
+++ b/docs/2.0/generated/torch.nn.RNNCell.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.RReLU.html
+++ b/docs/2.0/generated/torch.nn.RReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReLU.html
+++ b/docs/2.0/generated/torch.nn.ReLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReLU6.html
+++ b/docs/2.0/generated/torch.nn.ReLU6.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReflectionPad1d.html
+++ b/docs/2.0/generated/torch.nn.ReflectionPad1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReflectionPad2d.html
+++ b/docs/2.0/generated/torch.nn.ReflectionPad2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReflectionPad3d.html
+++ b/docs/2.0/generated/torch.nn.ReflectionPad3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReplicationPad1d.html
+++ b/docs/2.0/generated/torch.nn.ReplicationPad1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReplicationPad2d.html
+++ b/docs/2.0/generated/torch.nn.ReplicationPad2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ReplicationPad3d.html
+++ b/docs/2.0/generated/torch.nn.ReplicationPad3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.SELU.html
+++ b/docs/2.0/generated/torch.nn.SELU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Sequential.html
+++ b/docs/2.0/generated/torch.nn.Sequential.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.SiLU.html
+++ b/docs/2.0/generated/torch.nn.SiLU.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Sigmoid.html
+++ b/docs/2.0/generated/torch.nn.Sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.SmoothL1Loss.html
+++ b/docs/2.0/generated/torch.nn.SmoothL1Loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.SoftMarginLoss.html
+++ b/docs/2.0/generated/torch.nn.SoftMarginLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softmax.html
+++ b/docs/2.0/generated/torch.nn.Softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softmax2d.html
+++ b/docs/2.0/generated/torch.nn.Softmax2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softmin.html
+++ b/docs/2.0/generated/torch.nn.Softmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softplus.html
+++ b/docs/2.0/generated/torch.nn.Softplus.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softshrink.html
+++ b/docs/2.0/generated/torch.nn.Softshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Softsign.html
+++ b/docs/2.0/generated/torch.nn.Softsign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.SyncBatchNorm.html
+++ b/docs/2.0/generated/torch.nn.SyncBatchNorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Tanh.html
+++ b/docs/2.0/generated/torch.nn.Tanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Tanhshrink.html
+++ b/docs/2.0/generated/torch.nn.Tanhshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Threshold.html
+++ b/docs/2.0/generated/torch.nn.Threshold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Transformer.html
+++ b/docs/2.0/generated/torch.nn.Transformer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TransformerDecoder.html
+++ b/docs/2.0/generated/torch.nn.TransformerDecoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TransformerDecoderLayer.html
+++ b/docs/2.0/generated/torch.nn.TransformerDecoderLayer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TransformerEncoder.html
+++ b/docs/2.0/generated/torch.nn.TransformerEncoder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TransformerEncoderLayer.html
+++ b/docs/2.0/generated/torch.nn.TransformerEncoderLayer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TripletMarginLoss.html
+++ b/docs/2.0/generated/torch.nn.TripletMarginLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.TripletMarginWithDistanceLoss.html
+++ b/docs/2.0/generated/torch.nn.TripletMarginWithDistanceLoss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Unflatten.html
+++ b/docs/2.0/generated/torch.nn.Unflatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Unfold.html
+++ b/docs/2.0/generated/torch.nn.Unfold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.Upsample.html
+++ b/docs/2.0/generated/torch.nn.Upsample.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.UpsamplingBilinear2d.html
+++ b/docs/2.0/generated/torch.nn.UpsamplingBilinear2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.UpsamplingNearest2d.html
+++ b/docs/2.0/generated/torch.nn.UpsamplingNearest2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.ZeroPad2d.html
+++ b/docs/2.0/generated/torch.nn.ZeroPad2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_avg_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_max_pool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_max_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_max_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_max_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.adaptive_max_pool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.adaptive_max_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.affine_grid.html
+++ b/docs/2.0/generated/torch.nn.functional.affine_grid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.alpha_dropout.html
+++ b/docs/2.0/generated/torch.nn.functional.alpha_dropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.avg_pool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.avg_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.avg_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.avg_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.avg_pool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.avg_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.batch_norm.html
+++ b/docs/2.0/generated/torch.nn.functional.batch_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.bilinear.html
+++ b/docs/2.0/generated/torch.nn.functional.bilinear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.binary_cross_entropy.html
+++ b/docs/2.0/generated/torch.nn.functional.binary_cross_entropy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.binary_cross_entropy_with_logits.html
+++ b/docs/2.0/generated/torch.nn.functional.binary_cross_entropy_with_logits.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.celu.html
+++ b/docs/2.0/generated/torch.nn.functional.celu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv1d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv2d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv3d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv_transpose1d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv_transpose1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv_transpose2d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv_transpose2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.conv_transpose3d.html
+++ b/docs/2.0/generated/torch.nn.functional.conv_transpose3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.cosine_embedding_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.cosine_embedding_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.cosine_similarity.html
+++ b/docs/2.0/generated/torch.nn.functional.cosine_similarity.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.cross_entropy.html
+++ b/docs/2.0/generated/torch.nn.functional.cross_entropy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.ctc_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.ctc_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.dropout.html
+++ b/docs/2.0/generated/torch.nn.functional.dropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.dropout1d.html
+++ b/docs/2.0/generated/torch.nn.functional.dropout1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.dropout2d.html
+++ b/docs/2.0/generated/torch.nn.functional.dropout2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.dropout3d.html
+++ b/docs/2.0/generated/torch.nn.functional.dropout3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.elu.html
+++ b/docs/2.0/generated/torch.nn.functional.elu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.elu_.html
+++ b/docs/2.0/generated/torch.nn.functional.elu_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.embedding.html
+++ b/docs/2.0/generated/torch.nn.functional.embedding.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.embedding_bag.html
+++ b/docs/2.0/generated/torch.nn.functional.embedding_bag.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.feature_alpha_dropout.html
+++ b/docs/2.0/generated/torch.nn.functional.feature_alpha_dropout.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.fold.html
+++ b/docs/2.0/generated/torch.nn.functional.fold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.fractional_max_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.fractional_max_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.fractional_max_pool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.fractional_max_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.gaussian_nll_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.gaussian_nll_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.gelu.html
+++ b/docs/2.0/generated/torch.nn.functional.gelu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.glu.html
+++ b/docs/2.0/generated/torch.nn.functional.glu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.grid_sample.html
+++ b/docs/2.0/generated/torch.nn.functional.grid_sample.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.group_norm.html
+++ b/docs/2.0/generated/torch.nn.functional.group_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.gumbel_softmax.html
+++ b/docs/2.0/generated/torch.nn.functional.gumbel_softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hardshrink.html
+++ b/docs/2.0/generated/torch.nn.functional.hardshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hardsigmoid.html
+++ b/docs/2.0/generated/torch.nn.functional.hardsigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hardswish.html
+++ b/docs/2.0/generated/torch.nn.functional.hardswish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hardtanh.html
+++ b/docs/2.0/generated/torch.nn.functional.hardtanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hardtanh_.html
+++ b/docs/2.0/generated/torch.nn.functional.hardtanh_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.hinge_embedding_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.hinge_embedding_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.huber_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.huber_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.instance_norm.html
+++ b/docs/2.0/generated/torch.nn.functional.instance_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.interpolate.html
+++ b/docs/2.0/generated/torch.nn.functional.interpolate.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.kl_div.html
+++ b/docs/2.0/generated/torch.nn.functional.kl_div.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.l1_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.l1_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.layer_norm.html
+++ b/docs/2.0/generated/torch.nn.functional.layer_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.leaky_relu.html
+++ b/docs/2.0/generated/torch.nn.functional.leaky_relu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.leaky_relu_.html
+++ b/docs/2.0/generated/torch.nn.functional.leaky_relu_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.linear.html
+++ b/docs/2.0/generated/torch.nn.functional.linear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.local_response_norm.html
+++ b/docs/2.0/generated/torch.nn.functional.local_response_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.log_softmax.html
+++ b/docs/2.0/generated/torch.nn.functional.log_softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.logsigmoid.html
+++ b/docs/2.0/generated/torch.nn.functional.logsigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.lp_pool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.lp_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.lp_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.lp_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.margin_ranking_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.margin_ranking_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_pool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_pool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_pool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_pool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_unpool1d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_unpool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_unpool2d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_unpool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.max_unpool3d.html
+++ b/docs/2.0/generated/torch.nn.functional.max_unpool3d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.mish.html
+++ b/docs/2.0/generated/torch.nn.functional.mish.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.mse_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.mse_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.multi_margin_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.multi_margin_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.multilabel_margin_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.multilabel_margin_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.multilabel_soft_margin_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.multilabel_soft_margin_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.nll_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.nll_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.normalize.html
+++ b/docs/2.0/generated/torch.nn.functional.normalize.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.one_hot.html
+++ b/docs/2.0/generated/torch.nn.functional.one_hot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.pad.html
+++ b/docs/2.0/generated/torch.nn.functional.pad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.pairwise_distance.html
+++ b/docs/2.0/generated/torch.nn.functional.pairwise_distance.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.pdist.html
+++ b/docs/2.0/generated/torch.nn.functional.pdist.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.pixel_shuffle.html
+++ b/docs/2.0/generated/torch.nn.functional.pixel_shuffle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.pixel_unshuffle.html
+++ b/docs/2.0/generated/torch.nn.functional.pixel_unshuffle.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.poisson_nll_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.poisson_nll_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.prelu.html
+++ b/docs/2.0/generated/torch.nn.functional.prelu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.relu.html
+++ b/docs/2.0/generated/torch.nn.functional.relu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.relu6.html
+++ b/docs/2.0/generated/torch.nn.functional.relu6.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.relu_.html
+++ b/docs/2.0/generated/torch.nn.functional.relu_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.rrelu.html
+++ b/docs/2.0/generated/torch.nn.functional.rrelu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.rrelu_.html
+++ b/docs/2.0/generated/torch.nn.functional.rrelu_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.scaled_dot_product_attention.html
+++ b/docs/2.0/generated/torch.nn.functional.scaled_dot_product_attention.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.selu.html
+++ b/docs/2.0/generated/torch.nn.functional.selu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.sigmoid.html
+++ b/docs/2.0/generated/torch.nn.functional.sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.silu.html
+++ b/docs/2.0/generated/torch.nn.functional.silu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.smooth_l1_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.smooth_l1_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.soft_margin_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.soft_margin_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.softmax.html
+++ b/docs/2.0/generated/torch.nn.functional.softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.softmin.html
+++ b/docs/2.0/generated/torch.nn.functional.softmin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.softplus.html
+++ b/docs/2.0/generated/torch.nn.functional.softplus.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.softshrink.html
+++ b/docs/2.0/generated/torch.nn.functional.softshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.softsign.html
+++ b/docs/2.0/generated/torch.nn.functional.softsign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.tanh.html
+++ b/docs/2.0/generated/torch.nn.functional.tanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.tanhshrink.html
+++ b/docs/2.0/generated/torch.nn.functional.tanhshrink.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.threshold.html
+++ b/docs/2.0/generated/torch.nn.functional.threshold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.threshold_.html
+++ b/docs/2.0/generated/torch.nn.functional.threshold_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.torch.nn.parallel.data_parallel.html
+++ b/docs/2.0/generated/torch.nn.functional.torch.nn.parallel.data_parallel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.triplet_margin_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.triplet_margin_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.triplet_margin_with_distance_loss.html
+++ b/docs/2.0/generated/torch.nn.functional.triplet_margin_with_distance_loss.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.unfold.html
+++ b/docs/2.0/generated/torch.nn.functional.unfold.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.upsample.html
+++ b/docs/2.0/generated/torch.nn.functional.upsample.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.upsample_bilinear.html
+++ b/docs/2.0/generated/torch.nn.functional.upsample_bilinear.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.functional.upsample_nearest.html
+++ b/docs/2.0/generated/torch.nn.functional.upsample_nearest.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.modules.lazy.LazyModuleMixin.html
+++ b/docs/2.0/generated/torch.nn.modules.lazy.LazyModuleMixin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.modules.module.register_module_backward_hook.html
+++ b/docs/2.0/generated/torch.nn.modules.module.register_module_backward_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.modules.module.register_module_forward_hook.html
+++ b/docs/2.0/generated/torch.nn.modules.module.register_module_forward_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.modules.module.register_module_forward_pre_hook.html
+++ b/docs/2.0/generated/torch.nn.modules.module.register_module_forward_pre_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.modules.module.register_module_full_backward_hook.html
+++ b/docs/2.0/generated/torch.nn.modules.module.register_module_full_backward_hook.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.parallel.DistributedDataParallel.html
+++ b/docs/2.0/generated/torch.nn.parallel.DistributedDataParallel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.parameter.Parameter.html
+++ b/docs/2.0/generated/torch.nn.parameter.Parameter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.parameter.UninitializedBuffer.html
+++ b/docs/2.0/generated/torch.nn.parameter.UninitializedBuffer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.parameter.UninitializedParameter.html
+++ b/docs/2.0/generated/torch.nn.parameter.UninitializedParameter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.clip_grad_norm_.html
+++ b/docs/2.0/generated/torch.nn.utils.clip_grad_norm_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.clip_grad_value_.html
+++ b/docs/2.0/generated/torch.nn.utils.clip_grad_value_.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parameters_to_vector.html
+++ b/docs/2.0/generated/torch.nn.utils.parameters_to_vector.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrizations.orthogonal.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrizations.orthogonal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrizations.spectral_norm.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrizations.spectral_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrize.ParametrizationList.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrize.ParametrizationList.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrize.cached.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrize.cached.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrize.is_parametrized.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrize.is_parametrized.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrize.register_parametrization.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrize.register_parametrization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.parametrize.remove_parametrizations.html
+++ b/docs/2.0/generated/torch.nn.utils.parametrize.remove_parametrizations.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.BasePruningMethod.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.BasePruningMethod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.CustomFromMask.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.CustomFromMask.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.Identity.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.Identity.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.L1Unstructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.L1Unstructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.LnStructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.LnStructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.PruningContainer.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.PruningContainer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.RandomStructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.RandomStructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.RandomUnstructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.RandomUnstructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.custom_from_mask.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.custom_from_mask.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.global_unstructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.global_unstructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.identity.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.identity.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.is_pruned.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.is_pruned.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.l1_unstructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.l1_unstructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.ln_structured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.ln_structured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.random_structured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.random_structured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.random_unstructured.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.random_unstructured.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.prune.remove.html
+++ b/docs/2.0/generated/torch.nn.utils.prune.remove.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.remove_spectral_norm.html
+++ b/docs/2.0/generated/torch.nn.utils.remove_spectral_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.remove_weight_norm.html
+++ b/docs/2.0/generated/torch.nn.utils.remove_weight_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.PackedSequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.PackedSequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.pack_padded_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.pack_padded_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.pack_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.pack_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.pad_packed_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.pad_packed_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.pad_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.pad_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.unpack_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.unpack_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.rnn.unpad_sequence.html
+++ b/docs/2.0/generated/torch.nn.utils.rnn.unpad_sequence.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.skip_init.html
+++ b/docs/2.0/generated/torch.nn.utils.skip_init.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.spectral_norm.html
+++ b/docs/2.0/generated/torch.nn.utils.spectral_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.stateless.functional_call.html
+++ b/docs/2.0/generated/torch.nn.utils.stateless.functional_call.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.vector_to_parameters.html
+++ b/docs/2.0/generated/torch.nn.utils.vector_to_parameters.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nn.utils.weight_norm.html
+++ b/docs/2.0/generated/torch.nn.utils.weight_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.no_grad.html
+++ b/docs/2.0/generated/torch.no_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.nonzero.html
+++ b/docs/2.0/generated/torch.nonzero.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.norm.html
+++ b/docs/2.0/generated/torch.norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.normal.html
+++ b/docs/2.0/generated/torch.normal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.not_equal.html
+++ b/docs/2.0/generated/torch.not_equal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.numel.html
+++ b/docs/2.0/generated/torch.numel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ones.html
+++ b/docs/2.0/generated/torch.ones.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ones_like.html
+++ b/docs/2.0/generated/torch.ones_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.onnx.JitScalarType.html
+++ b/docs/2.0/generated/torch.onnx.JitScalarType.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.onnx.verification.GraphInfo.html
+++ b/docs/2.0/generated/torch.onnx.verification.GraphInfo.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.onnx.verification.VerificationOptions.html
+++ b/docs/2.0/generated/torch.onnx.verification.VerificationOptions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.ASGD.html
+++ b/docs/2.0/generated/torch.optim.ASGD.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Adadelta.html
+++ b/docs/2.0/generated/torch.optim.Adadelta.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Adagrad.html
+++ b/docs/2.0/generated/torch.optim.Adagrad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Adam.html
+++ b/docs/2.0/generated/torch.optim.Adam.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.AdamW.html
+++ b/docs/2.0/generated/torch.optim.AdamW.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Adamax.html
+++ b/docs/2.0/generated/torch.optim.Adamax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.LBFGS.html
+++ b/docs/2.0/generated/torch.optim.LBFGS.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.NAdam.html
+++ b/docs/2.0/generated/torch.optim.NAdam.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Optimizer.add_param_group.html
+++ b/docs/2.0/generated/torch.optim.Optimizer.add_param_group.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Optimizer.load_state_dict.html
+++ b/docs/2.0/generated/torch.optim.Optimizer.load_state_dict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Optimizer.state_dict.html
+++ b/docs/2.0/generated/torch.optim.Optimizer.state_dict.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Optimizer.step.html
+++ b/docs/2.0/generated/torch.optim.Optimizer.step.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Optimizer.zero_grad.html
+++ b/docs/2.0/generated/torch.optim.Optimizer.zero_grad.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.RAdam.html
+++ b/docs/2.0/generated/torch.optim.RAdam.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.RMSprop.html
+++ b/docs/2.0/generated/torch.optim.RMSprop.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.Rprop.html
+++ b/docs/2.0/generated/torch.optim.Rprop.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.SGD.html
+++ b/docs/2.0/generated/torch.optim.SGD.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.SparseAdam.html
+++ b/docs/2.0/generated/torch.optim.SparseAdam.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.ChainedScheduler.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.ChainedScheduler.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.ConstantLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.ConstantLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.CosineAnnealingLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.CosineAnnealingWarmRestarts.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.CosineAnnealingWarmRestarts.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.CyclicLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.CyclicLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.ExponentialLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.ExponentialLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.LambdaLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.LambdaLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.LinearLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.LinearLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.MultiStepLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.MultiStepLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.MultiplicativeLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.MultiplicativeLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.OneCycleLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.OneCycleLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.PolynomialLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.PolynomialLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.SequentialLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.SequentialLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.optim.lr_scheduler.StepLR.html
+++ b/docs/2.0/generated/torch.optim.lr_scheduler.StepLR.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.orgqr.html
+++ b/docs/2.0/generated/torch.orgqr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ormqr.html
+++ b/docs/2.0/generated/torch.ormqr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.outer.html
+++ b/docs/2.0/generated/torch.outer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.pca_lowrank.html
+++ b/docs/2.0/generated/torch.pca_lowrank.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.permute.html
+++ b/docs/2.0/generated/torch.permute.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.pinverse.html
+++ b/docs/2.0/generated/torch.pinverse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.poisson.html
+++ b/docs/2.0/generated/torch.poisson.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.polar.html
+++ b/docs/2.0/generated/torch.polar.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.polygamma.html
+++ b/docs/2.0/generated/torch.polygamma.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.positive.html
+++ b/docs/2.0/generated/torch.positive.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.pow.html
+++ b/docs/2.0/generated/torch.pow.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.prod.html
+++ b/docs/2.0/generated/torch.prod.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.promote_types.html
+++ b/docs/2.0/generated/torch.promote_types.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.qr.html
+++ b/docs/2.0/generated/torch.qr.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantile.html
+++ b/docs/2.0/generated/torch.quantile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantize_per_channel.html
+++ b/docs/2.0/generated/torch.quantize_per_channel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantize_per_tensor.html
+++ b/docs/2.0/generated/torch.quantize_per_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantized_batch_norm.html
+++ b/docs/2.0/generated/torch.quantized_batch_norm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantized_max_pool1d.html
+++ b/docs/2.0/generated/torch.quantized_max_pool1d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quantized_max_pool2d.html
+++ b/docs/2.0/generated/torch.quantized_max_pool2d.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.quasirandom.SobolEngine.html
+++ b/docs/2.0/generated/torch.quasirandom.SobolEngine.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.rad2deg.html
+++ b/docs/2.0/generated/torch.rad2deg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.rand.html
+++ b/docs/2.0/generated/torch.rand.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.rand_like.html
+++ b/docs/2.0/generated/torch.rand_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.randint.html
+++ b/docs/2.0/generated/torch.randint.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.randint_like.html
+++ b/docs/2.0/generated/torch.randint_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.randn.html
+++ b/docs/2.0/generated/torch.randn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.randn_like.html
+++ b/docs/2.0/generated/torch.randn_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.randperm.html
+++ b/docs/2.0/generated/torch.randperm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.range.html
+++ b/docs/2.0/generated/torch.range.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.ravel.html
+++ b/docs/2.0/generated/torch.ravel.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.real.html
+++ b/docs/2.0/generated/torch.real.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.reciprocal.html
+++ b/docs/2.0/generated/torch.reciprocal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.remainder.html
+++ b/docs/2.0/generated/torch.remainder.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.renorm.html
+++ b/docs/2.0/generated/torch.renorm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.repeat_interleave.html
+++ b/docs/2.0/generated/torch.repeat_interleave.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.reshape.html
+++ b/docs/2.0/generated/torch.reshape.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.resolve_conj.html
+++ b/docs/2.0/generated/torch.resolve_conj.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.resolve_neg.html
+++ b/docs/2.0/generated/torch.resolve_neg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.result_type.html
+++ b/docs/2.0/generated/torch.result_type.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.roll.html
+++ b/docs/2.0/generated/torch.roll.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.rot90.html
+++ b/docs/2.0/generated/torch.rot90.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.round.html
+++ b/docs/2.0/generated/torch.round.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.row_stack.html
+++ b/docs/2.0/generated/torch.row_stack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.rsqrt.html
+++ b/docs/2.0/generated/torch.rsqrt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.save.html
+++ b/docs/2.0/generated/torch.save.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.scatter.html
+++ b/docs/2.0/generated/torch.scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.scatter_add.html
+++ b/docs/2.0/generated/torch.scatter_add.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.scatter_reduce.html
+++ b/docs/2.0/generated/torch.scatter_reduce.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.searchsorted.html
+++ b/docs/2.0/generated/torch.searchsorted.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.seed.html
+++ b/docs/2.0/generated/torch.seed.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.select.html
+++ b/docs/2.0/generated/torch.select.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.select_scatter.html
+++ b/docs/2.0/generated/torch.select_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_default_device.html
+++ b/docs/2.0/generated/torch.set_default_device.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_default_dtype.html
+++ b/docs/2.0/generated/torch.set_default_dtype.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_default_tensor_type.html
+++ b/docs/2.0/generated/torch.set_default_tensor_type.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_deterministic_debug_mode.html
+++ b/docs/2.0/generated/torch.set_deterministic_debug_mode.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_float32_matmul_precision.html
+++ b/docs/2.0/generated/torch.set_float32_matmul_precision.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_flush_denormal.html
+++ b/docs/2.0/generated/torch.set_flush_denormal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_grad_enabled.html
+++ b/docs/2.0/generated/torch.set_grad_enabled.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_num_interop_threads.html
+++ b/docs/2.0/generated/torch.set_num_interop_threads.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_num_threads.html
+++ b/docs/2.0/generated/torch.set_num_threads.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_printoptions.html
+++ b/docs/2.0/generated/torch.set_printoptions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_rng_state.html
+++ b/docs/2.0/generated/torch.set_rng_state.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.set_warn_always.html
+++ b/docs/2.0/generated/torch.set_warn_always.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sgn.html
+++ b/docs/2.0/generated/torch.sgn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sigmoid.html
+++ b/docs/2.0/generated/torch.sigmoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sign.html
+++ b/docs/2.0/generated/torch.sign.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.bartlett.html
+++ b/docs/2.0/generated/torch.signal.windows.bartlett.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.blackman.html
+++ b/docs/2.0/generated/torch.signal.windows.blackman.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.cosine.html
+++ b/docs/2.0/generated/torch.signal.windows.cosine.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.exponential.html
+++ b/docs/2.0/generated/torch.signal.windows.exponential.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.gaussian.html
+++ b/docs/2.0/generated/torch.signal.windows.gaussian.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.general_cosine.html
+++ b/docs/2.0/generated/torch.signal.windows.general_cosine.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.general_hamming.html
+++ b/docs/2.0/generated/torch.signal.windows.general_hamming.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.hamming.html
+++ b/docs/2.0/generated/torch.signal.windows.hamming.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.hann.html
+++ b/docs/2.0/generated/torch.signal.windows.hann.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.kaiser.html
+++ b/docs/2.0/generated/torch.signal.windows.kaiser.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signal.windows.nuttall.html
+++ b/docs/2.0/generated/torch.signal.windows.nuttall.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.signbit.html
+++ b/docs/2.0/generated/torch.signbit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sin.html
+++ b/docs/2.0/generated/torch.sin.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sinc.html
+++ b/docs/2.0/generated/torch.sinc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sinh.html
+++ b/docs/2.0/generated/torch.sinh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.slice_scatter.html
+++ b/docs/2.0/generated/torch.slice_scatter.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.slogdet.html
+++ b/docs/2.0/generated/torch.slogdet.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.smm.html
+++ b/docs/2.0/generated/torch.smm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.softmax.html
+++ b/docs/2.0/generated/torch.softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sort.html
+++ b/docs/2.0/generated/torch.sort.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.addmm.html
+++ b/docs/2.0/generated/torch.sparse.addmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.check_sparse_tensor_invariants.html
+++ b/docs/2.0/generated/torch.sparse.check_sparse_tensor_invariants.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.log_softmax.html
+++ b/docs/2.0/generated/torch.sparse.log_softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.mm.html
+++ b/docs/2.0/generated/torch.sparse.mm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.sampled_addmm.html
+++ b/docs/2.0/generated/torch.sparse.sampled_addmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.softmax.html
+++ b/docs/2.0/generated/torch.sparse.softmax.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.spdiags.html
+++ b/docs/2.0/generated/torch.sparse.spdiags.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse.sum.html
+++ b/docs/2.0/generated/torch.sparse.sum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_bsc_tensor.html
+++ b/docs/2.0/generated/torch.sparse_bsc_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_bsr_tensor.html
+++ b/docs/2.0/generated/torch.sparse_bsr_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_compressed_tensor.html
+++ b/docs/2.0/generated/torch.sparse_compressed_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_coo_tensor.html
+++ b/docs/2.0/generated/torch.sparse_coo_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_csc_tensor.html
+++ b/docs/2.0/generated/torch.sparse_csc_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sparse_csr_tensor.html
+++ b/docs/2.0/generated/torch.sparse_csr_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.split.html
+++ b/docs/2.0/generated/torch.split.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sqrt.html
+++ b/docs/2.0/generated/torch.sqrt.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.square.html
+++ b/docs/2.0/generated/torch.square.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.squeeze.html
+++ b/docs/2.0/generated/torch.squeeze.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sspaddmm.html
+++ b/docs/2.0/generated/torch.sspaddmm.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.stack.html
+++ b/docs/2.0/generated/torch.stack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.std.html
+++ b/docs/2.0/generated/torch.std.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.std_mean.html
+++ b/docs/2.0/generated/torch.std_mean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.stft.html
+++ b/docs/2.0/generated/torch.stft.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sub.html
+++ b/docs/2.0/generated/torch.sub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.subtract.html
+++ b/docs/2.0/generated/torch.subtract.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sum.html
+++ b/docs/2.0/generated/torch.sum.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.svd.html
+++ b/docs/2.0/generated/torch.svd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.svd_lowrank.html
+++ b/docs/2.0/generated/torch.svd_lowrank.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.swapaxes.html
+++ b/docs/2.0/generated/torch.swapaxes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.swapdims.html
+++ b/docs/2.0/generated/torch.swapdims.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sym_float.html
+++ b/docs/2.0/generated/torch.sym_float.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sym_int.html
+++ b/docs/2.0/generated/torch.sym_int.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sym_max.html
+++ b/docs/2.0/generated/torch.sym_max.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sym_min.html
+++ b/docs/2.0/generated/torch.sym_min.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.sym_not.html
+++ b/docs/2.0/generated/torch.sym_not.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.t.html
+++ b/docs/2.0/generated/torch.t.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.take.html
+++ b/docs/2.0/generated/torch.take.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.take_along_dim.html
+++ b/docs/2.0/generated/torch.take_along_dim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tan.html
+++ b/docs/2.0/generated/torch.tan.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tanh.html
+++ b/docs/2.0/generated/torch.tanh.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tensor.html
+++ b/docs/2.0/generated/torch.tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tensor_split.html
+++ b/docs/2.0/generated/torch.tensor_split.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tensordot.html
+++ b/docs/2.0/generated/torch.tensordot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tile.html
+++ b/docs/2.0/generated/torch.tile.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.topk.html
+++ b/docs/2.0/generated/torch.topk.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.trace.html
+++ b/docs/2.0/generated/torch.trace.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.transpose.html
+++ b/docs/2.0/generated/torch.transpose.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.trapezoid.html
+++ b/docs/2.0/generated/torch.trapezoid.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.trapz.html
+++ b/docs/2.0/generated/torch.trapz.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.triangular_solve.html
+++ b/docs/2.0/generated/torch.triangular_solve.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tril.html
+++ b/docs/2.0/generated/torch.tril.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.tril_indices.html
+++ b/docs/2.0/generated/torch.tril_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.triu.html
+++ b/docs/2.0/generated/torch.triu.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.triu_indices.html
+++ b/docs/2.0/generated/torch.triu_indices.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.true_divide.html
+++ b/docs/2.0/generated/torch.true_divide.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.trunc.html
+++ b/docs/2.0/generated/torch.trunc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.unbind.html
+++ b/docs/2.0/generated/torch.unbind.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.unflatten.html
+++ b/docs/2.0/generated/torch.unflatten.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.unique.html
+++ b/docs/2.0/generated/torch.unique.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.unique_consecutive.html
+++ b/docs/2.0/generated/torch.unique_consecutive.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.unsqueeze.html
+++ b/docs/2.0/generated/torch.unsqueeze.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.use_deterministic_algorithms.html
+++ b/docs/2.0/generated/torch.use_deterministic_algorithms.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.vander.html
+++ b/docs/2.0/generated/torch.vander.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.var.html
+++ b/docs/2.0/generated/torch.var.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.var_mean.html
+++ b/docs/2.0/generated/torch.var_mean.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.vdot.html
+++ b/docs/2.0/generated/torch.vdot.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.view_as_complex.html
+++ b/docs/2.0/generated/torch.view_as_complex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.view_as_real.html
+++ b/docs/2.0/generated/torch.view_as_real.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.vmap.html
+++ b/docs/2.0/generated/torch.vmap.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.vsplit.html
+++ b/docs/2.0/generated/torch.vsplit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.vstack.html
+++ b/docs/2.0/generated/torch.vstack.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.where.html
+++ b/docs/2.0/generated/torch.where.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.xlogy.html
+++ b/docs/2.0/generated/torch.xlogy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.zeros.html
+++ b/docs/2.0/generated/torch.zeros.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/generated/torch.zeros_like.html
+++ b/docs/2.0/generated/torch.zeros_like.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/genindex.html
+++ b/docs/2.0/genindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/hub.html
+++ b/docs/2.0/hub.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/index.html
+++ b/docs/2.0/index.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/ir.html
+++ b/docs/2.0/ir.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit.html
+++ b/docs/2.0/jit.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_builtin_functions.html
+++ b/docs/2.0/jit_builtin_functions.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_language_reference.html
+++ b/docs/2.0/jit_language_reference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_language_reference_v2.html
+++ b/docs/2.0/jit_language_reference_v2.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_python_reference.html
+++ b/docs/2.0/jit_python_reference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_unsupported.html
+++ b/docs/2.0/jit_unsupported.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/jit_utils.html
+++ b/docs/2.0/jit_utils.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/library.html
+++ b/docs/2.0/library.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/linalg.html
+++ b/docs/2.0/linalg.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/masked.html
+++ b/docs/2.0/masked.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/mobile_optimizer.html
+++ b/docs/2.0/mobile_optimizer.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/model_zoo.html
+++ b/docs/2.0/model_zoo.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/monitor.html
+++ b/docs/2.0/monitor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/mps.html
+++ b/docs/2.0/mps.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/multiprocessing.html
+++ b/docs/2.0/multiprocessing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/name_inference.html
+++ b/docs/2.0/name_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/named_tensor.html
+++ b/docs/2.0/named_tensor.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/nested.html
+++ b/docs/2.0/nested.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/nn.functional.html
+++ b/docs/2.0/nn.functional.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/nn.html
+++ b/docs/2.0/nn.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/nn.init.html
+++ b/docs/2.0/nn.init.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/amp_examples.html
+++ b/docs/2.0/notes/amp_examples.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/autograd.html
+++ b/docs/2.0/notes/autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/broadcasting.html
+++ b/docs/2.0/notes/broadcasting.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/cpu_threading_torchscript_inference.html
+++ b/docs/2.0/notes/cpu_threading_torchscript_inference.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/cuda.html
+++ b/docs/2.0/notes/cuda.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/ddp.html
+++ b/docs/2.0/notes/ddp.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/extending.func.html
+++ b/docs/2.0/notes/extending.func.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/extending.html
+++ b/docs/2.0/notes/extending.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/faq.html
+++ b/docs/2.0/notes/faq.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/gradcheck.html
+++ b/docs/2.0/notes/gradcheck.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/hip.html
+++ b/docs/2.0/notes/hip.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/large_scale_deployments.html
+++ b/docs/2.0/notes/large_scale_deployments.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/modules.html
+++ b/docs/2.0/notes/modules.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/mps.html
+++ b/docs/2.0/notes/mps.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/multiprocessing.html
+++ b/docs/2.0/notes/multiprocessing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/numerical_accuracy.html
+++ b/docs/2.0/notes/numerical_accuracy.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/randomness.html
+++ b/docs/2.0/notes/randomness.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/serialization.html
+++ b/docs/2.0/notes/serialization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/notes/windows.html
+++ b/docs/2.0/notes/windows.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/onnx.html
+++ b/docs/2.0/onnx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/onnx_diagnostics.html
+++ b/docs/2.0/onnx_diagnostics.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/onnx_supported_aten_ops.html
+++ b/docs/2.0/onnx_supported_aten_ops.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/optim.html
+++ b/docs/2.0/optim.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/package.html
+++ b/docs/2.0/package.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/pipeline.html
+++ b/docs/2.0/pipeline.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/profiler.html
+++ b/docs/2.0/profiler.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/py-modindex.html
+++ b/docs/2.0/py-modindex.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/quantization-accuracy-debugging.html
+++ b/docs/2.0/quantization-accuracy-debugging.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/quantization-backend-configuration.html
+++ b/docs/2.0/quantization-backend-configuration.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/quantization-support.html
+++ b/docs/2.0/quantization-support.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/quantization.html
+++ b/docs/2.0/quantization.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/random.html
+++ b/docs/2.0/random.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/rpc.html
+++ b/docs/2.0/rpc.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/rpc/distributed_autograd.html
+++ b/docs/2.0/rpc/distributed_autograd.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/rpc/rref.html
+++ b/docs/2.0/rpc/rref.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/search.html
+++ b/docs/2.0/search.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/2.0/signal.html
+++ b/docs/2.0/signal.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/sparse.html
+++ b/docs/2.0/sparse.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/special.html
+++ b/docs/2.0/special.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/storage.html
+++ b/docs/2.0/storage.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/tensor_attributes.html
+++ b/docs/2.0/tensor_attributes.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/tensor_view.html
+++ b/docs/2.0/tensor_view.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/tensorboard.html
+++ b/docs/2.0/tensorboard.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/tensors.html
+++ b/docs/2.0/tensors.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/testing.html
+++ b/docs/2.0/testing.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/torch.ao.ns._numeric_suite.html
+++ b/docs/2.0/torch.ao.ns._numeric_suite.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/torch.ao.ns._numeric_suite_fx.html
+++ b/docs/2.0/torch.ao.ns._numeric_suite_fx.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/torch.html
+++ b/docs/2.0/torch.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/torch.overrides.html
+++ b/docs/2.0/torch.overrides.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 

--- a/docs/2.0/type_info.html
+++ b/docs/2.0/type_info.html
@@ -5,6 +5,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en" > <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
+  <meta name="robots" content="noindex">
   <meta charset="utf-8">
   <meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
 


### PR DESCRIPTION
This PR removes PyTorch 2.0 docs from google search indexing by adding the `noindex` tag to all 2.0 docs.

The following command was ran locally to add the tag:
```
./scripts/add_noindex_tags.sh ./docs/2.0
```