### PR TITLE
Include arm64 libtorch in download instructions with auto-generated page

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -38,6 +38,12 @@ jobs:
       package-type: all
       os: macos
       channel: "nightly"
+  macos-arm64-nightly-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: all
+      os: macos-arm64
+      channel: "nightly"
   linux-release-matrix:
     needs: [linux-nightly-matrix]
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
@@ -59,10 +65,17 @@ jobs:
       package-type: all
       os: macos
       channel: "release"
+  macos-arm64-release-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: all
+      os: macos-arm64
+      channel: "release"
 
   update-quick-start:
     needs: [linux-nightly-matrix, windows-nightly-matrix, macos-nightly-matrix,
-      linux-release-matrix, windows-release-matrix, macos-release-matrix]
+      macos-arm64-nightly-matrix, linux-release-matrix, windows-release-matrix,
+      macos-release-matrix, macos-arm64-release-matrix]
     runs-on: "ubuntu-20.04"
     environment: pytorchbot-env
     steps:
@@ -79,17 +92,21 @@ jobs:
           LINUX_NIGHTLY_MATRIX: ${{ needs.linux-nightly-matrix.outputs.matrix }}
           WINDOWS_NIGHTLY_MATRIX: ${{ needs.windows-nightly-matrix.outputs.matrix }}
           MACOS_NIGHTLY_MATRIX: ${{ needs.macos-nightly-matrix.outputs.matrix }}
+          MACOS_ARM64_NIGHTLY_MATRIX: ${{ needs.macos-arm64-nightly-matrix.outputs.matrix }}
           LINUX_RELEASE_MATRIX: ${{ needs.linux-release-matrix.outputs.matrix }}
           WINDOWS_RELEASE_MATRIX: ${{ needs.windows-release-matrix.outputs.matrix }}
           MACOS_RELEASE_MATRIX: ${{ needs.macos-release-matrix.outputs.matrix }}
+          MACOS_ARM64_RELEASE_MATRIX: ${{ needs.macos-arm64-release-matrix.outputs.matrix }}
         run: |
           set -ex
           printf '%s\n' "$LINUX_NIGHTLY_MATRIX" > linux_nightly_matrix.json
           printf '%s\n' "$WINDOWS_NIGHTLY_MATRIX" > windows_nightly_matrix.json
           printf '%s\n' "$MACOS_NIGHTLY_MATRIX" > macos_nightly_matrix.json
+          printf '%s\n' "$MACOS_ARM64_NIGHTLY_MATRIX" > macos_arm64_nightly_matrix.json
           printf '%s\n' "$LINUX_RELEASE_MATRIX" > linux_release_matrix.json
           printf '%s\n' "$WINDOWS_RELEASE_MATRIX" > windows_release_matrix.json
           printf '%s\n' "$MACOS_RELEASE_MATRIX" > macos_release_matrix.json
+          printf '%s\n' "$MACOS_ARM64_RELEASE_MATRIX" > macos_arm64_release_matrix.json
           python3 ./scripts/gen_quick_start_module.py --autogenerate > assets/quick-start-module.js
           rm *_matrix.json
       - name: Create Issue if failed

--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -66,6 +66,7 @@ jobs:
       os: macos
       channel: "release"
   macos-arm64-release-matrix:
+    needs: [macos-arm64-nightly-matrix]
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
       package-type: all

--- a/published_versions.json
+++ b/published_versions.json
@@ -126,24 +126,24 @@
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
           "cuda.y": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
           "rocm5.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           }
         }
@@ -2986,28 +2986,28 @@
           "accnone": {
             "note": null,
             "versions": {
-              "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "cuda.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "cuda.y": {
             "note": null,
             "default": true,
             "versions": {
-              "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "rocm5.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download default libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           }
         }

--- a/published_versions.json
+++ b/published_versions.json
@@ -2986,28 +2986,28 @@
           "accnone": {
             "note": null,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "cuda.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "cuda.y": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           },
           "rocm5.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.0.zip"
             }
           }
         }

