### PR TITLE
Remove updating pre-cxx-abi mention for libtorch release builds as well

### DIFF
--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -158,8 +158,9 @@ def update_versions(versions, release_matrix, release_version):
                             }
                             if instr["versions"] is not None:
                                 for ver in [CXX11_ABI, PRE_CXX11_ABI]:
-                                    # temporarily apply removal of cxx11 abi only to nightly and rocm builds
-                                    if ver == PRE_CXX11_ABI and (release_version == "nightly" or gpu_arch_type == "rocm"):
+                                    # temporarily remove setting pre-cxx11-abi. For Release 2.7 we 
+                                    # should remove pre-cxx11-abi completely.
+                                    if ver == PRE_CXX11_ABI:
                                         continue
                                     else:
                                         instr["versions"][LIBTORCH_DWNL_INSTR[ver]] = (


### PR DESCRIPTION
This will simply skip updating cxx11-abi entries for release. But they will still be displayed.
Followup after: https://github.com/pytorch/pytorch.github.io/pull/1976