### PR TITLE
Remove ref from validate-quick-start-module.yml

### DIFF
--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       os: all
       channel: "nightly"
-      ref: main
   validate-release-binaries:
     if: always()
     uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
@@ -30,4 +29,3 @@ jobs:
     with:
       os: all
       channel: "release"
-      ref: main


### PR DESCRIPTION
As ref was removed from pytorch/builder/.github/workflows/validate-binaries.yml in https://github.com/pytorch/builder/pull/1999