### PR TITLE
Remove dependency on builder since these workflows are moved to test-infra

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -66,12 +66,10 @@ jobs:
     runs-on: "ubuntu-20.04"
     environment: pytorchbot-env
     steps:
-      - name: Checkout builder
-        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
           architecture: x64
       - name: Create json file
         shell: bash

--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       os: all
       channel: "nightly"
-      ref: main
   validate-release-binaries:
     if: always()
     uses: pytorch/test-infra/.github/workflows/validate-binaries.yml@main
@@ -30,4 +29,3 @@ jobs:
     with:
       os: all
       channel: "release"
-      ref: main

--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -18,14 +18,14 @@ on:
 
 jobs:
   validate-nightly-binaries:
-    uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
+    uses: pytorch/test-infra/.github/workflows/validate-binaries.yml@main
     with:
       os: all
       channel: "nightly"
       ref: main
   validate-release-binaries:
     if: always()
-    uses: pytorch/builder/.github/workflows/validate-binaries.yml@main
+    uses: pytorch/test-infra/.github/workflows/validate-binaries.yml@main
     needs: validate-nightly-binaries
     with:
       os: all


### PR DESCRIPTION
Remove builder dependency: Related to https://github.com/pytorch/builder/issues/2054
Move update quick start module to python 3.9
