### PR TITLE
Add install instruction for python and pip for  Fedora Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To view the status of the build visit [https://circleci.com/gh/pytorch/pytorch.g
 
 ## Contributing to PyTorch Documentation and Tutorials
 * You can find information about contributing to PyTorch documentation in the 
-PyTorch repo [README.md](https://github.com/pytorch/pytorch/blob/master/README.md) file. 
+PyTorch repo [README.md](https://github.com/pytorch/pytorch/blob/main/README.md) file. 
 * Information about contributing to PyTorch Tutorials can be found in the 
-tutorials [README.md](https://github.com/pytorch/tutorials/blob/master/README.md).
-* Additional contribution information can be found in [PyTorch CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md).
+tutorials [README.md](https://github.com/pytorch/tutorials/blob/main/README.md).
+* Additional contribution information can be found in [PyTorch CONTRIBUTING.md](https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md).

--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ external_urls:
   github: https://github.com/pytorch/pytorch
   github_issues: https://github.com/pytorch/pytorch/issues
   hub_issues: https://github.com/pytorch/hub/issues
-  contributing: https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md
+  contributing: https://github.com/pytorch/pytorch/blob/main/CONTRIBUTING.md
   hub_template: https://github.com/pytorch/hub/blob/master/docs/template.md
   twitter: https://twitter.com/pytorch
   facebook: https://www.facebook.com/pytorch

--- a/_get_started/installation/linux.md
+++ b/_get_started/installation/linux.md
@@ -33,11 +33,18 @@ However, if you want to install another version, there are multiple ways:
 
 * APT
 * [Python website](https://www.python.org/downloads/mac-osx/)
+* DNF
 
 If you decide to use APT, you can run the following command to install it:
 
 ```bash
 sudo apt install python
+```
+
+If you decide to use DNF, you can run the following command to install it:
+
+```bash
+sudo dnf install python
 ```
 
 ### Package Manager
@@ -52,6 +59,12 @@ While Python 3.x is installed by default on Linux, `pip` is not installed by def
 
 ```bash
 sudo apt install python3-pip
+```
+
+While in Fedora Linux, `pip` can be installed using the `dnf`
+
+```bash
+sudo dnf install python3-pip
 ```
 
 > Tip: If you want to use just the command  `pip`, instead of `pip3`, you can symlink `pip` to the `pip3` binary.


### PR DESCRIPTION
Found that DNF instructions were missing and added them. Please review the PR! Thanks :)