### PR TITLE
fix  : Possible typo: "PyTorch 3.x" in get started webpage #1912

### DIFF
--- a/_get_started/installation/windows.md
+++ b/_get_started/installation/windows.md
@@ -43,7 +43,7 @@ To install the PyTorch binaries, you will need to use at least one of two suppor
 
 #### Anaconda
 
-To install Anaconda, you will use the [64-bit graphical installer](https://www.anaconda.com/download/#windows) for PyTorch 3.x. Click on the installer link and select `Run`. Anaconda will download and the installer prompt will be presented to you. The default options are generally sane.
+To install Anaconda,  download and use the [64-bit graphical installer](https://www.anaconda.com/download/#windows) for Anaconda3(PyTorch 3.x). Click on the installer link and select `Run`. Anaconda will download acceptable. The default options are generally acceptable.
 
 #### pip
 


### PR DESCRIPTION
📚 Documentation
(Add a clear and concise description of what the documentation content issue is. A link to any relevant https://pytorch.org/ page is helpful if you have one.)

At https://pytorch.org/get-started/locally/#windows-package-manager, Anaconda section, it reads "you will use the [64-bit graphical installer](https://www.anaconda.com/download/#windows) for PyTorch 3.x.". It is a typo that use the installer for Python 3.x or Anaconda 3.x? As I guess Pytorch has released 2.6 up to now.