### PR TITLE
Update update-quick-start-module to ubuntu-latest

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -63,7 +63,7 @@ jobs:
   update-quick-start:
     needs: [linux-nightly-matrix, windows-nightly-matrix, macos-arm64-nightly-matrix,
     linux-release-matrix, windows-release-matrix, macos-arm64-release-matrix]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     environment: pytorchbot-env
     steps:
       - name: Checkout pytorch.github.io


### PR DESCRIPTION
ubuntu-20.04 worker was deprecated hence moving to ubuntu-latest