### PR TITLE
Updating TorchServe version to 0.8.2

### DIFF
--- a/_posts/2023-10-04-new-library-updates.md
+++ b/_posts/2023-10-04-new-library-updates.md
@@ -13,7 +13,7 @@ Along with 2.1, we are also releasing a series of beta updates to the PyTorch do
 | Latest Stable Library Versions  |([Full List](https://pytorch.org/docs/stable/index.html))*                  |                             |
 |--------------------------------------------|------------------|-----------------------------|
 | TorchArrow 0.1.0                           | TorchRec 0.4.0   | TorchVision 0.16            |
-| TorchAudio 2.1                             | TorchServe 0.7.1 | TorchX 0.5.0                |
+| TorchAudio 2.1                             | TorchServe 0.8.2 | TorchX 0.5.0                |
 | TorchData 0.7.0                            | TorchText 0.16.0 | PyTorch on XLA Devices 1.14 |
 
 \*To see [prior versions](https://pytorch.org/docs/stable/index.html) or (unstable) nightlies, click on versions in the top left menu above ‘Search Docs’.


### PR DESCRIPTION
Updating TorchServe version to 0.8.2 as thats the latest

https://github.com/pytorch/serve/releases/tag/v0.8.2