### PR TITLE
Remove TorchArrow; add TorchCodec

### DIFF
--- a/pytorch-domains.html
+++ b/pytorch-domains.html
@@ -42,7 +42,7 @@ background-class: features-background
         <div class="col-sm-5 domain-card">
           <a href="https://pytorch.org/torchcodec/">
             <h4>TorchCodec</h4>
-            <p>A PyTorch library for fast media decoding and encoding. When running PyTorch models on videos, torchcodec is our recommended way to turn those videos into data your model can use.
+            <p>A PyTorch library for fast media decoding and encoding. When running PyTorch models on audio and video, torchcodec is our recommended way to turn audio and video files into data your model can use.
             </p>
           </a>
         </div>

--- a/pytorch-domains.html
+++ b/pytorch-domains.html
@@ -40,9 +40,9 @@ background-class: features-background
           </a>
         </div>
         <div class="col-sm-5 domain-card">
-          <a href="https://pytorch.org/torcharrow/beta/index.html">
-            <h4>torcharrow</h4>
-            <p>TorchArrow is a torch.Tensor-like Python DataFrame library for data preprocessing in deep learning. It supports multiple execution runtimes and Arrow as a common format.
+          <a href="https://pytorch.org/torchcodec/">
+            <h4>TorchCodec</h4>
+            <p>A PyTorch library for fast media decoding and encoding. When running PyTorch models on videos, torchcodec is our recommended way to turn those videos into data your model can use.
             </p>
           </a>
         </div>


### PR DESCRIPTION
TorchArrow is no longer being developed and it was archived last year. See: https://github.com/pytorch/torcharrow

TorchCodec (https://github.com/pytorch/torchcodec) is being actively developed, and along with TorchAudio and TorchVision, will form the foundation of how PyTorch users process media.

This PR removes TorchArrow from the list of domain libraries and adds TorchCodec.