### PR TITLE
Add sitemap index and update robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -14,6 +14,25 @@ Disallow: /docs/1.7.*
 Disallow: /docs/1.8.*
 Disallow: /docs/1.9.*
 Disallow: /docs/master/
+Disallow: /docs/1.10*/
+Disallow: /docs/1.11*/
+Disallow: /docs/1.12*/
+Disallow: /docs/1.13*/
+Disallow: /docs/2.0*/
+Disallow: /docs/2.1*/
+Disallow: /docs/2.2*/
+Disallow: /docs/2.3*/
+Disallow: /docs/2.4*/
+Disallow: /docs/2.5*/
+Disallow: /docs/2.6*/
+Disallow: /docs/2.7*/
+Disallow: /docs/2.8*/
+Disallow: /docs/2.9*/
+Disallow: /docs/2.10*/
+Disallow: /*/_static/
+Disallow: /*/_sources/
+Disallow: /*/_modules/
+Disallow: /*/_downloads/
 
 # libraries: torchx
 Disallow: /torchx/*/
@@ -23,3 +42,6 @@ Allow: /torchx/main/
 # libraries: torchelastic
 Disallow: /elastic/*/
 Allow: /elastic/latest/
+
+Sitemap: https://docs.pytorch.org/sitemap.xml
+Llms-txt: https://docs.pytorch.org/docs/stable/llms.txt

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://docs.pytorch.org/docs/stable/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://docs.pytorch.org/tutorials/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://docs.pytorch.org/executorch/stable/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://docs.pytorch.org/ao/stable/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
- Add a top-level sitemap.xml index file referencing sitemaps for docs, tutorials, ExecuTorch, and torchao                                           
- Update robots.txt to disallow crawling of old doc versions (1.10–1.13, 2.0–2.10) and generated directories ( e.g. _static/)                                                                                                                                         
- Add Sitemap: directive to robots.txt pointing to the new sitemap index