### PR TITLE
Small fix into quickstart module

### DIFF
--- a/_includes/quick_start_local.html
+++ b/_includes/quick_start_local.html
@@ -5,7 +5,7 @@
   <a href="{{ site.baseurl }}/get-started/previous-versions">install previous versions of PyTorch</a>. Note that LibTorch is only available for C++.
 </p>
 
-<p><b>NOTE:</b> Latest PyTorch requires Python 3.8 or later. For more details, see Python section below.</p>
+<p><b>NOTE:</b> Latest PyTorch requires Python 3.8 or later.</p>
 
 <div class="row">
   <div class="col-md-3 headings">


### PR DESCRIPTION
Remove the part about the version below since we include quickstart module on multiple pages that might not have that section below. 