### PR TITLE
Fix generated PR branch collision

### DIFF
--- a/.github/workflows/update-quick-start-module.yml
+++ b/.github/workflows/update-quick-start-module.yml
@@ -108,6 +108,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PYTORCHBOT_TOKEN }}
+          branch: create-pull-request/update-quick-start
           commit-message: Modify published_versions.json, releases.json and quick-start-module.js
           title: '[Getting Started Page] Modify published_versions.json, releases.json and quick-start-module.js'
           body: >
@@ -138,6 +139,7 @@ jobs:
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.PYTORCHBOT_TOKEN }}
+          branch: create-pull-request/update-additional-platforms
           commit-message: Regenerate additional-platforms assets
           title: '[Additional Platforms] Regenerate quick-start-additional-platforms.js and additional-platforms.json'
           body: >


### PR DESCRIPTION
## Author Notes

Fix the two workflows clobbering each other, leading to empty PRs like #2124.

## Agent Notes

> AI-generated summary:
>
> Both `create-pull-request` jobs used the default `create-pull-request/patch` branch, allowing one workflow job to overwrite the other job's changes and close its PR as empty. This change assigns each job a distinct, stable branch.
>
> Validation:
> - `git diff --check`
> - YAML syntax parsed successfully with Python and PyYAML.