### PR TITLE
Auto redirect pages that get migrated to meta-pytorch

### DIFF
--- a/404.html
+++ b/404.html
@@ -20,11 +20,46 @@ layout: general
     FOUROHFOUR_CUSTOM: 3,
   };
 
+  // Repos that are expected to be moved to the meta-pytorch.org domain
+  const META_PYTORCH_PROJECTS = [
+    "ao",
+    "helion",
+    "torchcodec",
+    "torchft",
+    "data",
+    "torchx",
+    "torchtune",
+    "mobile-docs",
+    "tnt",
+    "botorch",
+    "captum",
+    "opacus",
+    "torchsnapshot",
+    "torcheval",
+    "multipy",
+    "text",
+    "live-website",
+    "live-old",
+    // Temporary test entries
+    "tritonparse",
+    "monarch",
+    "fakerepo",
+  ]
+
   const PROJECTS = {
     live: {
       location: 'https://playtorch.dev/',
       style: REDIRECT_STYLE.FULL,
     },
+    ...Object.fromEntries(
+      META_PYTORCH_PROJECTS.map(project => [
+        project,
+        {
+          location: `https://meta-pytorch.org/${project}`,
+          style: REDIRECT_STYLE.FULL,
+        }
+      ])
+    ),
   };
 
   // eg "https://facebook.github.io/flux/docs/overview/"


### PR DESCRIPTION
Should have no effect initially. Effect will take place only as each repo is moved and it's original route starts 404-ing