### PR TITLE
Quick start module, remove macos x86

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -32,12 +32,6 @@ jobs:
       package-type: all
       os: windows
       channel: "nightly"
-  macos-nightly-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: all
-      os: macos
-      channel: "nightly"
   macos-arm64-nightly-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
     with:
@@ -58,13 +52,6 @@ jobs:
       package-type: all
       os: windows
       channel: "release"
-  macos-release-matrix:
-    needs: [macos-nightly-matrix]
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
-    with:
-      package-type: all
-      os: macos
-      channel: "release"
   macos-arm64-release-matrix:
     needs: [macos-arm64-nightly-matrix]
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
@@ -74,9 +61,8 @@ jobs:
       channel: "release"
 
   update-quick-start:
-    needs: [linux-nightly-matrix, windows-nightly-matrix, macos-nightly-matrix,
-      macos-arm64-nightly-matrix, linux-release-matrix, windows-release-matrix,
-      macos-release-matrix, macos-arm64-release-matrix]
+    needs: [linux-nightly-matrix, windows-nightly-matrix, macos-arm64-nightly-matrix,
+    linux-release-matrix, windows-release-matrix, macos-arm64-release-matrix]
     runs-on: "ubuntu-20.04"
     environment: pytorchbot-env
     steps:
@@ -92,22 +78,18 @@ jobs:
         env:
           LINUX_NIGHTLY_MATRIX: ${{ needs.linux-nightly-matrix.outputs.matrix }}
           WINDOWS_NIGHTLY_MATRIX: ${{ needs.windows-nightly-matrix.outputs.matrix }}
-          MACOS_NIGHTLY_MATRIX: ${{ needs.macos-nightly-matrix.outputs.matrix }}
-          MACOS_ARM64_NIGHTLY_MATRIX: ${{ needs.macos-arm64-nightly-matrix.outputs.matrix }}
+          MACOS_NIGHTLY_MATRIX: ${{ needs.macos-arm64-nightly-matrix.outputs.matrix }}
           LINUX_RELEASE_MATRIX: ${{ needs.linux-release-matrix.outputs.matrix }}
           WINDOWS_RELEASE_MATRIX: ${{ needs.windows-release-matrix.outputs.matrix }}
-          MACOS_RELEASE_MATRIX: ${{ needs.macos-release-matrix.outputs.matrix }}
-          MACOS_ARM64_RELEASE_MATRIX: ${{ needs.macos-arm64-release-matrix.outputs.matrix }}
+          MACOS_RELEASE_MATRIX: ${{ needs.macos-arm64-release-matrix.outputs.matrix }}
         run: |
           set -ex
           printf '%s\n' "$LINUX_NIGHTLY_MATRIX" > linux_nightly_matrix.json
           printf '%s\n' "$WINDOWS_NIGHTLY_MATRIX" > windows_nightly_matrix.json
           printf '%s\n' "$MACOS_NIGHTLY_MATRIX" > macos_nightly_matrix.json
-          printf '%s\n' "$MACOS_ARM64_NIGHTLY_MATRIX" > macos_arm64_nightly_matrix.json
           printf '%s\n' "$LINUX_RELEASE_MATRIX" > linux_release_matrix.json
           printf '%s\n' "$WINDOWS_RELEASE_MATRIX" > windows_release_matrix.json
           printf '%s\n' "$MACOS_RELEASE_MATRIX" > macos_release_matrix.json
-          printf '%s\n' "$MACOS_ARM64_RELEASE_MATRIX" > macos_arm64_release_matrix.json
           python3 ./scripts/gen_quick_start_module.py --autogenerate > assets/quick-start-module.js
           rm *_matrix.json
       - name: Create Issue if failed

--- a/published_versions.json
+++ b/published_versions.json
@@ -118,7 +118,6 @@
           "accnone": {
             "note": null,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
               "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
@@ -126,7 +125,6 @@
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
               "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
@@ -134,7 +132,6 @@
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
               "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           },
@@ -142,7 +139,6 @@
             "note": null,
             "default": true,
             "versions": {
-              "Download x86 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-x86_64-latest.zip",
               "Download arm64 libtorch here (ROCm and CUDA are not supported):": "https://download.pytorch.org/libtorch/nightly/cpu/libtorch-macos-arm64-latest.zip"
             }
           }

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -215,7 +215,7 @@ def main():
     versions_str = json.dumps(gen_install_matrix(versions))
     template = template.replace("{{ installMatrix }}", versions_str)
     template = template.replace("{{ VERSION }}", f"\"Stable ({versions['latest_stable']})\"")
