### PR TITLE
Update previous-versions.md

### DIFF
--- a/_get_started/previous-versions.md
+++ b/_get_started/previous-versions.md
@@ -935,8 +935,8 @@ conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 -c pytorch
 # CUDA 10.2
 conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=10.2 -c pytorch
 
-# CUDA 11.3
-conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.1
+conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cudatoolkit=11.1 -c pytorch -c conda-forge
 
 # CPU Only
 conda install pytorch==1.9.1 torchvision==0.10.1 torchaudio==0.9.1 cpuonly -c pytorch
@@ -989,8 +989,8 @@ conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 -c pytorch
 # CUDA 10.2
 conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=10.2 -c pytorch
 
-# CUDA 11.3
-conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.1
+conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cudatoolkit=11.1 -c pytorch -c conda-forge
 
 # CPU Only
 conda install pytorch==1.9.0 torchvision==0.10.0 torchaudio==0.9.0 cpuonly -c pytorch
@@ -1098,8 +1098,8 @@ conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 -c pytorch
 # CUDA 10.2
 conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=10.2 -c pytorch
 
-# CUDA 11.3
-conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=11.3 -c pytorch -c conda-forge
+# CUDA 11.1
+conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cudatoolkit=11.1 -c pytorch -c conda-forge
 
 # CPU Only
 conda install pytorch==1.8.1 torchvision==0.9.1 torchaudio==0.8.1 cpuonly -c pytorch


### PR DESCRIPTION
Use CUDA 11.1 instead of CUDA 11.3 for PyTorch 1.8.1, 1.9.0, and 1.9.1.

This patch will close three issues: #1403, #1033, and #925.

This work comes from: https://discuss.pytorch.org/t/cant-find-package-of-pytorch1-8-1-and-cudatoolkit-11-3/212679