### PR TITLE
Add openEuler info to supported Linux distributions

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -19,6 +19,7 @@ PyTorch is supported on Linux distributions that use [glibc](https://www.gnu.org
 * [PCLinuxOS](https://www.pclinuxos.com/get-pclinuxos/), minimum version 2014.7
 * [Slackware](http://www.slackware.com/getslack/), minimum version 14.2
 * [Ubuntu](https://www.ubuntu.com/download/desktop), minimum version 13.04
+* [openEuler](https://www.openeuler.org/en/), minimum version 20.03 LTS
 
 > The install instructions here will generally apply to all supported Linux distributions. An example difference is that your distribution may support `yum` instead of `apt`. The specific examples shown were run on an Ubuntu 18.04 machine.
 


### PR DESCRIPTION
Add openEuler info to supported Linux distributions.

- The PyTorch can be installed since openEuler 20.03 LTS.
- The openEuler OS also provided PyTorch pakcage and maintained by openEuler Bigdata and AI SIG. [1]
- openEuler is an unified and open OS supports multiple processor architectures, helping promote a more robust software and hardware ecosystem through joint efforts of the community. [2]

[1] https://gitee.com/src-openeuler/pytorch
[2] https://www.openeuler.org/en/