### PR TITLE
Drop Windows libtorch debug from quick-start generation

### DIFF
--- a/scripts/gen_quick_start_module.py
+++ b/scripts/gen_quick_start_module.py
@@ -173,10 +173,15 @@ def update_versions(versions, release_matrix, release_version):
                                 for x in pkg_arch_matrix
                             }
                             if instr["versions"] is not None:
-                                for ver in [RELEASE, DEBUG]:
-                                    instr["versions"][LIBTORCH_DWNL_INSTR[ver]] = (
-                                        rel_entry_dict[ver]
-                                    )
+                                # Windows libtorch debug builds are no longer produced, so
+                                # only publish the release download and drop any stale
+                                # debug entry carried over from previous versions.
+                                instr["versions"][LIBTORCH_DWNL_INSTR[RELEASE]] = (
+                                    rel_entry_dict[RELEASE]
+                                )
+                                instr["versions"].pop(
+                                    LIBTORCH_DWNL_INSTR[DEBUG], None
+                                )
                         elif os_key == OperatingSystem.MACOS.value:
                             if instr["versions"] is not None:
                                 instr["versions"][LIBTORCH_DWNL_INSTR[MACOS]] = (


### PR DESCRIPTION
Windows libtorch debug binaries are no longer produced — pytorch/test-infra#8194 stops generating them in the binary build matrix (only the `release` `libtorch_config` is emitted for Windows libtorch).

This updates the Windows libtorch branch of `gen_quick_start_module.py` to:
- publish only the **Release** download, and
- drop any stale **Debug** entry carried over from the `preview` template.

Without this, regenerating `published_versions.json` for 2.12.1 and nightlies would `KeyError` on the now-missing `debug` matrix entry, and would otherwise leave dead `Download here (Debug version):` links in the `preview` and new `2.12.1` Windows libtorch entries.

Historical released versions keep their existing Debug links (those binaries still exist).

### Testing
Generated nightly + release matrices from pytorch/test-infra#8194 and ran `python3 scripts/gen_quick_start_module.py --autogenerate`:
- exits 0 (previously `KeyError`),
- `preview` and the new `2.12.1` Windows libtorch entries contain Release only,
- historical `1.13.0` retains both Release and Debug.

Companion to pytorch/test-infra#8194.