### PR TITLE
xpu: add XPU to additional pages

### DIFF
--- a/_additional_platforms/xpu.json
+++ b/_additional_platforms/xpu.json
@@ -1,0 +1,12 @@
+{
+  "name": "XPU",
+  "support_channel": "https://github.com/pytorch/pytorch",
+  "stable": {
+    "linux": "pip3 install torch torchvision --index-url https://download.pytorch.org/whl/xpu",
+    "windows": "pip3 install torch torchvision --index-url https://download.pytorch.org/whl/xpu"
+  },
+  "preview": {
+    "linux": "pip3 install torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/xpu",
+    "windows": "pip3 install torch torchvision --pre --index-url https://download.pytorch.org/whl/nightly/xpu"
+  }
+}

--- a/_additional_platforms/xpu.json
+++ b/_additional_platforms/xpu.json
@@ -1,6 +1,6 @@
 {
   "name": "XPU",
-  "support_channel": "https://github.com/pytorch/pytorch",
+  "support_channel": "https://github.com/pytorch/pytorch/issues",
   "stable": {
     "linux": "pip3 install torch torchvision --index-url https://download.pytorch.org/whl/xpu",
     "windows": "pip3 install torch torchvision --index-url https://download.pytorch.org/whl/xpu"

--- a/_get_started/additional_platforms/xpu.md
+++ b/_get_started/additional_platforms/xpu.md
@@ -1,0 +1,56 @@
+# Installing on Intel GPU (XPU) Platform
+
+XPU is a PyTorch device backend designed to support hardware acceleration on Intel GPUs. Key technical features:
+
+* Native support for FP32, BF16, FP16, and Automatic Mixed Precision (AMP)
+* Extensions of operator set through custom SYCL kernels
+* Graph compilation
+* Distributed training (through `XCCL`)
+
+## Prerequisites
+
+### Hardware Requirements
+
+* Intel Client GPU:
+
+  * Intel® Arc A-Series Graphics (CodeName: Alchemist)
+  * Intel® Arc B-Series Graphics (CodeName: Battlemage)
+  * Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (CodeName: Meteor Lake-H)
+  * Intel® Core™ Ultra Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Arrow Lake-H)
+  * Intel® Core™ Ultra Mobile Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Lunar Lake)
+  * Intel® Core™ Ultra Mobile Processors (Series 3) with Intel® Arc™ Graphics (CodeName: Panther Lake)
+
+* Intel Data Center GPU:
+
+  * Intel® Data Center GPU Max Series (CodeName: Ponte Vecchio)
+
+### Software Requirements
+
+* [Intel GPU Driver](https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu.html)
+* Python 3.10 or later
+
+## Installation
+
+### pip
+
+Use the pip package manager to install PyTorch with XPU support. Select your preferred options in the selector above to get the installation command.
+
+## Verification
+
+To ensure that PyTorch was installed correctly with XPU support, run the following code:
+
+```python
+import torch
+print(torch.__version__)
+
+# Check XPU availability
+if torch.xpu.is_available():
+    print("XPU is available!")
+    print(f"XPU devices: {torch.xpu.device_count()}")
+else:
+    print("XPU is not available.")
+```
+
+## Documentation
+
+For more information, please visit the [Getting Started on Intel GPU](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html).

--- a/_get_started/additional_platforms/xpu.md
+++ b/_get_started/additional_platforms/xpu.md
@@ -1,13 +1,6 @@
 # Installing on Intel GPU (XPU) Platform
 
-XPU device backend brings native Intel GPU support to PyTorch, enabling performant training and inference on both Linux and Windows:
-
-* Supports both eager and graph execution
-* Built-in support for FP32, BF16, FP16, FP8 and AMP
-* Broad operator coverage and model readiness
-* Supports PyTorch CPP Extension API through SYCL-based custom kernels
-* Enables training and inference workflows
-* Scales across devices with distributed training via the `XCCL` backend
+XPU device backend brings native Intel GPU support to PyTorch, enabling performant training and inference on both Linux and Windows.
 
 ## Prerequisites
 

--- a/_get_started/additional_platforms/xpu.md
+++ b/_get_started/additional_platforms/xpu.md
@@ -1,33 +1,17 @@
 # Installing on Intel GPU (XPU) Platform
 
-XPU is a PyTorch device backend designed to support hardware acceleration on Intel GPUs. Key technical features:
+XPU device backend brings native Intel GPU support to PyTorch, enabling performant training and inference on both Linux and Windows:
 
-* Native support for FP32, BF16, FP16, and Automatic Mixed Precision (AMP)
-* Extensions of operator set through custom SYCL kernels
-* Graph compilation
-* Distributed training (through `XCCL`)
+* Supports both eager and graph execution
+* Built-in support for FP32, BF16, FP16, FP8 and AMP
+* Broad operator coverage and model readiness
+* Supports PyTorch CPP Extension API through SYCL-based custom kernels
+* Enables training and inference workflows
+* Scales across devices with distributed training via the `XCCL` backend
 
 ## Prerequisites
 
-### Hardware Requirements
-
-* Intel Client GPU:
-
-  * Intel® Arc A-Series Graphics (CodeName: Alchemist)
-  * Intel® Arc B-Series Graphics (CodeName: Battlemage)
-  * Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (CodeName: Meteor Lake-H)
-  * Intel® Core™ Ultra Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Arrow Lake-H)
-  * Intel® Core™ Ultra Mobile Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Lunar Lake)
-  * Intel® Core™ Ultra Mobile Processors (Series 3) with Intel® Arc™ Graphics (CodeName: Panther Lake)
-
-* Intel Data Center GPU:
-
-  * Intel® Data Center GPU Max Series (CodeName: Ponte Vecchio)
-
-### Software Requirements
-
-* [Intel GPU Driver](https://www.intel.com/content/www/us/en/developer/articles/tool/pytorch-prerequisites-for-intel-gpu.html)
-* Python 3.10 or later
+The system with configured Intel GPU card is required. For detailed list of supported devices and driver install instructions refer to [Getting Started on Intel GPU](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html).
 
 ## Installation
 
@@ -53,4 +37,4 @@ else:
 
 ## Documentation
 
-For more information, please visit the [Getting Started on Intel GPU](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html).
+For more information, please visit the [torch.xpu](https://docs.pytorch.org/docs/stable/xpu.html).

--- a/_get_started/additional_platforms/xpu.md
+++ b/_get_started/additional_platforms/xpu.md
@@ -35,6 +35,14 @@ else:
     print("XPU is not available.")
 ```
 
+The following, or a similar output, indicates successful installation:
+
+```bash
+2.13.0+xpu
+XPU is available!
+XPU devices: 4
+```
+
 ## Documentation
 
 For more information, please visit the [torch.xpu](https://docs.pytorch.org/docs/stable/xpu.html).


### PR DESCRIPTION
XPU is an in-tree PyTorch device backend designed to support hardware acceleration on Intel GPUs. XPU admission to additional pages is approved by https://github.com/pytorch-fdn/additional-compute-platforms/issues/2.

CC: @EikanWang, @guangyey, @zeshengzong.
