### PR TITLE
Update recommended Python version in the getting started sections

### DIFF
--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -40,8 +40,6 @@ If you decide to use APT, you can run the following command to install it:
 sudo apt install python
 ```
 
-> It is recommended that you use Python 3.6, 3.7 or 3.8, which can be installed via any of the mechanisms above .
-
 > If you use [Anaconda](#anaconda) to install PyTorch, it will install a sandboxed version of Python that will be used for running PyTorch applications.
 
 ### Package Manager

--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -5,6 +5,9 @@
   <a href="{{ site.baseurl }}/get-started/previous-versions">install previous versions of PyTorch</a>. Note that LibTorch is only available for C++.
 </p>
 
+<p><b>NOTE:</b> Latest PyTorch requires Python 3.8 - 3.11.
+</p>
+
 <div class="row">
   <div class="col-md-3 headings">
     <div class="col-md-12 title-block">


### PR DESCRIPTION
Update the getting started locally page to list Python 3.8-3.11 as the required versions for the latest PyTorch.