### PR TITLE
Fix meta-pytorch.org redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -55,7 +55,7 @@ layout: general
       META_PYTORCH_PROJECTS.map(project => [
         project,
         {
-          location: `https://meta-pytorch.org/${project}`,
+          location: `https://meta-pytorch.org/${project}/`,
           style: REDIRECT_STYLE.FULL,
         }
       ])
@@ -71,7 +71,7 @@ layout: general
   // eg "docs/overview/"
   const SUBPATH = PATH_PARTS.slice(2).join('/');
 
-  
+
   // Perform the redirect only for explicitly defined projects.
   // Otherwise show the 404 page below
   if (PROJECTS.hasOwnProperty(PROJECT)) {
@@ -100,7 +100,7 @@ layout: general
   }
 
 </script>
-  
+
 <div style="text-align: center;">
   <img src="{{ site.baseurl }}/assets/images/404_sign.png" />
 


### PR DESCRIPTION
Was missing a slash that broke sub-path redirects