### PR TITLE
Fix PyTorch 2.5 release note format error

### DIFF
--- a/_posts/2024-10-17-pytorch2-5.md
+++ b/_posts/2024-10-17-pytorch2-5.md
@@ -81,7 +81,7 @@ The cuDNN "Fused Flash Attention" backend  was landed for *torch.nn.functional.s
 
 ### [Beta] *torch.compile* regional compilation without recompilations
 
-Regional compilation without recompilations, via* torch._dynamo.config.inline_inbuilt_nn_modules* which default to True in 2.5+. This option allows users to compile a repeated *nn.Module* (e.g. a transformer layer in LLM) without recompilations. Compared to compiling the full model, this option can result in smaller compilation latencies with 1%-5% performance degradation compared to full model compilation.
+Regional compilation without recompilations, via *torch._dynamo.config.inline_inbuilt_nn_modules* which default to True in 2.5+. This option allows users to compile a repeated *nn.Module* (e.g. a transformer layer in LLM) without recompilations. Compared to compiling the full model, this option can result in smaller compilation latencies with 1%-5% performance degradation compared to full model compilation.
 
 See the [tutorial](https://pytorch.org/tutorials/recipes/regional_compilation.html) for more information.
 


### PR DESCRIPTION
Fix space position to make italics works as expected

Current
![image](https://github.com/user-attachments/assets/30a371b5-ca3a-4641-a563-56d09ee1de5f)
