### PR TITLE
Fix build: override additional-fetch-refs in reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     secrets: inherit
     with:
+      additional-fetch-refs: ""
       runner: linux.12xlarge
       repository: pytorch/pytorch.github.io
       docker-image: cimg/ruby:2.7-node


### PR DESCRIPTION
The reusable workflow `pytorch/test-infra/.github/workflows/linux_job_v2.yml` defaults `additional-fetch-refs` to `main`, which does not exist in this repository (default branch is `site`). This causes the build job to fail when attempting to fetch that ref.

Override `additional-fetch-refs` to an empty string to avoid the failed fetch.

Signed-off-by: Jordan Conway <jconway@linuxfoundation.org>