### PR TITLE
Getting started page update. Use generic 2.x link

### DIFF
--- a/_get_started/pytorch.md
+++ b/_get_started/pytorch.md
@@ -1,6 +1,6 @@
 ---
 layout: get_started
-title: PyTorch 2.0
+title: PyTorch 2.x
 permalink: /get-started/pytorch-2.0/
 featured-img: "assets/images/featured-img-pytorch-2.png"
 background-class: get-started-background


### PR DESCRIPTION
This should update link PyTorch 2.0 -> PyTorch 2.x on https://pytorch.org/get-started/locally/

<img width="632" alt="Screenshot 2024-10-21 at 9 48 35 AM" src="https://github.com/user-attachments/assets/a121123a-702e-46d8-90a6-070fb07fa6a8">
