### PR TITLE
Fix CI missing dependency error

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -132,10 +132,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
           architecture: x64
       - name: Generate quick-start-additional-platforms.js
         shell: bash
         run: |
           set -ex
+          pip install markdown==3.10.2
           python3 ./scripts/gen_additional_platforms.py


### PR DESCRIPTION
## Description
In the previous PR, I created a new job in the workflow to check whether the vendors' JSON and MD files were written in the expected templates. A Python script would do that check, but it needed the `markdown` package to convert markdown to HTML, which was not installed in the workflow beforehand. This PR fixes the error by adding an installation step in the workflow job.

Sorry to bother you again cc @albanD @fffrog

