### PR TITLE
Update CNAME to docs.pytorch.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-pytorch.org
+docs.pytorch.org


### PR DESCRIPTION
With the site update that happened this week. The new domain for docs is docs.pytorch.org so update the CNAME appropriately.