### PR TITLE
Allow master docs to remove from Google search results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -13,7 +13,6 @@ Disallow: /docs/1.6.0/
 Disallow: /docs/1.7.*
 Disallow: /docs/1.8.*
 Disallow: /docs/1.9.*
-Disallow: /docs/master/
 
 # libraries: torchx
 Disallow: /torchx/*/


### PR DESCRIPTION
We want to unlist this page in Google: https://pytorch.org/docs/master/community/contribution_guide.html - because it goes to the master docs and we want it to go the stable or main docs. The existing way of just unlisting with robots.txt did not give the desired result - the master docs version appeared as a first result in the search. Google suggests to use the `nonindex` to unlist pages.

I have added the noindex tag to all master docs: https://github.com/pytorch/docs/pull/10 

For this change to take effect, we need to allow master docs in robots.txt according to this official Google recommendation: 
https://support.google.com/webmasters/answer/7489871?hl=en#zippy=%2Cthis-is-my-site%2Cthe-page-is-blocked-by-robotstxt 

At the moment, while the master docs have noindex tag, I still see this as my first result in Google for "PyTorch Contributor Guide":

<img width="603" alt="Screenshot 2024-09-06 at 3 41 38 PM" src="https://github.com/user-attachments/assets/fda31b12-deb6-4159-9ab1-e0c058217156">

If you click on Learn Why, it would take you to the aforementioned support.google.com page that suggest to remove the disallow rule from robots.txt.