--- a/published_versions.json
+++ b/published_versions.json
@@ -118,32 +118,32 @@
           "accnone": {
             "note": null,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
           "cuda.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
           "cuda.y": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
           "rocm5.x": {
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
-              "Download arm64 libtorch here": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
+              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
+              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           }
         }

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -213,7 +213,7 @@ def main():
     options = parser.parse_args()
     versions = read_published_versions()
 
-    if options.autogenerate or True:
+    if options.autogenerate:
         release_matrix = {}
         for val in ("nightly", "release"):
             release_matrix[val] = {}

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -210,7 +210,7 @@ def main():
     options = parser.parse_args()
     versions = read_published_versions()
 
-    if options.autogenerate or True:
+    if options.autogenerate:
         release_matrix = {}
         for val in ("nightly", "release"):
             release_matrix[val] = {}

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -59,8 +59,8 @@ LIBTORCH_DWNL_INSTR = {
         CXX11_ABI: "Download here (cxx11 ABI):",
         RELEASE: "Download here (Release version):",
         DEBUG: "Download here (Debug version):",
-        MACOS: "Download x86 libtorch here",
-        MACOS_ARM64: "Download arm64 libtorch here",
+        MACOS: "Download x86 libtorch here (ROCm and CUDA are not supported):",
+        MACOS_ARM64: "Download arm64 libtorch here (ROCm and CUDA are not supported):",
     }
 
 def load_json_from_basedir(filename: str):
@@ -124,8 +124,12 @@ def update_versions(versions, release_matrix, release_version):
                     if (x["package_type"], x["gpu_arch_type"], x["gpu_arch_version"]) ==
                     (package_type, gpu_arch_type, gpu_arch_version)
                     ]
+                # MACOS and MACOS_ARM64 release matrices are reduced to
+                # one single matrix in get started page. This is the only
+                # OS that this logic applies to. Hence this logic is needed.
+                pkg_arch_matrix_arm64 = []
                 if os_key == OperatingSystem.MACOS.value and package_type == "libtorch":
-                    pkg_arch_matrix += [
+                    pkg_arch_matrix_arm64 = [
                         x for x in release_matrix[OperatingSystem.MACOS_ARM64.value]
                         if (x["package_type"], x["gpu_arch_type"], x["gpu_arch_version"]) ==
                         (package_type, gpu_arch_type, gpu_arch_version)
@@ -151,9 +155,8 @@ def update_versions(versions, release_matrix, release_version):
                         elif os_key == OperatingSystem.MACOS.value:
                             if instr["versions"] is not None:
                                 instr["versions"][LIBTORCH_DWNL_INSTR[MACOS]] = pkg_arch_matrix[0]["installation"]
-                                # todo: remove this once we release libtorch for arm64 as stable
-                                if release_version == "nightly":
-                                    instr["versions"][LIBTORCH_DWNL_INSTR[MACOS_ARM64]] = pkg_arch_matrix[1]["installation"]
+                                if len(pkg_arch_matrix_arm64) > 0:
+                                    instr["versions"][LIBTORCH_DWNL_INSTR[MACOS_ARM64]] = pkg_arch_matrix_arm64[0]["installation"]
 
 # This method is used for generating new quick-start-module.js
 # from the versions json object
@@ -210,7 +213,7 @@ def main():
     options = parser.parse_args()
     versions = read_published_versions()
 
-    if options.autogenerate:
+    if options.autogenerate or True:
         release_matrix = {}
         for val in ("nightly", "release"):
             release_matrix[val] = {}


### PR DESCRIPTION
MacOS x86 and Macos Arm64 instructions used to be exactly the same, hence we generated all the instructions from MacOS x86. Now since we added arm64 builds for libtorch in nightly these instructions need to get into the getting started page.