-    #print(template.replace("{{ ACC ARCH MAP }}", json.dumps(acc_arch_ver_map)))
+    print(template.replace("{{ ACC ARCH MAP }}", json.dumps(acc_arch_ver_map)))
 
 if __name__ == "__main__":
     main()

--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -21,7 +21,6 @@ class OperatingSystem(Enum):
     LINUX: str = "linux"
     WINDOWS: str = "windows"
     MACOS: str = "macos"
-    MACOS_ARM64: str = "macos_arm64"
 
 PRE_CXX11_ABI = "pre-cxx11"
 CXX11_ABI = "cxx11-abi"
@@ -31,7 +30,6 @@ DEFAULT = "default"
 ENABLE = "enable"
 DISABLE = "disable"
 MACOS = "macos"
-MACOS_ARM64 = "macos-arm64"
 
 # Mapping json to release matrix default values
 acc_arch_ver_default = {
@@ -39,13 +37,13 @@ acc_arch_ver_default = {
         "accnone": ("cpu", ""),
         "cuda.x": ("cuda", "11.8"),
         "cuda.y": ("cuda", "12.1"),
-        "rocm5.x": ("rocm", "5.7")
+        "rocm5.x": ("rocm", "6.0")
         },
     "release": {
         "accnone": ("cpu", ""),
         "cuda.x": ("cuda", "11.8"),
         "cuda.y": ("cuda", "12.1"),
-        "rocm5.x": ("rocm", "5.7")
+        "rocm5.x": ("rocm", "6.0")
         }
     }
 
@@ -59,8 +57,7 @@ LIBTORCH_DWNL_INSTR = {
         CXX11_ABI: "Download here (cxx11 ABI):",
         RELEASE: "Download here (Release version):",
         DEBUG: "Download here (Debug version):",
-        MACOS: "Download x86 libtorch here (ROCm and CUDA are not supported):",
-        MACOS_ARM64: "Download arm64 libtorch here (ROCm and CUDA are not supported):",
+        MACOS: "Download arm64 libtorch here (ROCm and CUDA are not supported):",
     }
 
 def load_json_from_basedir(filename: str):
@@ -124,16 +121,6 @@ def update_versions(versions, release_matrix, release_version):
                     if (x["package_type"], x["gpu_arch_type"], x["gpu_arch_version"]) ==
                     (package_type, gpu_arch_type, gpu_arch_version)
                     ]
-                # MACOS and MACOS_ARM64 release matrices are reduced to
-                # one single matrix in get started page. This is the only
-                # OS that this logic applies to. Hence this logic is needed.
-                pkg_arch_matrix_arm64 = []
-                if os_key == OperatingSystem.MACOS.value and package_type == "libtorch":
-                    pkg_arch_matrix_arm64 = [
-                        x for x in release_matrix[OperatingSystem.MACOS_ARM64.value]
-                        if (x["package_type"], x["gpu_arch_type"], x["gpu_arch_version"]) ==
-                        (package_type, gpu_arch_type, gpu_arch_version)
-                        ]
 
                 if pkg_arch_matrix:
                     if package_type != "libtorch":
@@ -155,10 +142,6 @@ def update_versions(versions, release_matrix, release_version):
                         elif os_key == OperatingSystem.MACOS.value:
                             if instr["versions"] is not None:
                                 instr["versions"][LIBTORCH_DWNL_INSTR[MACOS]] = pkg_arch_matrix[0]["installation"]
-                                if len(pkg_arch_matrix_arm64) > 0:
-                                    instr["versions"][LIBTORCH_DWNL_INSTR[MACOS_ARM64]] = pkg_arch_matrix_arm64[0]["installation"]
-                                else:
-                                    instr["versions"].pop(LIBTORCH_DWNL_INSTR[MACOS_ARM64], None)
 
 # This method is used for generating new quick-start-module.js
 # from the versions json object
@@ -232,7 +215,7 @@ def main():
     versions_str = json.dumps(gen_install_matrix(versions))
     template = template.replace("{{ installMatrix }}", versions_str)
     template = template.replace("{{ VERSION }}", f"\"Stable ({versions['latest_stable']})\"")
-    print(template.replace("{{ ACC ARCH MAP }}", json.dumps(acc_arch_ver_map)))
+    #print(template.replace("{{ ACC ARCH MAP }}", json.dumps(acc_arch_ver_map)))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
MacOS x86 are no longer released and not supported on nightly. Hence remove them from the quick start module