### PR TITLE
Move get started back to top level

### DIFF
--- a/_includes/main_menu.html
+++ b/_includes/main_menu.html
@@ -1,15 +1,17 @@
 <div class="main-menu">
   <ul>
     <li class="main-menu-item">
+      <a href="{{ site.baseurl }}/get-started" data-cta="get-started">
+        Get Started
+      </a>
+    </li>
+
+    <li class="main-menu-item">
       <div id="dropdownMenuButton" data-toggle="resources-dropdown" class="resources-dropdown">
         <a class="with-down-arrow">
           Learn
         </a>
         <div class="resources-dropdown-menu">
-          <a class="nav-dropdown-item" href="{{ site.baseurl }}/get-started">
-            <span class=dropdown-title>Get Started</span>
-            <p>Run PyTorch locally or get started quickly with one of the supported cloud platforms</p>
-          </a>
           <a class="nav-dropdown-item" href="https://pytorch.org/tutorials/">
             <span class="dropdown-title">Tutorials</span>
             <p>Whats new in PyTorch tutorials</p>


### PR DESCRIPTION
This allows it to be accessible from any other page on the website effectively.
No change to mobile version since all dropdowns are expanded there.

Curious for any feedback on this?