### PR TITLE
Include arm64 libtorch in download instructions with auto-generated page

### DIFF
--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -215,7 +215,7 @@ def main():
     options = parser.parse_args()
     versions = read_published_versions()
 
-    if options.autogenerate or True:
+    if options.autogenerate:
         release_matrix = {}
         for val in ("nightly", "release"):
             release_matrix[val] = {}

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -157,6 +157,8 @@ def update_versions(versions, release_matrix, release_version):
                                 instr["versions"][LIBTORCH_DWNL_INSTR[MACOS]] = pkg_arch_matrix[0]["installation"]
                                 if len(pkg_arch_matrix_arm64) > 0:
                                     instr["versions"][LIBTORCH_DWNL_INSTR[MACOS_ARM64]] = pkg_arch_matrix_arm64[0]["installation"]
+                                else:
+                                    instr["versions"].pop(LIBTORCH_DWNL_INSTR[MACOS_ARM64], None)
 
 # This method is used for generating new quick-start-module.js
 # from the versions json object
@@ -213,7 +215,7 @@ def main():
     options = parser.parse_args()
     versions = read_published_versions()
 
-    if options.autogenerate:
+    if options.autogenerate or True:
         release_matrix = {}
         for val in ("nightly", "release"):
             release_matrix[val] = {}


### PR DESCRIPTION
Follow up on: https://github.com/pytorch/pytorch.github.io/pull/1507. Fix make sure arm64 instructions are not included if not present. We are using nightly instructions as a template to fill release template. In this case we do have arm64 in nightly but not in stable. If pop is not performed we generate this for stable release update:

```
"versions": {
              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.1.zip",
              "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
            }
```

However this is required:
```
"versions": {
              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/cpu/libtorch-macos-2.1.1.zip"
            }
```