### PR TITLE
Updated torch.compile.html

### DIFF
--- a/docs/2.2/generated/torch.compile.html
+++ b/docs/2.2/generated/torch.compile.html
@@ -498,7 +498,7 @@ dynamic kernel upon recompile.</p></li>
 <li><p>”inductor” is the default backend, which is a good balance between performance and overhead</p></li>
 <li><p>Non experimental in-tree backends can be seen with <cite>torch._dynamo.list_backends()</cite></p></li>
 <li><p>Experimental or debug in-tree backends can be seen with <cite>torch._dynamo.list_backends(None)</cite></p></li>
-<li><p>To register an out-of-tree custom backend: <a class="reference external" href="https://pytorch.org/docs/main/compile/custom-backends.html">https://pytorch.org/docs/main/compile/custom-backends.html</a></p></li>
+<li><p>To register an out-of-tree custom backend: <a class="reference external" href="https://pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends">https://pytorch.org/docs/stable/torch.compiler_custom_backends.html#registering-custom-backends</a></p></li>
 </ul>
 </p></li>
 <li><p><strong>mode</strong> (<a class="reference external" href="https://docs.python.org/3/library/stdtypes.html#str" title="(in Python v3.12)"><em>str</em></a>) – <p>Can be either “default”, “reduce-overhead”, “max-autotune” or “max-autotune-no-cudagraphs”</p>


### PR DESCRIPTION
Replaced dead link in pytorch.github.io/docs/stable/generated/torch.compile