### PR TITLE
Replace link to torchtext docs with torchcodec

### DIFF
--- a/pytorch-domains.html
+++ b/pytorch-domains.html
@@ -89,9 +89,9 @@ background-class: features-background
           </a>
         </div>
         <div class="col-sm-5 domain-card">
-          <a href="https://pytorch.org/text/stable/index.html">
-            <h4>torchtext</h4>
-            <p>This library is part of the PyTorch project. PyTorch is an open source machine learning framework. The torchtext package consists of data processing utilities and popular datasets for natural language.
+          <a href="https://pytorch.org/torchcodec/stable/index.html">
+            <h4>TorchCodec</h4>
+            <p>TorchCodec is a media decoding and encoding library for PyTorch. It exposes fast and easy-to-use decoders for video and audio data.
             </p>
           </a>
         </div>


### PR DESCRIPTION
TorchText has been deprecated and un-maintained for years now, so it shouldn't be prominently exposed. This PR proposes to replace the link to torchtext with a link to torchcodec, which is much more relevant for users.

EDIT: just saw https://github.com/pytorch/pytorch.github.io/pull/2028 which we can merge first. I'll keep this PR as draft and re-open it later, because I still think we should remove torchtext.