### PR TITLE
Add deprecation notice and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+> [!WARNING]
+> **This repository is NOT the source of truth for the PyTorch website.**
+> Only a very small number of files here are still actively used. Please do not submit website changes to this repo.
+>
+> See the [README](../README.md) for details, or contact the PyTorch Foundation team at [ops@pytorch.org](mailto:ops@pytorch.org).
+
+---
+
+**If your change is to one of the few files still served from this repo**, please describe it below:
+
+## Description
+
+
+## Motivation
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!CAUTION]
+> **This repository is NOT the source of truth for the [PyTorch website](https://pytorch.org).**
+>
+> Only a very small number of files in this repo are still actively used. The website is now managed separately by the **PyTorch Foundation** team.
+>
+> **If you want to make changes to the PyTorch website, please contact the PyTorch Foundation team at [ops@pytorch.org](mailto:ops@pytorch.org).** Do not open pull requests here for website changes.
+
 # pytorch.org site
 
 [https://pytorch.org](https://pytorch.org)


### PR DESCRIPTION
## Summary

- Adds a prominent `[!CAUTION]` banner at the top of the README clarifying that this repo is **not** the source of truth for the PyTorch website, and directing contributors to contact the PyTorch Foundation team at ops@pytorch.org.
- Adds a new PR template (`.github/PULL_REQUEST_TEMPLATE.md`) with a `[!WARNING]` block telling contributors not to submit website changes here, with a link to ops@pytorch.org.

## Test plan

- [x] Verify README renders correctly on GitHub with the caution banner
- [x] Verify PR template renders correctly when opening a new PR