### PR TITLE
Upgrade to new linux_job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     secrets: inherit
     with:
       runner: linux.12xlarge


### PR DESCRIPTION
The builds for this site were failing today and outputting this error:
```
Please note: We are currently migrating Linux Wheel builds to Manywheel 2.28
If you see error like: ImportError: /lib64/libc.so.6: version GLIBC_2.28 not found
Please migrate to: https://github.com/pytorch/test-infra/blob/main/.github/workflows/linux_job_v2.yml
Issue: https://github.com/pytorch/pytorch/issues/123649
```

So this is an attempt to fix the problem.