### PR TITLE
Add small wheel install instructions for previous versions page

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -53,7 +53,7 @@ pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 # ROCM 5.4.2 (Linux only)
 pip install torch==2.0.1+rocm5.4.2 torchvision==0.15.2+rocm5.4.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/rocm5.4.2
 # CUDA 11.7
-pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 # CUDA 11.8
 pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu118
 # CPU only
@@ -96,7 +96,7 @@ pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1
 # ROCM 5.4.2 (Linux only)
 pip install torch==2.0.0+rocm5.4.2 torchvision==0.15.1+rocm5.4.2 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/rocm5.4.2
 # CUDA 11.7
-pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1
 # CUDA 11.8
 pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118
 # CPU only
@@ -141,7 +141,7 @@ pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 torchaudio==0.13.1
 # CUDA 11.6
 pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
 # CUDA 11.7
-pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu117
+pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
 # CPU only
 pip install torch==1.13.1+cpu torchvision==0.14.1+cpu torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cpu
 ```
@@ -184,7 +184,7 @@ pip install torch==1.13.0+rocm5.2 torchvision==0.14.0+rocm5.2 torchaudio==0.13.0
 # CUDA 11.6
 pip install torch==1.13.0+cu116 torchvision==0.14.0+cu116 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu116
 # CUDA 11.7
-pip install torch==1.13.0+cu117 torchvision==0.14.0+cu117 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu117
+pip install torch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0
 # CPU only
 pip install torch==1.13.0+cpu torchvision==0.14.0+cpu torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cpu
 ```

--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -47,13 +47,18 @@ conda install pytorch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 cpuonly -c py
 pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
 ```
 
+##### Linux CUDA 11.7
+```
+pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
+```
+
 ##### Linux and Windows
 
 ```
 # ROCM 5.4.2 (Linux only)
 pip install torch==2.0.1+rocm5.4.2 torchvision==0.15.2+rocm5.4.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/rocm5.4.2
 # CUDA 11.7
-pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2
+pip install torch==2.0.1+cu117 torchvision==0.15.2+cu117 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu117
 # CUDA 11.8
 pip install torch==2.0.1+cu118 torchvision==0.15.2+cu118 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu118
 # CPU only
@@ -90,13 +95,18 @@ conda install pytorch==2.0.0 torchvision==0.15.0 torchaudio==2.0.0 cpuonly -c py
 pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1
 ```
 
+##### Linux CUDA 11.7
+```
+pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1
+```
+
 ##### Linux and Windows
 
 ```
 # ROCM 5.4.2 (Linux only)
 pip install torch==2.0.0+rocm5.4.2 torchvision==0.15.1+rocm5.4.2 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/rocm5.4.2
 # CUDA 11.7
-pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1
+pip install torch==2.0.0+cu117 torchvision==0.15.1+cu117 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
 # CUDA 11.8
 pip install torch==2.0.0+cu118 torchvision==0.15.1+cu118 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu118
 # CPU only
@@ -133,6 +143,11 @@ conda install pytorch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 cpuonly -c 
 pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
 ```
 
+##### Linux CUDA 11.7
+```
+pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
+```
+
 ##### Linux and Windows
 
 ```
@@ -141,7 +156,7 @@ pip install torch==1.13.1+rocm5.2 torchvision==0.14.1+rocm5.2 torchaudio==0.13.1
 # CUDA 11.6
 pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
 # CUDA 11.7
-pip install torch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1
+pip install torch==1.13.1+cu117 torchvision==0.14.1+cu117 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu117
 # CPU only
 pip install torch==1.13.1+cpu torchvision==0.14.1+cpu torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cpu
 ```
@@ -176,6 +191,11 @@ conda install pytorch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0 cpuonly -c 
 pip install torch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0
 ```
 
+##### Linux CUDA 11.7
+```
+pip install torch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0
+```
+
 ##### Linux and Windows
 
 ```
@@ -184,7 +204,7 @@ pip install torch==1.13.0+rocm5.2 torchvision==0.14.0+rocm5.2 torchaudio==0.13.0
 # CUDA 11.6
 pip install torch==1.13.0+cu116 torchvision==0.14.0+cu116 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu116
 # CUDA 11.7
-pip install torch==1.13.0 torchvision==0.14.0 torchaudio==0.13.0
+pip install torch==1.13.0+cu117 torchvision==0.14.0+cu117 torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cu117
 # CPU only
 pip install torch==1.13.0+cpu torchvision==0.14.0+cpu torchaudio==0.13.0 --extra-index-url https://download.pytorch.org/whl/cpu
 ```


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/111716 . In addition to already provided large wheel instructions provide instructions to install from pypi without using index-url