### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - site
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/.github/workflows/validate-quick-start-module.yml
+++ b/.github/workflows/validate-quick-start-module.yml
@@ -16,6 +16,9 @@ on:
       - .github/workflows/validate-quick-start-module.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-nightly-binaries:
     uses: pytorch/test-infra/.github/workflows/validate-binaries.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

Left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Best declared by a maintainer: `update-quick-start-module.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.