### PR TITLE
update contribution link from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To view the status of the build visit [https://circleci.com/gh/pytorch/pytorch.g
 
 ## Contributing to PyTorch Documentation and Tutorials
 * You can find information about contributing to PyTorch documentation in the 
-PyTorch repo [README.md](https://github.com/pytorch/pytorch/blob/master/README.md) file. 
+PyTorch repo [README.md](https://github.com/pytorch/pytorch/blob/main/README.md) file. 
 * Information about contributing to PyTorch Tutorials can be found in the 
-tutorials [README.md](https://github.com/pytorch/tutorials/blob/master/README.md).
-* Additional contribution information can be found in [PyTorch CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md).
+tutorials [README.md](https://github.com/pytorch/tutorials/blob/main/README.md).
+* Additional contribution information can be found in [PyTorch CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md).

--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ external_urls:
   github: https://github.com/pytorch/pytorch
   github_issues: https://github.com/pytorch/pytorch/issues
   hub_issues: https://github.com/pytorch/hub/issues
-  contributing: https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md
+  contributing: https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md
   hub_template: https://github.com/pytorch/hub/blob/master/docs/template.md
   twitter: https://twitter.com/pytorch
   facebook: https://www.facebook.com/pytorch


### PR DESCRIPTION
Update "master" to main which usually is currently redirecting 